### PR TITLE
feat: student list view with datacore query, preferences, and highlights

### DIFF
--- a/admindash/docs/superpowers/plans/2026-03-31-student-list-view.md
+++ b/admindash/docs/superpowers/plans/2026-03-31-student-list-view.md
@@ -1,0 +1,1558 @@
+# Student List View Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the legacy student list with a datacore-backed table featuring server-side filtering/sorting, adaptive page size, column toggle, localStorage preferences, and newly-added student highlighting.
+
+**Architecture:** A new datacore query endpoint exposes filtered/sorted/paginated entity queries via DuckDB SQL. The admindash frontend caches model definitions in a ModelContext (per session), persists table preferences in localStorage, and enhances the DataTable component with sort, page size, column toggle, and row highlighting support.
+
+**Tech Stack:** Python/FastAPI/DuckDB (datacore), React 19/TypeScript 5.9/Vite 8/React Router 7 (admindash), CSS with CSS variables, localStorage for preferences.
+
+**OpenSpec Change:** `openspec/changes/student-list-view/`
+
+---
+
+## File Map
+
+### Datacore (backend)
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `datacore/src/datacore/api/routes.py` | Modify | Add query endpoint |
+| `datacore/tests/test_api.py` | Modify | Add query endpoint tests |
+
+### Admindash (frontend)
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `frontend/src/api/client.ts` | Modify | Add `queryStudents()` function |
+| `frontend/src/types/models.ts` | Modify | Add `QueryStudentsResponse` type |
+| `frontend/src/contexts/ModelContext.tsx` | Create | Session-scoped model definition cache |
+| `frontend/src/App.tsx` | Modify | Wrap with ModelProvider |
+| `frontend/src/hooks/useTablePreferences.ts` | Create | localStorage read/write for table prefs |
+| `frontend/src/i18n/translations.ts` | Modify | Add new i18n keys |
+| `frontend/src/components/DataTable.tsx` | Modify | Add sort, page size, column toggle, rowClassName |
+| `frontend/src/components/DataTable.css` | Modify | Sort indicator, page size selector, highlight styles |
+| `frontend/src/pages/StudentsPage.tsx` | Rewrite | New data fetching, search, column ordering, preferences |
+| `frontend/src/pages/StudentsPage.css` | Modify | Column toggle popover, highlight row styles |
+| `frontend/src/pages/AddStudentPage.tsx` | Modify | Pass entity_id via router state |
+
+---
+
+### Task 1: Datacore Query Endpoint
+
+**Files:**
+- Modify: `datacore/src/datacore/api/routes.py`
+- Modify: `datacore/tests/test_api.py`
+
+This task adds `GET /api/entities/{tenant_id}/{entity_type}/query` with filter, sort, and pagination support. The endpoint builds a SQL WHERE clause from query params, delegates to `QueryEngine.query()`, and returns `{ data: [...], total: int }`.
+
+- [ ] **Step 1: Write tests for the query endpoint**
+
+Add to `datacore/tests/test_api.py`:
+
+```python
+# --- Query endpoint tests ---
+
+def test_query_default_returns_active_students(client, store):
+    """Default query returns only active entities sorted by last_name."""
+    store.put_entity("t1", "student", "s1", {"first_name": "Zara", "last_name": "Adams"}, {})
+    store.put_entity("t1", "student", "s2", {"first_name": "Alice", "last_name": "Brown"}, {})
+    store.put_entity("t1", "student", "s3", {"first_name": "Bob", "last_name": "Clark"}, {})
+    # Archive one to test status filter
+    store.put_entity("t1", "student", "s3", {"first_name": "Bob", "last_name": "Clark"}, {}, status="archived")
+
+    resp = client.get("/api/entities/t1/student/query")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 2
+    assert len(body["data"]) == 2
+    # Default sort by last_name ASC
+    assert body["data"][0]["last_name"] == "Adams"
+    assert body["data"][1]["last_name"] == "Brown"
+
+
+def test_query_status_filter(client, store):
+    """Explicit _status param filters correctly."""
+    store.put_entity("t1", "student", "s1", {"last_name": "A"}, {})
+    store.put_entity("t1", "student", "s1", {"last_name": "A"}, {}, status="archived")
+
+    resp = client.get("/api/entities/t1/student/query?_status=archived")
+    assert resp.status_code == 200
+    assert resp.json()["total"] == 1
+
+    resp_all = client.get("/api/entities/t1/student/query?_status=all")
+    assert resp_all.status_code == 200
+    assert resp_all.json()["total"] == 2
+
+
+def test_query_filters_by_entity_type(client, store):
+    """Only returns entities matching the entity_type path param."""
+    store.put_entity("t1", "student", "s1", {"last_name": "A"}, {})
+    store.put_entity("t1", "teacher", "t1", {"last_name": "B"}, {})
+
+    resp = client.get("/api/entities/t1/student/query")
+    assert resp.status_code == 200
+    assert resp.json()["total"] == 1
+    assert resp.json()["data"][0]["entity_type"] == "student"
+
+
+def test_query_sort(client, store):
+    """Custom sort_by and sort_dir."""
+    store.put_entity("t1", "student", "s1", {"first_name": "Zara", "last_name": "A"}, {})
+    store.put_entity("t1", "student", "s2", {"first_name": "Alice", "last_name": "B"}, {})
+
+    resp = client.get("/api/entities/t1/student/query?sort_by=first_name&sort_dir=desc")
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert data[0]["first_name"] == "Zara"
+
+
+def test_query_invalid_sort_column(client, store):
+    """Invalid sort_by returns 400."""
+    store.put_entity("t1", "student", "s1", {"last_name": "A"}, {})
+    resp = client.get("/api/entities/t1/student/query?sort_by=nonexistent")
+    assert resp.status_code == 400
+
+
+def test_query_pagination(client, store):
+    """Limit and offset work correctly."""
+    for i in range(5):
+        store.put_entity("t1", "student", f"s{i}", {"last_name": f"Name{i:02d}"}, {})
+
+    resp = client.get("/api/entities/t1/student/query?limit=2&offset=2")
+    body = resp.json()
+    assert body["total"] == 5
+    assert len(body["data"]) == 2
+
+
+def test_query_limit_clamped(client, store):
+    """Limit above 50 is clamped."""
+    store.put_entity("t1", "student", "s1", {"last_name": "A"}, {})
+    resp = client.get("/api/entities/t1/student/query?limit=100")
+    assert resp.status_code == 200  # No error, just clamped
+
+
+def test_query_base_field_filter(client, store):
+    """ILIKE filter on base fields."""
+    store.put_entity("t1", "student", "s1", {"first_name": "Jane", "last_name": "Doe"}, {})
+    store.put_entity("t1", "student", "s2", {"first_name": "John", "last_name": "Smith"}, {})
+
+    resp = client.get("/api/entities/t1/student/query?first_name=jan")
+    body = resp.json()
+    assert body["total"] == 1
+    assert body["data"][0]["first_name"] == "Jane"
+
+
+def test_query_address_fuzzy(client, store):
+    """Address param searches across address-related columns with OR logic."""
+    store.put_entity("t1", "student", "s1", {"last_name": "A", "city": "Springfield"}, {})
+    store.put_entity("t1", "student", "s2", {"last_name": "B", "city": "Portland"}, {})
+
+    resp = client.get("/api/entities/t1/student/query?address=spring")
+    body = resp.json()
+    assert body["total"] == 1
+    assert body["data"][0]["city"] == "Springfield"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/kennylee/Development/NeoApex/datacore && python -m pytest tests/test_api.py -v -k "query" 2>&1 | tail -20`
+Expected: All `test_query_*` tests FAIL (endpoint doesn't exist yet)
+
+- [ ] **Step 3: Implement the query endpoint**
+
+In `datacore/src/datacore/api/routes.py`, add the following. The `register_routes` function already receives `store`, and we need to import `QueryEngine` from `datacore.query`:
+
+At the top of the file, add the import:
+
+```python
+from datacore.query import QueryEngine, TableNotFoundError
+```
+
+Inside `register_routes()`, after the existing `create_entity` endpoint, add:
+
+```python
+    @app.get("/api/entities/{tenant_id}/{entity_type}/query")
+    def query_entities(
+        tenant_id: str,
+        entity_type: str,
+        _status: str = "active",
+        sort_by: str = "last_name",
+        sort_dir: str = "asc",
+        limit: int = 20,
+        offset: int = 0,
+        first_name: str | None = None,
+        last_name: str | None = None,
+        student_id: str | None = None,
+        email: str | None = None,
+        grade_level: str | None = None,
+        gender: str | None = None,
+        address: str | None = None,
+    ):
+        # Clamp pagination
+        if limit < 1:
+            limit = 20
+        if limit > 50:
+            limit = 50
+        if offset < 0:
+            offset = 0
+        if sort_dir not in ("asc", "desc"):
+            sort_dir = "asc"
+
+        # Build WHERE clauses
+        conditions = [f"entity_type = '{entity_type}'"]
+
+        if _status and _status != "all":
+            conditions.append(f"_status = '{_status}'")
+
+        # Base field ILIKE filters
+        field_filters = {
+            "first_name": first_name,
+            "last_name": last_name,
+            "student_id": student_id,
+            "email": email,
+            "grade_level": grade_level,
+            "gender": gender,
+        }
+        for col, val in field_filters.items():
+            if val:
+                safe_val = val.replace("'", "''")
+                conditions.append(f"{col} ILIKE '%{safe_val}%'")
+
+        # Fuzzy address search (OR across address-related columns)
+        if address:
+            safe_addr = address.replace("'", "''")
+            # We'll check which address columns exist after table is loaded
+            # For now, build the OR clause; nonexistent columns handled below
+            address_cols = ["address", "city", "state", "zip"]
+            # Dynamically check columns via QueryEngine
+            qe = QueryEngine(store)
+            arrow_table = store.get_table_as_arrow(tenant_id, "entities")
+            if arrow_table is not None:
+                # Flatten to get actual column names
+                from datacore.query import QueryEngine as QE
+                flat = qe._flatten_custom_fields(arrow_table)
+                available_cols = set(flat.column_names)
+                matching_addr_cols = [c for c in address_cols if c in available_cols]
+                if matching_addr_cols:
+                    addr_parts = [f"{c} ILIKE '%{safe_addr}%'" for c in matching_addr_cols]
+                    conditions.append(f"({' OR '.join(addr_parts)})")
+
+        where = " AND ".join(conditions)
+        sql = f"SELECT * FROM data WHERE {where}"
+
+        # Validate sort column by checking available columns
+        qe = QueryEngine(store)
+        try:
+            # First, check if sort_by is valid by running a schema check
+            arrow_table = store.get_table_as_arrow(tenant_id, "entities")
+            if arrow_table is None:
+                return {"data": [], "total": 0}
+            flat = qe._flatten_custom_fields(arrow_table)
+            if sort_by not in flat.column_names:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Invalid sort column: '{sort_by}'. Available: {sorted(flat.column_names)}",
+                )
+
+            sql += f" ORDER BY {sort_by} {sort_dir.upper()}"
+            result = qe.query(tenant_id, "entities", sql, limit=limit, offset=offset)
+            return {"data": result["rows"], "total": result["total"]}
+
+        except TableNotFoundError:
+            return {"data": [], "total": 0}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/kennylee/Development/NeoApex/datacore && python -m pytest tests/test_api.py -v -k "query" 2>&1 | tail -30`
+Expected: All `test_query_*` tests PASS
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `cd /Users/kennylee/Development/NeoApex/datacore && python -m pytest tests/ -v 2>&1 | tail -20`
+Expected: All tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/kennylee/Development/NeoApex/admindash
+git add ../datacore/src/datacore/api/routes.py ../datacore/tests/test_api.py
+git commit -m "feat: add GET /api/entities query endpoint with filter, sort, pagination"
+```
+
+---
+
+### Task 2: Admindash API Client and Types
+
+**Files:**
+- Modify: `frontend/src/api/client.ts`
+- Modify: `frontend/src/types/models.ts`
+
+- [ ] **Step 1: Add QueryStudentsParams and QueryStudentsResponse types**
+
+In `frontend/src/types/models.ts`, add after the `ExtractResponse` interface (end of file):
+
+```typescript
+export interface QueryStudentsParams {
+  _status?: string;
+  sort_by?: string;
+  sort_dir?: 'asc' | 'desc';
+  limit?: number;
+  offset?: number;
+  first_name?: string;
+  last_name?: string;
+  student_id?: string;
+  email?: string;
+  grade_level?: string;
+  gender?: string;
+  address?: string;
+}
+
+export interface QueryStudentsResponse {
+  data: Record<string, unknown>[];
+  total: number;
+}
+```
+
+- [ ] **Step 2: Add queryStudents function**
+
+In `frontend/src/api/client.ts`, add the import for the new types at the top:
+
+```typescript
+import type {
+  StudentsResponse,
+  TenantsResponse,
+  ModelResponse,
+  CreateEntityResponse,
+  ExtractResponse,
+  QueryStudentsParams,
+  QueryStudentsResponse,
+} from '../types/models.ts';
+```
+
+Add the function at the end of the file:
+
+```typescript
+export async function queryStudents(
+  tenantId: string,
+  params: QueryStudentsParams = {},
+): Promise<QueryStudentsResponse> {
+  const searchParams = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value != null && value !== '') {
+      searchParams.set(key, String(value));
+    }
+  }
+  const resp = await fetch(
+    `${DATACORE_API_BASE}/api/entities/${tenantId}/student/query?${searchParams}`,
+  );
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+  return resp.json();
+}
+```
+
+- [ ] **Step 3: Type check**
+
+Run: `cd /Users/kennylee/Development/NeoApex/admindash/frontend && npx tsc -b 2>&1`
+Expected: No errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/kennylee/Development/NeoApex/admindash
+git add frontend/src/api/client.ts frontend/src/types/models.ts
+git commit -m "feat: add queryStudents API client function and types"
+```
+
+---
+
+### Task 3: ModelContext
+
+**Files:**
+- Create: `frontend/src/contexts/ModelContext.tsx`
+- Modify: `frontend/src/App.tsx`
+- Modify: `frontend/src/pages/AddStudentPage.tsx`
+
+- [ ] **Step 1: Create ModelContext**
+
+Create `frontend/src/contexts/ModelContext.tsx`:
+
+```typescript
+import { createContext, useContext, useState, useCallback, type ReactNode } from 'react';
+import { fetchStudentModel } from '../api/client.ts';
+import type { ModelDefinition } from '../types/models.ts';
+
+interface ModelCache {
+  [entityType: string]: ModelDefinition;
+}
+
+interface ModelContextValue {
+  getModel: (tenantId: string, entityType: string) => Promise<ModelDefinition>;
+  getCachedModel: (entityType: string) => ModelDefinition | undefined;
+  clearCache: () => void;
+}
+
+const ModelContext = createContext<ModelContextValue>({
+  getModel: () => Promise.reject(new Error('ModelContext not initialized')),
+  getCachedModel: () => undefined,
+  clearCache: () => {},
+});
+
+export function ModelProvider({ children }: { children: ReactNode }) {
+  const [cache, setCache] = useState<ModelCache>({});
+
+  const getModel = useCallback(
+    async (tenantId: string, entityType: string): Promise<ModelDefinition> => {
+      if (cache[entityType]) return cache[entityType];
+
+      const resp = await fetchStudentModel(tenantId);
+      const modelDef = resp.model_definition;
+      setCache((prev) => ({ ...prev, [entityType]: modelDef }));
+      return modelDef;
+    },
+    [cache],
+  );
+
+  const getCachedModel = useCallback(
+    (entityType: string): ModelDefinition | undefined => cache[entityType],
+    [cache],
+  );
+
+  const clearCache = useCallback(() => setCache({}), []);
+
+  return (
+    <ModelContext.Provider value={{ getModel, getCachedModel, clearCache }}>
+      {children}
+    </ModelContext.Provider>
+  );
+}
+
+export function useModel() {
+  return useContext(ModelContext);
+}
+```
+
+- [ ] **Step 2: Wrap App with ModelProvider and clear on logout**
+
+In `frontend/src/App.tsx`, add the import:
+
+```typescript
+import { ModelProvider, useModel } from './contexts/ModelContext.tsx';
+```
+
+Wrap the protected routes section with `<ModelProvider>`. The full `AppRoutes` function becomes:
+
+```typescript
+function AppRoutes() {
+  const { user, ready } = useAuth();
+  const [tenant, setTenant] = useState(user?.tenant_id ?? '');
+
+  useEffect(() => {
+    if (user?.tenant_id) setTenant(user.tenant_id);
+  }, [user?.tenant_id]);
+
+  if (!ready) return null;
+
+  return (
+    <Routes>
+      <Route
+        path="/login"
+        element={user ? <Navigate to="/home" replace /> : <LoginPage />}
+      />
+      <Route
+        path="*"
+        element={
+          !user ? (
+            <Navigate to="/login" replace />
+          ) : (
+            <ModelProvider>
+              <div className="app-shell">
+                <Navbar currentTenant={tenant} onTenantChange={setTenant} />
+                <main className="app-main">
+                  <Routes>
+                    <Route path="/home" element={<HomePage />} />
+                    <Route
+                      path="/students/add"
+                      element={<AddStudentPage tenant={tenant} />}
+                    />
+                    <Route
+                      path="/students"
+                      element={<StudentsPage tenant={tenant} />}
+                    />
+                    <Route path="/leads" element={<LeadPage />} />
+                    <Route path="/programs" element={<ProgramPage />} />
+                    <Route path="*" element={<Navigate to="/home" replace />} />
+                  </Routes>
+                </main>
+                <Footer />
+              </div>
+            </ModelProvider>
+          )
+        }
+      />
+    </Routes>
+  );
+}
+```
+
+Note: `ModelProvider` is inside the `!user` guard, so it unmounts (and clears cache) on logout automatically.
+
+- [ ] **Step 3: Refactor AddStudentPage to use ModelContext**
+
+In `frontend/src/pages/AddStudentPage.tsx`, replace the direct `fetchStudentModel` call with `useModel()`.
+
+Replace the imports:
+
+```typescript
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useTranslation } from '../hooks/useTranslation.ts';
+import { createStudent, extractStudentFromDocument } from '../api/client.ts';
+import { useModel } from '../contexts/ModelContext.tsx';
+import DynamicForm from '../components/DynamicForm.tsx';
+import DocumentUpload from '../components/DocumentUpload.tsx';
+import type { ModelDefinition } from '../types/models.ts';
+import './AddStudentPage.css';
+```
+
+Replace the state and useEffect for model fetching (lines 18-34) with:
+
+```typescript
+  const { getModel } = useModel();
+
+  const [activeTab, setActiveTab] = useState<'form' | 'upload'>('form');
+  const [modelDef, setModelDef] = useState<ModelDefinition | null>(null);
+  const [modelError, setModelError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [extractedValues, setExtractedValues] = useState<Record<string, unknown>>({});
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    setModelError(null);
+    getModel(tenant, 'student')
+      .then((def) => setModelDef(def))
+      .catch(() => setModelError(t('addStudent.modelNotFound')))
+      .finally(() => setLoading(false));
+  }, [tenant, getModel, t]);
+```
+
+Remove `fetchStudentModel` from the import of `'../api/client.ts'`.
+
+- [ ] **Step 4: Type check and build**
+
+Run: `cd /Users/kennylee/Development/NeoApex/admindash/frontend && npx tsc -b && npm run build 2>&1 | tail -10`
+Expected: No errors, build succeeds
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/kennylee/Development/NeoApex/admindash
+git add frontend/src/contexts/ModelContext.tsx frontend/src/App.tsx frontend/src/pages/AddStudentPage.tsx
+git commit -m "feat: add ModelContext for session-scoped model definition caching"
+```
+
+---
+
+### Task 4: i18n Keys
+
+**Files:**
+- Modify: `frontend/src/i18n/translations.ts`
+
+- [ ] **Step 1: Add en-US keys**
+
+In `frontend/src/i18n/translations.ts`, add after the `addStudent.submitError` line, before `// Program`:
+
+```typescript
+    // Student List
+    'students.pageSize': 'Rows per page',
+    'students.columnSettings': 'Columns',
+    'students.addressSearch': 'Address',
+    'students.addressSearchPlaceholder': 'Search by address, city, state, zip',
+    'students.sortAsc': 'Sorted ascending',
+    'students.sortDesc': 'Sorted descending',
+    'students.showAll': 'Show All',
+```
+
+- [ ] **Step 2: Add zh-CN keys**
+
+In the same file, add after the zh-CN `addStudent.submitError` line, before `// Program`:
+
+```typescript
+    // Student List
+    'students.pageSize': '每页行数',
+    'students.columnSettings': '列设置',
+    'students.addressSearch': '地址',
+    'students.addressSearchPlaceholder': '按地址、城市、州、邮编搜索',
+    'students.sortAsc': '升序排列',
+    'students.sortDesc': '降序排列',
+    'students.showAll': '显示全部',
+```
+
+- [ ] **Step 3: Type check**
+
+Run: `cd /Users/kennylee/Development/NeoApex/admindash/frontend && npx tsc -b 2>&1`
+Expected: No errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/kennylee/Development/NeoApex/admindash
+git add frontend/src/i18n/translations.ts
+git commit -m "feat: add i18n keys for student list view enhancements"
+```
+
+---
+
+### Task 5: useTablePreferences Hook
+
+**Files:**
+- Create: `frontend/src/hooks/useTablePreferences.ts`
+
+- [ ] **Step 1: Create the hook**
+
+Create `frontend/src/hooks/useTablePreferences.ts`:
+
+```typescript
+import { useState, useCallback } from 'react';
+
+const VALID_PAGE_SIZES = [10, 20, 30, 40, 50] as const;
+type ValidPageSize = (typeof VALID_PAGE_SIZES)[number];
+
+export interface TablePreferences {
+  hiddenColumns: string[];
+  pageSize: ValidPageSize;
+  sortBy: string;
+  sortDir: 'asc' | 'desc';
+}
+
+const DEFAULT_PREFS: TablePreferences = {
+  hiddenColumns: [],
+  pageSize: 20,
+  sortBy: 'last_name',
+  sortDir: 'asc',
+};
+
+function buildStorageKey(userId: string, tenantId: string): string {
+  return `admindash_table_prefs_${userId}_${tenantId}`;
+}
+
+function validatePageSize(size: number): ValidPageSize {
+  return VALID_PAGE_SIZES.includes(size as ValidPageSize)
+    ? (size as ValidPageSize)
+    : 20;
+}
+
+function loadPreferences(
+  userId: string,
+  tenantId: string,
+  currentColumns: string[],
+): TablePreferences {
+  const key = buildStorageKey(userId, tenantId);
+  const raw = localStorage.getItem(key);
+  if (!raw) return { ...DEFAULT_PREFS };
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<TablePreferences>;
+    const colSet = new Set(currentColumns);
+    return {
+      hiddenColumns: (parsed.hiddenColumns ?? []).filter((c) => colSet.has(c)),
+      pageSize: validatePageSize(parsed.pageSize ?? 20),
+      sortBy: parsed.sortBy ?? DEFAULT_PREFS.sortBy,
+      sortDir: parsed.sortDir === 'desc' ? 'desc' : 'asc',
+    };
+  } catch {
+    return { ...DEFAULT_PREFS };
+  }
+}
+
+function savePreferences(
+  userId: string,
+  tenantId: string,
+  prefs: TablePreferences,
+): void {
+  const key = buildStorageKey(userId, tenantId);
+  localStorage.setItem(key, JSON.stringify(prefs));
+}
+
+export function useTablePreferences(
+  userId: string,
+  tenantId: string,
+  currentColumns: string[],
+) {
+  const [prefs, setPrefs] = useState<TablePreferences>(() =>
+    loadPreferences(userId, tenantId, currentColumns),
+  );
+
+  const updatePrefs = useCallback(
+    (updates: Partial<TablePreferences>) => {
+      setPrefs((prev) => {
+        const next = { ...prev, ...updates };
+        savePreferences(userId, tenantId, next);
+        return next;
+      });
+    },
+    [userId, tenantId],
+  );
+
+  const toggleColumn = useCallback(
+    (columnKey: string) => {
+      setPrefs((prev) => {
+        const hidden = prev.hiddenColumns.includes(columnKey)
+          ? prev.hiddenColumns.filter((c) => c !== columnKey)
+          : [...prev.hiddenColumns, columnKey];
+        const next = { ...prev, hiddenColumns: hidden };
+        savePreferences(userId, tenantId, next);
+        return next;
+      });
+    },
+    [userId, tenantId],
+  );
+
+  return { prefs, updatePrefs, toggleColumn };
+}
+```
+
+- [ ] **Step 2: Type check**
+
+Run: `cd /Users/kennylee/Development/NeoApex/admindash/frontend && npx tsc -b 2>&1`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/kennylee/Development/NeoApex/admindash
+git add frontend/src/hooks/useTablePreferences.ts
+git commit -m "feat: add useTablePreferences hook for localStorage persistence"
+```
+
+---
+
+### Task 6: DataTable Enhancements
+
+**Files:**
+- Modify: `frontend/src/components/DataTable.tsx`
+- Modify: `frontend/src/components/DataTable.css`
+
+This task adds optional props to DataTable for sort, page size selector, hidden columns, and row class names. All new props are optional so existing usage is unaffected.
+
+- [ ] **Step 1: Update DataTable props and rendering**
+
+Replace the full content of `frontend/src/components/DataTable.tsx`:
+
+```typescript
+import { useState, type ReactNode } from 'react';
+import { useTranslation } from '../hooks/useTranslation.ts';
+import './DataTable.css';
+
+export interface Column<T> {
+  key: string;
+  label: string;
+  i18nKey?: string;
+  render?: (row: T) => ReactNode;
+}
+
+interface DataTableProps<T> {
+  columns: Column<T>[];
+  data: T[];
+  total: number;
+  page: number;
+  pageSize: number;
+  loading?: boolean;
+  onPageChange: (page: number) => void;
+  rowKey: (row: T) => string;
+  // Sort
+  sortBy?: string;
+  sortDir?: 'asc' | 'desc';
+  onSortChange?: (column: string) => void;
+  // Page size
+  pageSizeOptions?: number[];
+  onPageSizeChange?: (size: number) => void;
+  // Column visibility
+  hiddenColumns?: string[];
+  // Row styling
+  rowClassName?: (row: T) => string;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export default function DataTable<T extends Record<string, any>>({
+  columns,
+  data,
+  total,
+  page,
+  pageSize,
+  loading,
+  onPageChange,
+  rowKey,
+  sortBy,
+  sortDir,
+  onSortChange,
+  pageSizeOptions,
+  onPageSizeChange,
+  hiddenColumns,
+  rowClassName,
+}: DataTableProps<T>) {
+  const { t } = useTranslation();
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+
+  // Filter out hidden columns
+  const visibleColumns = hiddenColumns
+    ? columns.filter((col) => !hiddenColumns.includes(col.key))
+    : columns;
+
+  const allOnPageSelected =
+    data.length > 0 && data.every((row) => selectedIds.has(rowKey(row)));
+
+  function toggleAll() {
+    if (allOnPageSelected) {
+      const next = new Set(selectedIds);
+      data.forEach((row) => next.delete(rowKey(row)));
+      setSelectedIds(next);
+    } else {
+      const next = new Set(selectedIds);
+      data.forEach((row) => next.add(rowKey(row)));
+      setSelectedIds(next);
+    }
+  }
+
+  function toggleRow(id: string) {
+    const next = new Set(selectedIds);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    setSelectedIds(next);
+  }
+
+  function handleHeaderClick(colKey: string) {
+    if (!onSortChange) return;
+    onSortChange(colKey);
+  }
+
+  const startRecord = total === 0 ? 0 : (page - 1) * pageSize + 1;
+  const endRecord = Math.min(page * pageSize, total);
+
+  const maxButtons = 5;
+  let btnStart = Math.max(1, page - Math.floor(maxButtons / 2));
+  const btnEnd = Math.min(totalPages, btnStart + maxButtons - 1);
+  if (btnEnd - btnStart < maxButtons - 1) {
+    btnStart = Math.max(1, btnEnd - maxButtons + 1);
+  }
+  const pageButtons: number[] = [];
+  for (let i = btnStart; i <= btnEnd; i++) pageButtons.push(i);
+
+  return (
+    <div className="data-table-card">
+      <div className="data-table-wrapper">
+        <table className="data-table">
+          <thead>
+            <tr>
+              <th className="data-table-checkbox">
+                <input
+                  type="checkbox"
+                  checked={allOnPageSelected}
+                  onChange={toggleAll}
+                />
+              </th>
+              {visibleColumns.map((col) => {
+                const isSorted = sortBy === col.key;
+                const sortable = !!onSortChange;
+                return (
+                  <th
+                    key={col.key}
+                    className={sortable ? 'data-table-sortable' : ''}
+                    onClick={() => handleHeaderClick(col.key)}
+                  >
+                    <span className="data-table-header-content">
+                      {col.i18nKey ? t(col.i18nKey) : col.label}
+                      {isSorted && (
+                        <span className="data-table-sort-indicator">
+                          {sortDir === 'asc' ? ' \u25B2' : ' \u25BC'}
+                        </span>
+                      )}
+                    </span>
+                  </th>
+                );
+              })}
+            </tr>
+          </thead>
+          <tbody>
+            {loading ? (
+              <tr>
+                <td
+                  colSpan={visibleColumns.length + 1}
+                  className="data-table-empty"
+                >
+                  {t('common.loading')}
+                </td>
+              </tr>
+            ) : data.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={visibleColumns.length + 1}
+                  className="data-table-empty"
+                >
+                  {t('students.noResults')}
+                </td>
+              </tr>
+            ) : (
+              data.map((row) => {
+                const id = rowKey(row);
+                const extraClass = rowClassName ? rowClassName(row) : '';
+                return (
+                  <tr key={id} className={extraClass}>
+                    <td className="data-table-checkbox">
+                      <input
+                        type="checkbox"
+                        checked={selectedIds.has(id)}
+                        onChange={() => toggleRow(id)}
+                      />
+                    </td>
+                    {visibleColumns.map((col) => (
+                      <td key={col.key}>
+                        {col.render
+                          ? col.render(row)
+                          : (String(row[col.key] ?? '-'))}
+                      </td>
+                    ))}
+                  </tr>
+                );
+              })
+            )}
+          </tbody>
+        </table>
+      </div>
+      <div className="data-table-pagination">
+        <div className="data-table-pagination-info">
+          {t('common.showing')} {startRecord} {t('common.to')} {endRecord}{' '}
+          {t('common.of')} {total} {t('common.records')}
+          {pageSizeOptions && onPageSizeChange && (
+            <span className="data-table-page-size">
+              {' | '}{t('students.pageSize')}:{' '}
+              <select
+                value={pageSize}
+                onChange={(e) => onPageSizeChange(Number(e.target.value))}
+              >
+                {pageSizeOptions.map((s) => (
+                  <option key={s} value={s}>
+                    {s}
+                  </option>
+                ))}
+              </select>
+            </span>
+          )}
+        </div>
+        <div className="data-table-pagination-controls">
+          <button
+            disabled={page <= 1}
+            onClick={() => onPageChange(page - 1)}
+          >
+            {t('common.previous')}
+          </button>
+          {pageButtons.map((p) => (
+            <button
+              key={p}
+              className={p === page ? 'active' : ''}
+              onClick={() => onPageChange(p)}
+            >
+              {p}
+            </button>
+          ))}
+          <button
+            disabled={page >= totalPages}
+            onClick={() => onPageChange(page + 1)}
+          >
+            {t('common.next')}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Add CSS for sort indicators, page size selector, and row highlight**
+
+Append to `frontend/src/components/DataTable.css`:
+
+```css
+/* Sort */
+.data-table-sortable {
+  cursor: pointer;
+  user-select: none;
+}
+
+.data-table-sortable:hover {
+  color: var(--accent);
+}
+
+.data-table-header-content {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.data-table-sort-indicator {
+  font-size: 0.65rem;
+  color: var(--accent);
+}
+
+/* Page size selector */
+.data-table-page-size {
+  margin-left: 0.25rem;
+}
+
+.data-table-page-size select {
+  font-family: var(--font-sans);
+  font-size: 0.8rem;
+  padding: 0.15rem 0.4rem;
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-sm);
+  background: var(--bg-input);
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+/* Row highlight for newly added */
+.data-table-row-highlight {
+  background: var(--accent-muted) !important;
+  animation: fadeIn 0.5s ease;
+}
+
+.data-table-row-highlight:hover {
+  background: rgba(55, 138, 221, 0.15) !important;
+}
+```
+
+- [ ] **Step 3: Type check and build**
+
+Run: `cd /Users/kennylee/Development/NeoApex/admindash/frontend && npx tsc -b && npm run build 2>&1 | tail -10`
+Expected: No errors, build succeeds (existing DataTable usage doesn't break since new props are optional)
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/kennylee/Development/NeoApex/admindash
+git add frontend/src/components/DataTable.tsx frontend/src/components/DataTable.css
+git commit -m "feat: enhance DataTable with sort, page size, column toggle, row highlight"
+```
+
+---
+
+### Task 7: StudentsPage Rewrite
+
+**Files:**
+- Rewrite: `frontend/src/pages/StudentsPage.tsx`
+- Modify: `frontend/src/pages/StudentsPage.css`
+
+This is the largest task. It replaces the legacy data fetching with the new datacore query, adds dynamic search pane from model definition, column ordering from ModelContext, column visibility toggle, adaptive page size, preferences integration, and newly-added student highlighting.
+
+- [ ] **Step 1: Rewrite StudentsPage**
+
+Replace the full content of `frontend/src/pages/StudentsPage.tsx`:
+
+```typescript
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useTranslation } from '../hooks/useTranslation.ts';
+import { useAuth } from '../contexts/AuthContext.tsx';
+import { useModel } from '../contexts/ModelContext.tsx';
+import { useTablePreferences } from '../hooks/useTablePreferences.ts';
+import { queryStudents } from '../api/client.ts';
+import DataTable, { type Column } from '../components/DataTable.tsx';
+import FilterForm from '../components/FilterForm.tsx';
+import StatusBadge from '../components/StatusBadge.tsx';
+import type { ModelDefinition } from '../types/models.ts';
+import './StudentsPage.css';
+
+const PAGE_SIZE_OPTIONS = [10, 20, 30, 40, 50];
+const STATUS_OPTIONS = ['Active', 'On Leave', 'Suspended', 'Graduated', 'Dropped'];
+const STATUS_I18N: Record<string, string> = {
+  Active: 'students.status.active',
+  'On Leave': 'students.status.onLeave',
+  Suspended: 'students.status.suspended',
+  Graduated: 'students.status.graduated',
+  Dropped: 'students.status.dropped',
+};
+
+interface StudentsPageProps {
+  tenant: string;
+}
+
+/**
+ * Converts snake_case or camelCase to Title Case labels.
+ */
+function formatFieldLabel(key: string): string {
+  return key
+    .replace(/_/g, ' ')
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+/**
+ * Builds columns from model definition: base_fields first, then custom_fields.
+ */
+function buildColumns(modelDef: ModelDefinition): Column<Record<string, unknown>>[] {
+  const cols: Column<Record<string, unknown>>[] = [];
+
+  for (const field of modelDef.base_fields) {
+    if (field.name === 'enrollment_status' || field.name === '_status') {
+      cols.push({
+        key: field.name,
+        label: formatFieldLabel(field.name),
+        render: (row) => <StatusBadge status={String(row[field.name] ?? '')} />,
+      });
+    } else {
+      cols.push({
+        key: field.name,
+        label: formatFieldLabel(field.name),
+        render: (row) => {
+          const val = row[field.name];
+          if (val == null) return '-';
+          if (typeof val === 'object') return JSON.stringify(val);
+          return String(val);
+        },
+      });
+    }
+  }
+
+  for (const field of modelDef.custom_fields) {
+    cols.push({
+      key: `custom:${field.name}`,
+      label: formatFieldLabel(field.name),
+      render: (row) => {
+        const val = row[field.name];
+        if (val == null) return '-';
+        if (typeof val === 'object') return JSON.stringify(val);
+        return String(val);
+      },
+    });
+  }
+
+  return cols;
+}
+
+/**
+ * Calculate best-fit page size for viewport. Rounds down to nearest 10.
+ */
+function calcAdaptivePageSize(containerRef: React.RefObject<HTMLDivElement | null>): number {
+  const el = containerRef.current;
+  if (!el) return 20;
+  // Estimate: table header ~180px, pagination ~60px, row ~48px
+  const available = el.clientHeight - 240;
+  const rows = Math.floor(available / 48);
+  const rounded = Math.floor(rows / 10) * 10;
+  if (rounded < 10) return 10;
+  if (rounded > 50) return 50;
+  return rounded;
+}
+
+export default function StudentsPage({ tenant }: StudentsPageProps) {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { user } = useAuth();
+  const { getModel, getCachedModel } = useModel();
+
+  // Model definition
+  const [modelDef, setModelDef] = useState<ModelDefinition | null>(
+    getCachedModel('student') ?? null,
+  );
+  const [modelLoading, setModelLoading] = useState(!modelDef);
+
+  // Data
+  const [data, setData] = useState<Record<string, unknown>[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Newly added highlight
+  const highlightId = (location.state as { highlightEntityId?: string } | null)
+    ?.highlightEntityId ?? null;
+  const [activeHighlight, setActiveHighlight] = useState<string | null>(highlightId);
+
+  // Container ref for adaptive page size
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Build column keys for preferences
+  const allColumnKeys = useMemo(() => {
+    if (!modelDef) return [];
+    return [
+      ...modelDef.base_fields.map((f) => f.name),
+      ...modelDef.custom_fields.map((f) => `custom:${f.name}`),
+    ];
+  }, [modelDef]);
+
+  // Preferences
+  const { prefs, updatePrefs, toggleColumn } = useTablePreferences(
+    user?.user_id ?? '',
+    tenant,
+    allColumnKeys,
+  );
+
+  // Filter state
+  const [filters, setFilters] = useState<Record<string, string>>({
+    _status: 'active',
+  });
+
+  // Column toggle popover
+  const [showColumnSettings, setShowColumnSettings] = useState(false);
+
+  // Fetch model on mount
+  useEffect(() => {
+    if (modelDef) return;
+    setModelLoading(true);
+    getModel(tenant, 'student')
+      .then((def) => setModelDef(def))
+      .catch(() => setError('Failed to load student model'))
+      .finally(() => setModelLoading(false));
+  }, [tenant, getModel, modelDef]);
+
+  // Adaptive page size on mount
+  useEffect(() => {
+    if (!prefs) return;
+    const adaptive = calcAdaptivePageSize(containerRef);
+    if (adaptive !== prefs.pageSize && prefs.pageSize === 20) {
+      // Only auto-adjust if user hasn't manually set a preference
+      updatePrefs({ pageSize: adaptive });
+    }
+  }, [modelDef]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Build columns from model
+  const columns = useMemo(() => {
+    if (!modelDef) return [];
+    return buildColumns(modelDef);
+  }, [modelDef]);
+
+  // Data loading
+  const loadData = useCallback(
+    async (p: number) => {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await queryStudents(tenant, {
+          ...filters,
+          sort_by: prefs.sortBy,
+          sort_dir: prefs.sortDir,
+          limit: prefs.pageSize,
+          offset: (p - 1) * prefs.pageSize,
+        });
+        let rows = res.data ?? [];
+
+        // If there's a highlighted new student, prepend it
+        if (activeHighlight && p === 1) {
+          const idx = rows.findIndex((r) => r.entity_id === activeHighlight);
+          if (idx > 0) {
+            const [item] = rows.splice(idx, 1);
+            rows = [item, ...rows];
+          }
+        }
+
+        setData(rows);
+        setTotal(res.total ?? 0);
+        setPage(p);
+      } catch (err) {
+        setError(`Failed to load students. Is datacore running? (${err})`);
+        setData([]);
+        setTotal(0);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [tenant, filters, prefs.sortBy, prefs.sortDir, prefs.pageSize, activeHighlight],
+  );
+
+  useEffect(() => {
+    if (!modelDef) return;
+    loadData(1);
+  }, [loadData, modelDef]);
+
+  // Handlers
+  function handleSearch() {
+    loadData(1);
+  }
+
+  function handleReset() {
+    setFilters({ _status: 'active' });
+    loadData(1);
+  }
+
+  function handleFilterChange(field: string, value: string) {
+    setFilters((prev) => ({ ...prev, [field]: value }));
+  }
+
+  function handleSortChange(column: string) {
+    // Clear highlight when sort changes
+    setActiveHighlight(null);
+    if (column === prefs.sortBy) {
+      updatePrefs({ sortDir: prefs.sortDir === 'asc' ? 'desc' : 'asc' });
+    } else {
+      updatePrefs({ sortBy: column, sortDir: 'asc' });
+    }
+  }
+
+  function handlePageSizeChange(size: number) {
+    updatePrefs({ pageSize: size as 10 | 20 | 30 | 40 | 50 });
+    loadData(1);
+  }
+
+  // Row highlight class
+  function rowClassName(row: Record<string, unknown>): string {
+    if (activeHighlight && row.entity_id === activeHighlight) {
+      return 'data-table-row-highlight';
+    }
+    return '';
+  }
+
+  if (modelLoading) {
+    return (
+      <div className="students-page" ref={containerRef}>
+        <p>{t('common.loading')}</p>
+      </div>
+    );
+  }
+
+  // Build search fields from model base_fields
+  const searchFields = modelDef?.base_fields ?? [];
+
+  return (
+    <div className="students-page" ref={containerRef}>
+      <h1>{t('students.title')}</h1>
+
+      <FilterForm onSearch={handleSearch} onReset={handleReset}>
+        {searchFields.map((field) => {
+          if (field.name === 'enrollment_status' || field.name === '_status') return null;
+          return (
+            <div className="filter-field" key={field.name}>
+              <label>{formatFieldLabel(field.name)}</label>
+              {field.type === 'selection' && field.options ? (
+                <select
+                  value={filters[field.name] ?? ''}
+                  onChange={(e) => handleFilterChange(field.name, e.target.value)}
+                >
+                  <option value="">All</option>
+                  {field.options.map((opt) => (
+                    <option key={opt} value={opt}>{opt}</option>
+                  ))}
+                </select>
+              ) : (
+                <input
+                  type="text"
+                  placeholder={`Search ${formatFieldLabel(field.name).toLowerCase()}`}
+                  value={filters[field.name] ?? ''}
+                  onChange={(e) => handleFilterChange(field.name, e.target.value)}
+                />
+              )}
+            </div>
+          );
+        })}
+        {/* Status filter */}
+        <div className="filter-field">
+          <label>{t('students.searchStatus')}</label>
+          <select
+            value={filters._status ?? 'active'}
+            onChange={(e) => handleFilterChange('_status', e.target.value)}
+          >
+            <option value="active">{t('students.status.active')}</option>
+            {STATUS_OPTIONS.map((s) => (
+              <option key={s} value={s.toLowerCase()}>
+                {t(STATUS_I18N[s])}
+              </option>
+            ))}
+            <option value="all">{t('students.showAll')}</option>
+          </select>
+        </div>
+        {/* Address fuzzy search */}
+        <div className="filter-field">
+          <label>{t('students.addressSearch')}</label>
+          <input
+            type="text"
+            placeholder={t('students.addressSearchPlaceholder')}
+            value={filters.address ?? ''}
+            onChange={(e) => handleFilterChange('address', e.target.value)}
+          />
+        </div>
+      </FilterForm>
+
+      <div className="students-toolbar">
+        <button>{t('students.batchExport')}</button>
+        <button>{t('students.batchActions')}</button>
+        <div className="students-column-toggle">
+          <button onClick={() => setShowColumnSettings((v) => !v)}>
+            {t('students.columnSettings')}
+          </button>
+          {showColumnSettings && (
+            <div className="students-column-popover">
+              {columns.map((col) => (
+                <label key={col.key} className="students-column-option">
+                  <input
+                    type="checkbox"
+                    checked={!prefs.hiddenColumns.includes(col.key)}
+                    onChange={() => toggleColumn(col.key)}
+                  />
+                  {col.label}
+                </label>
+              ))}
+            </div>
+          )}
+        </div>
+        <button onClick={() => navigate('/students/add')}>
+          {t('students.addStudent')}
+        </button>
+      </div>
+
+      {error ? (
+        <div className="student-error">{error}</div>
+      ) : (
+        <DataTable<Record<string, unknown>>
+          columns={columns}
+          data={data}
+          total={total}
+          page={page}
+          pageSize={prefs.pageSize}
+          loading={loading}
+          onPageChange={loadData}
+          rowKey={(row) => String(row.entity_id ?? row.student_id ?? '')}
+          sortBy={prefs.sortBy}
+          sortDir={prefs.sortDir}
+          onSortChange={handleSortChange}
+          pageSizeOptions={PAGE_SIZE_OPTIONS}
+          onPageSizeChange={handlePageSizeChange}
+          hiddenColumns={prefs.hiddenColumns}
+          rowClassName={rowClassName}
+        />
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Add column toggle popover CSS**
+
+Append to `frontend/src/pages/StudentsPage.css`:
+
+```css
+/* Column toggle */
+.students-column-toggle {
+  position: relative;
+}
+
+.students-column-popover {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  z-index: 100;
+  margin-top: 0.25rem;
+  background: var(--bg-card);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-elevated);
+  padding: 0.5rem;
+  min-width: 180px;
+  max-height: 300px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.students-column-option {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.8rem;
+  color: var(--text-primary);
+  padding: 0.25rem 0.4rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.students-column-option:hover {
+  background: var(--accent-glow);
+}
+
+.students-column-option input[type="checkbox"] {
+  width: 0.9rem;
+  height: 0.9rem;
+}
+```
+
+- [ ] **Step 3: Type check and build**
+
+Run: `cd /Users/kennylee/Development/NeoApex/admindash/frontend && npx tsc -b && npm run build 2>&1 | tail -10`
+Expected: No errors, build succeeds
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/kennylee/Development/NeoApex/admindash
+git add frontend/src/pages/StudentsPage.tsx frontend/src/pages/StudentsPage.css
+git commit -m "feat: rewrite StudentsPage with datacore query, dynamic search, column toggle, preferences"
+```
+
+---
+
+### Task 8: AddStudentPage Integration
+
+**Files:**
+- Modify: `frontend/src/pages/AddStudentPage.tsx`
+
+- [ ] **Step 1: Pass entity_id via router state on successful creation**
+
+In `frontend/src/pages/AddStudentPage.tsx`, update the `handleSubmit` function. Find the line:
+
+```typescript
+      setTimeout(() => navigate('/students'), 1500);
+```
+
+Replace with:
+
+```typescript
+      setTimeout(() => navigate('/students', {
+        state: { highlightEntityId: result.entity_id },
+      }), 1500);
+```
+
+This requires capturing the return value from `createStudent`. Update the try block:
+
+```typescript
+    try {
+      const result = await createStudent(tenant, baseData, customFields);
+      setSuccessMessage(t('addStudent.success'));
+      setTimeout(() => navigate('/students', {
+        state: { highlightEntityId: result.entity_id },
+      }), 1500);
+    } catch (e) {
+```
+
+- [ ] **Step 2: Type check and build**
+
+Run: `cd /Users/kennylee/Development/NeoApex/admindash/frontend && npx tsc -b && npm run build 2>&1 | tail -10`
+Expected: No errors, build succeeds
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/kennylee/Development/NeoApex/admindash
+git add frontend/src/pages/AddStudentPage.tsx
+git commit -m "feat: pass entity_id via router state for newly-added student highlighting"
+```
+
+---
+
+## Task Dependency Graph
+
+```
+Task 1 (Query API)  ──┐
+                       ├──► Task 7 (StudentsPage Rewrite)
+Task 2 (API Client) ──┤
+Task 3 (ModelContext)──┤
+Task 4 (i18n)       ──┤
+Task 5 (Preferences) ─┤
+Task 6 (DataTable)  ──┘
+                          Task 7 ──► Task 8 (AddStudent Integration)
+```
+
+Tasks 1-6 are independent of each other and can run in parallel. Task 7 depends on all of 1-6. Task 8 depends on Task 7.

--- a/admindash/frontend/src/App.tsx
+++ b/admindash/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { AuthProvider, useAuth } from './contexts/AuthContext.tsx';
+import { ModelProvider } from './contexts/ModelContext.tsx';
 import Navbar from './components/Navbar.tsx';
 import Footer from './components/Footer.tsx';
 import LoginPage from './pages/LoginPage.tsx';
@@ -37,26 +38,28 @@ function AppRoutes() {
           !user ? (
             <Navigate to="/login" replace />
           ) : (
-            <div className="app-shell">
-              <Navbar currentTenant={tenant} onTenantChange={setTenant} />
-              <main className="app-main">
-                <Routes>
-                  <Route path="/home" element={<HomePage />} />
-                  <Route
-                    path="/students/add"
-                    element={<AddStudentPage tenant={tenant} />}
-                  />
-                  <Route
-                    path="/students"
-                    element={<StudentsPage tenant={tenant} />}
-                  />
-                  <Route path="/leads" element={<LeadPage />} />
-                  <Route path="/programs" element={<ProgramPage />} />
-                  <Route path="*" element={<Navigate to="/home" replace />} />
-                </Routes>
-              </main>
-              <Footer />
-            </div>
+            <ModelProvider>
+              <div className="app-shell">
+                <Navbar currentTenant={tenant} onTenantChange={setTenant} />
+                <main className="app-main">
+                  <Routes>
+                    <Route path="/home" element={<HomePage />} />
+                    <Route
+                      path="/students/add"
+                      element={<AddStudentPage tenant={tenant} />}
+                    />
+                    <Route
+                      path="/students"
+                      element={<StudentsPage tenant={tenant} />}
+                    />
+                    <Route path="/leads" element={<LeadPage />} />
+                    <Route path="/programs" element={<ProgramPage />} />
+                    <Route path="*" element={<Navigate to="/home" replace />} />
+                  </Routes>
+                </main>
+                <Footer />
+              </div>
+            </ModelProvider>
           )
         }
       />

--- a/admindash/frontend/src/api/client.ts
+++ b/admindash/frontend/src/api/client.ts
@@ -4,6 +4,8 @@ import type {
   ModelResponse,
   CreateEntityResponse,
   ExtractResponse,
+  QueryStudentsParams,
+  QueryStudentsResponse,
 } from '../types/models.ts';
 
 const API_BASE = 'http://localhost:8080';
@@ -74,6 +76,23 @@ export async function extractStudentFromDocument(
       method: 'POST',
       body: formData,
     },
+  );
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+  return resp.json();
+}
+
+export async function queryStudents(
+  tenantId: string,
+  params: QueryStudentsParams = {},
+): Promise<QueryStudentsResponse> {
+  const searchParams = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value != null && value !== '') {
+      searchParams.set(key, String(value));
+    }
+  }
+  const resp = await fetch(
+    `${DATACORE_API_BASE}/api/entities/${tenantId}/student/query?${searchParams}`,
   );
   if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
   return resp.json();

--- a/admindash/frontend/src/components/DataTable.css
+++ b/admindash/frontend/src/components/DataTable.css
@@ -108,3 +108,50 @@
   opacity: 0.4;
   cursor: not-allowed;
 }
+
+/* Sort */
+.data-table-sortable {
+  cursor: pointer;
+  user-select: none;
+}
+
+.data-table-sortable:hover {
+  color: var(--accent);
+}
+
+.data-table-header-content {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.data-table-sort-indicator {
+  font-size: 0.65rem;
+  color: var(--accent);
+}
+
+/* Page size selector */
+.data-table-page-size {
+  margin-left: 0.25rem;
+}
+
+.data-table-page-size select {
+  font-family: var(--font-sans);
+  font-size: 0.8rem;
+  padding: 0.15rem 0.4rem;
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-sm);
+  background: var(--bg-input);
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+/* Row highlight for newly added */
+.data-table-row-highlight {
+  background: var(--accent-muted) !important;
+  animation: fadeIn 0.5s ease;
+}
+
+.data-table-row-highlight:hover {
+  background: rgba(55, 138, 221, 0.15) !important;
+}

--- a/admindash/frontend/src/components/DataTable.css
+++ b/admindash/frontend/src/components/DataTable.css
@@ -17,19 +17,20 @@
 }
 
 .data-table thead {
-  background: var(--bg-elevated);
+  background: var(--bg-tertiary);
 }
 
 .data-table th {
+  position: relative;
   padding: 0.7rem 1rem;
   text-align: left;
   font-size: 12px;
   font-weight: 600;
-  color: var(--text-tertiary);
+  color: var(--text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.05em;
   white-space: nowrap;
-  border-bottom: 1px solid var(--border-subtle);
+  border-bottom: 2px solid var(--border-primary);
 }
 
 .data-table td {
@@ -147,11 +148,11 @@
 }
 
 /* Row highlight for newly added */
-.data-table-row-highlight {
+.data-table-row-highlight td {
   background: var(--accent-muted) !important;
   animation: fadeIn 0.5s ease;
 }
 
-.data-table-row-highlight:hover {
+.data-table-row-highlight:hover td {
   background: rgba(55, 138, 221, 0.15) !important;
 }

--- a/admindash/frontend/src/components/DataTable.tsx
+++ b/admindash/frontend/src/components/DataTable.tsx
@@ -18,6 +18,17 @@ interface DataTableProps<T> {
   loading?: boolean;
   onPageChange: (page: number) => void;
   rowKey: (row: T) => string;
+  // Sort
+  sortBy?: string;
+  sortDir?: 'asc' | 'desc';
+  onSortChange?: (column: string) => void;
+  // Page size
+  pageSizeOptions?: number[];
+  onPageSizeChange?: (size: number) => void;
+  // Column visibility
+  hiddenColumns?: string[];
+  // Row styling
+  rowClassName?: (row: T) => string;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -30,10 +41,22 @@ export default function DataTable<T extends Record<string, any>>({
   loading,
   onPageChange,
   rowKey,
+  sortBy,
+  sortDir,
+  onSortChange,
+  pageSizeOptions,
+  onPageSizeChange,
+  hiddenColumns,
+  rowClassName,
 }: DataTableProps<T>) {
   const { t } = useTranslation();
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const totalPages = Math.max(1, Math.ceil(total / pageSize));
+
+  const hiddenSet = hiddenColumns ? new Set(hiddenColumns) : null;
+  const visibleColumns = hiddenSet
+    ? columns.filter((col) => !hiddenSet.has(col.key))
+    : columns;
 
   const allOnPageSelected =
     data.length > 0 && data.every((row) => selectedIds.has(rowKey(row)));
@@ -82,9 +105,20 @@ export default function DataTable<T extends Record<string, any>>({
                   onChange={toggleAll}
                 />
               </th>
-              {columns.map((col) => (
-                <th key={col.key}>
-                  {col.i18nKey ? t(col.i18nKey) : col.label}
+              {visibleColumns.map((col) => (
+                <th
+                  key={col.key}
+                  className={onSortChange ? 'data-table-sortable' : undefined}
+                  onClick={onSortChange ? () => onSortChange(col.key) : undefined}
+                >
+                  <span className="data-table-header-content">
+                    {col.i18nKey ? t(col.i18nKey) : col.label}
+                    {sortBy === col.key && (
+                      <span className="data-table-sort-indicator">
+                        {sortDir === 'asc' ? '\u25B2' : '\u25BC'}
+                      </span>
+                    )}
+                  </span>
                 </th>
               ))}
             </tr>
@@ -93,7 +127,7 @@ export default function DataTable<T extends Record<string, any>>({
             {loading ? (
               <tr>
                 <td
-                  colSpan={columns.length + 1}
+                  colSpan={visibleColumns.length + 1}
                   className="data-table-empty"
                 >
                   {t('common.loading')}
@@ -102,7 +136,7 @@ export default function DataTable<T extends Record<string, any>>({
             ) : data.length === 0 ? (
               <tr>
                 <td
-                  colSpan={columns.length + 1}
+                  colSpan={visibleColumns.length + 1}
                   className="data-table-empty"
                 >
                   {t('students.noResults')}
@@ -111,8 +145,9 @@ export default function DataTable<T extends Record<string, any>>({
             ) : (
               data.map((row) => {
                 const id = rowKey(row);
+                const extraClass = rowClassName ? rowClassName(row) : '';
                 return (
-                  <tr key={id}>
+                  <tr key={id} className={extraClass || undefined}>
                     <td className="data-table-checkbox">
                       <input
                         type="checkbox"
@@ -120,7 +155,7 @@ export default function DataTable<T extends Record<string, any>>({
                         onChange={() => toggleRow(id)}
                       />
                     </td>
-                    {columns.map((col) => (
+                    {visibleColumns.map((col) => (
                       <td key={col.key}>
                         {col.render
                           ? col.render(row)
@@ -138,6 +173,21 @@ export default function DataTable<T extends Record<string, any>>({
         <div className="data-table-pagination-info">
           {t('common.showing')} {startRecord} {t('common.to')} {endRecord}{' '}
           {t('common.of')} {total} {t('common.records')}
+          {pageSizeOptions && onPageSizeChange && (
+            <span className="data-table-page-size">
+              {t('students.pageSize')}{' '}
+              <select
+                value={pageSize}
+                onChange={(e) => onPageSizeChange(Number(e.target.value))}
+              >
+                {pageSizeOptions.map((opt) => (
+                  <option key={opt} value={opt}>
+                    {opt}
+                  </option>
+                ))}
+              </select>
+            </span>
+          )}
         </div>
         <div className="data-table-pagination-controls">
           <button

--- a/admindash/frontend/src/contexts/ModelContext.tsx
+++ b/admindash/frontend/src/contexts/ModelContext.tsx
@@ -1,0 +1,52 @@
+import { createContext, useContext, useState, useCallback, type ReactNode } from 'react';
+import { fetchStudentModel } from '../api/client.ts';
+import type { ModelDefinition } from '../types/models.ts';
+
+interface ModelCache {
+  [entityType: string]: ModelDefinition;
+}
+
+interface ModelContextValue {
+  getModel: (tenantId: string, entityType: string) => Promise<ModelDefinition>;
+  getCachedModel: (entityType: string) => ModelDefinition | undefined;
+  clearCache: () => void;
+}
+
+const ModelContext = createContext<ModelContextValue>({
+  getModel: () => Promise.reject(new Error('ModelContext not initialized')),
+  getCachedModel: () => undefined,
+  clearCache: () => {},
+});
+
+export function ModelProvider({ children }: { children: ReactNode }) {
+  const [cache, setCache] = useState<ModelCache>({});
+
+  const getModel = useCallback(
+    async (tenantId: string, entityType: string): Promise<ModelDefinition> => {
+      if (cache[entityType]) return cache[entityType];
+
+      const resp = await fetchStudentModel(tenantId);
+      const modelDef = resp.model_definition;
+      setCache((prev) => ({ ...prev, [entityType]: modelDef }));
+      return modelDef;
+    },
+    [cache],
+  );
+
+  const getCachedModel = useCallback(
+    (entityType: string): ModelDefinition | undefined => cache[entityType],
+    [cache],
+  );
+
+  const clearCache = useCallback(() => setCache({}), []);
+
+  return (
+    <ModelContext.Provider value={{ getModel, getCachedModel, clearCache }}>
+      {children}
+    </ModelContext.Provider>
+  );
+}
+
+export function useModel() {
+  return useContext(ModelContext);
+}

--- a/admindash/frontend/src/hooks/useTablePreferences.ts
+++ b/admindash/frontend/src/hooks/useTablePreferences.ts
@@ -1,0 +1,97 @@
+import { useState, useCallback } from 'react';
+
+const VALID_PAGE_SIZES = [10, 20, 30, 40, 50] as const;
+type ValidPageSize = (typeof VALID_PAGE_SIZES)[number];
+
+export interface TablePreferences {
+  hiddenColumns: string[];
+  pageSize: ValidPageSize;
+  sortBy: string;
+  sortDir: 'asc' | 'desc';
+}
+
+const DEFAULT_PREFS: TablePreferences = {
+  hiddenColumns: [],
+  pageSize: 20,
+  sortBy: 'last_name',
+  sortDir: 'asc',
+};
+
+function buildStorageKey(userId: string, tenantId: string): string {
+  return `admindash_table_prefs_${userId}_${tenantId}`;
+}
+
+function validatePageSize(size: number): ValidPageSize {
+  return VALID_PAGE_SIZES.includes(size as ValidPageSize)
+    ? (size as ValidPageSize)
+    : 20;
+}
+
+function loadPreferences(
+  userId: string,
+  tenantId: string,
+  currentColumns: string[],
+): TablePreferences {
+  const key = buildStorageKey(userId, tenantId);
+  const raw = localStorage.getItem(key);
+  if (!raw) return { ...DEFAULT_PREFS };
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<TablePreferences>;
+    const colSet = new Set(currentColumns);
+    return {
+      hiddenColumns: (parsed.hiddenColumns ?? []).filter((c) => colSet.has(c)),
+      pageSize: validatePageSize(parsed.pageSize ?? 20),
+      sortBy: parsed.sortBy ?? DEFAULT_PREFS.sortBy,
+      sortDir: parsed.sortDir === 'desc' ? 'desc' : 'asc',
+    };
+  } catch {
+    return { ...DEFAULT_PREFS };
+  }
+}
+
+function savePreferences(
+  userId: string,
+  tenantId: string,
+  prefs: TablePreferences,
+): void {
+  const key = buildStorageKey(userId, tenantId);
+  localStorage.setItem(key, JSON.stringify(prefs));
+}
+
+export function useTablePreferences(
+  userId: string,
+  tenantId: string,
+  currentColumns: string[],
+) {
+  const [prefs, setPrefs] = useState<TablePreferences>(() =>
+    loadPreferences(userId, tenantId, currentColumns),
+  );
+
+  const updatePrefs = useCallback(
+    (updates: Partial<TablePreferences>) => {
+      setPrefs((prev) => {
+        const next = { ...prev, ...updates };
+        savePreferences(userId, tenantId, next);
+        return next;
+      });
+    },
+    [userId, tenantId],
+  );
+
+  const toggleColumn = useCallback(
+    (columnKey: string) => {
+      setPrefs((prev) => {
+        const hidden = prev.hiddenColumns.includes(columnKey)
+          ? prev.hiddenColumns.filter((c) => c !== columnKey)
+          : [...prev.hiddenColumns, columnKey];
+        const next = { ...prev, hiddenColumns: hidden };
+        savePreferences(userId, tenantId, next);
+        return next;
+      });
+    },
+    [userId, tenantId],
+  );
+
+  return { prefs, updatePrefs, toggleColumn };
+}

--- a/admindash/frontend/src/hooks/useTablePreferences.ts
+++ b/admindash/frontend/src/hooks/useTablePreferences.ts
@@ -42,7 +42,7 @@ function loadPreferences(
     return {
       hiddenColumns: (parsed.hiddenColumns ?? []).filter((c) => colSet.has(c)),
       pageSize: validatePageSize(parsed.pageSize ?? 20),
-      sortBy: parsed.sortBy ?? DEFAULT_PREFS.sortBy,
+      sortBy: (parsed.sortBy && colSet.has(parsed.sortBy)) ? parsed.sortBy : DEFAULT_PREFS.sortBy,
       sortDir: parsed.sortDir === 'desc' ? 'desc' : 'asc',
     };
   } catch {

--- a/admindash/frontend/src/i18n/translations.ts
+++ b/admindash/frontend/src/i18n/translations.ts
@@ -94,6 +94,15 @@ export const translations: Record<Locale, Record<string, string>> = {
     'addStudent.success': 'Student added successfully.',
     'addStudent.submitError': 'Failed to add student. Please try again.',
 
+    // Student List
+    'students.pageSize': 'Rows per page',
+    'students.columnSettings': 'Columns',
+    'students.addressSearch': 'Address',
+    'students.addressSearchPlaceholder': 'Search by address, city, state, zip',
+    'students.sortAsc': 'Sorted ascending',
+    'students.sortDesc': 'Sorted descending',
+    'students.showAll': 'Show All',
+
     // Program
     'program.title': 'Course Management',
 
@@ -235,6 +244,15 @@ export const translations: Record<Locale, Record<string, string>> = {
     'addStudent.modelNotFound': '\u5b66\u751f\u6a21\u578b\u672a\u914d\u7f6e\u3002\u8bf7\u5148\u5728 Papermite \u4e2d\u8bbe\u7f6e\u5b66\u751f\u6a21\u578b\u3002',
     'addStudent.success': '\u5b66\u751f\u6dfb\u52a0\u6210\u529f\u3002',
     'addStudent.submitError': '\u6dfb\u52a0\u5b66\u751f\u5931\u8d25\uff0c\u8bf7\u91cd\u8bd5\u3002',
+
+    // Student List
+    'students.pageSize': '\u6bcf\u9875\u884c\u6570',
+    'students.columnSettings': '\u5217\u8bbe\u7f6e',
+    'students.addressSearch': '\u5730\u5740',
+    'students.addressSearchPlaceholder': '\u6309\u5730\u5740\u3001\u57ce\u5e02\u3001\u5dde\u3001\u90ae\u7f16\u641c\u7d22',
+    'students.sortAsc': '\u5347\u5e8f\u6392\u5217',
+    'students.sortDesc': '\u964d\u5e8f\u6392\u5217',
+    'students.showAll': '\u663e\u793a\u5168\u90e8',
 
     // Program
     'program.title': '\u8bfe\u7a0b\u7ba1\u7406',

--- a/admindash/frontend/src/pages/AddStudentPage.tsx
+++ b/admindash/frontend/src/pages/AddStudentPage.tsx
@@ -52,9 +52,11 @@ export default function AddStudentPage({ tenant }: AddStudentPageProps) {
     setSubmitting(true);
     setSubmitError(null);
     try {
-      await createStudent(tenant, baseData, customFields);
+      const result = await createStudent(tenant, baseData, customFields);
       setSuccessMessage(t('addStudent.success'));
-      setTimeout(() => navigate('/students'), 1500);
+      setTimeout(() => navigate('/students', {
+        state: { highlightEntityId: result.entity_id },
+      }), 1500);
     } catch (e) {
       setSubmitError(e instanceof Error ? e.message : t('addStudent.submitError'));
     } finally {

--- a/admindash/frontend/src/pages/AddStudentPage.tsx
+++ b/admindash/frontend/src/pages/AddStudentPage.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from '../hooks/useTranslation.ts';
-import { fetchStudentModel, createStudent, extractStudentFromDocument } from '../api/client.ts';
+import { createStudent, extractStudentFromDocument } from '../api/client.ts';
+import { useModel } from '../contexts/ModelContext.tsx';
 import DynamicForm from '../components/DynamicForm.tsx';
 import DocumentUpload from '../components/DocumentUpload.tsx';
 import type { ModelDefinition } from '../types/models.ts';
@@ -14,6 +15,7 @@ interface AddStudentPageProps {
 export default function AddStudentPage({ tenant }: AddStudentPageProps) {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const { getModel } = useModel();
 
   const [activeTab, setActiveTab] = useState<'form' | 'upload'>('form');
   const [modelDef, setModelDef] = useState<ModelDefinition | null>(null);
@@ -27,11 +29,11 @@ export default function AddStudentPage({ tenant }: AddStudentPageProps) {
   useEffect(() => {
     setLoading(true);
     setModelError(null);
-    fetchStudentModel(tenant)
-      .then((resp) => setModelDef(resp.model_definition))
+    getModel(tenant, 'student')
+      .then((def) => setModelDef(def))
       .catch(() => setModelError(t('addStudent.modelNotFound')))
       .finally(() => setLoading(false));
-  }, [tenant, t]);
+  }, [tenant, getModel, t]);
 
   const handleExtracted = (fields: Record<string, string>) => {
     setExtractedValues((prev) => ({ ...prev, ...fields }));

--- a/admindash/frontend/src/pages/StudentsPage.css
+++ b/admindash/frontend/src/pages/StudentsPage.css
@@ -77,3 +77,46 @@
   border-radius: var(--radius-md);
   margin-top: 1rem;
 }
+
+.students-column-toggle {
+  position: relative;
+}
+
+.students-column-popover {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  z-index: 100;
+  margin-top: 0.25rem;
+  background: var(--bg-card);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-elevated);
+  padding: 0.5rem;
+  min-width: 180px;
+  max-height: 300px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.students-column-option {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.8rem;
+  color: var(--text-primary);
+  padding: 0.25rem 0.4rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.students-column-option:hover {
+  background: var(--accent-glow);
+}
+
+.students-column-option input[type="checkbox"] {
+  width: 0.9rem;
+  height: 0.9rem;
+}

--- a/admindash/frontend/src/pages/StudentsPage.css
+++ b/admindash/frontend/src/pages/StudentsPage.css
@@ -38,6 +38,8 @@
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  white-space: nowrap;
+  min-width: 160px;
 }
 
 .student-avatar {
@@ -62,6 +64,10 @@
 .student-display-name {
   font-weight: 600;
   font-size: 0.9rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 220px;
 }
 
 .student-preferred-name {

--- a/admindash/frontend/src/pages/StudentsPage.tsx
+++ b/admindash/frontend/src/pages/StudentsPage.tsx
@@ -337,9 +337,11 @@ export default function StudentsPage({ tenant }: StudentsPageProps) {
 
   // Sort handler
   function handleSortChange(column: string) {
+    // Map composite UI column keys to actual data column names
+    const sortColumn = column === 'name' ? 'last_name' : column;
     const newDir =
-      prefs.sortBy === column && prefs.sortDir === 'asc' ? 'desc' : 'asc';
-    updatePrefs({ sortBy: column, sortDir: newDir });
+      prefs.sortBy === sortColumn && prefs.sortDir === 'asc' ? 'desc' : 'asc';
+    updatePrefs({ sortBy: sortColumn, sortDir: newDir });
     setActiveHighlight(null); // clear highlight on sort change
   }
 

--- a/admindash/frontend/src/pages/StudentsPage.tsx
+++ b/admindash/frontend/src/pages/StudentsPage.tsx
@@ -1,29 +1,135 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useTranslation } from '../hooks/useTranslation.ts';
-import { fetchStudents } from '../api/client.ts';
+import { useAuth } from '../contexts/AuthContext.tsx';
+import { useModel } from '../contexts/ModelContext.tsx';
+import { useTablePreferences } from '../hooks/useTablePreferences.ts';
+import { queryStudents } from '../api/client.ts';
 import DataTable, { type Column } from '../components/DataTable.tsx';
 import FilterForm from '../components/FilterForm.tsx';
 import StatusBadge from '../components/StatusBadge.tsx';
-import type { Student } from '../types/models.ts';
+import type { ModelDefinition, ModelFieldDefinition } from '../types/models.ts';
 import './StudentsPage.css';
 
-const PAGE_SIZE = 10;
+type DataRow = Record<string, unknown>;
+
+const PAGE_SIZE_OPTIONS = [10, 20, 30, 40, 50] as const;
+const DEFAULT_PAGE_SIZE = 20;
+
+const STATUS_OPTIONS = [
+  { value: 'active', i18nKey: 'students.status.active' },
+  { value: 'on_leave', i18nKey: 'students.status.onLeave' },
+  { value: 'suspended', i18nKey: 'students.status.suspended' },
+  { value: 'graduated', i18nKey: 'students.status.graduated' },
+  { value: 'dropped', i18nKey: 'students.status.dropped' },
+];
+
+/** Fields that get a dedicated Status dropdown instead of a dynamic input */
+const SKIP_DYNAMIC_FIELDS = new Set(['enrollment_status', '_status']);
 
 interface StudentsPageProps {
   tenant: string;
 }
 
 /**
- * Builds the required (fixed) columns that every tenant sees.
+ * Converts snake_case or camelCase field names to Title Case labels.
  */
-function getRequiredColumns(): Column<Student>[] {
+function formatFieldLabel(key: string): string {
+  return key
+    .replace(/_/g, ' ')
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+/**
+ * Build columns from a model definition. Base fields first, then custom fields,
+ * in model definition order. Special rendering for name and status fields.
+ */
+function buildColumnsFromModel(model: ModelDefinition): Column<DataRow>[] {
+  const cols: Column<DataRow>[] = [];
+
+  for (const field of model.base_fields) {
+    if (field.name === 'first_name') {
+      // Composite name column — placed at position of first_name
+      cols.push({
+        key: 'name',
+        label: 'Student Name',
+        i18nKey: 'students.name',
+        render: (row: DataRow) => {
+          const fullName =
+            `${row.first_name ?? ''} ${row.last_name ?? ''}`.trim() || '-';
+          const avatarChar = fullName.charAt(0);
+          return (
+            <div className="student-name-cell">
+              <div className="student-avatar">{avatarChar}</div>
+              <div className="student-name-info">
+                <span className="student-display-name">{fullName}</span>
+                {row.preferred_name ? (
+                  <span className="student-preferred-name">
+                    {String(row.preferred_name)}
+                  </span>
+                ) : null}
+              </div>
+            </div>
+          );
+        },
+      });
+      continue;
+    }
+    if (field.name === 'last_name' || field.name === 'preferred_name') {
+      // Consumed by composite name column
+      continue;
+    }
+
+    const i18nMap: Record<string, string> = {
+      student_id: 'students.studentId',
+      gender: 'students.gender',
+      dob: 'students.dob',
+      grade_level: 'students.gradeLevel',
+      email: 'students.email',
+    };
+
+    cols.push({
+      key: field.name,
+      label: formatFieldLabel(field.name),
+      i18nKey: i18nMap[field.name],
+      render: field.name === 'enrollment_status' || field.name === '_status'
+        ? (row: DataRow) => <StatusBadge status={String(row._status ?? row.enrollment_status ?? '-')} />
+        : undefined,
+    });
+  }
+
+  // Status column from _status (always present in query response)
+  // Add if not already included from base_fields
+  if (!cols.some((c) => c.key === 'enrollment_status' || c.key === '_status')) {
+    cols.push({
+      key: '_status',
+      label: 'Status',
+      i18nKey: 'students.status',
+      render: (row: DataRow) => <StatusBadge status={String(row._status ?? '-')} />,
+    });
+  }
+
+  for (const field of model.custom_fields) {
+    cols.push({
+      key: field.name,
+      label: formatFieldLabel(field.name),
+    });
+  }
+
+  return cols;
+}
+
+/**
+ * Build fallback columns when no model is available.
+ */
+function getFallbackColumns(): Column<DataRow>[] {
   return [
     {
       key: 'name',
       label: 'Student Name',
       i18nKey: 'students.name',
-      render: (row: Student) => {
+      render: (row: DataRow) => {
         const fullName =
           `${row.first_name ?? ''} ${row.last_name ?? ''}`.trim() || '-';
         const avatarChar = fullName.charAt(0);
@@ -32,11 +138,11 @@ function getRequiredColumns(): Column<Student>[] {
             <div className="student-avatar">{avatarChar}</div>
             <div className="student-name-info">
               <span className="student-display-name">{fullName}</span>
-              {row.preferred_name && (
+              {row.preferred_name ? (
                 <span className="student-preferred-name">
-                  {row.preferred_name}
+                  {String(row.preferred_name)}
                 </span>
-              )}
+              ) : null}
             </div>
           </div>
         );
@@ -45,101 +151,137 @@ function getRequiredColumns(): Column<Student>[] {
     { key: 'student_id', label: 'Student ID', i18nKey: 'students.studentId' },
     { key: 'gender', label: 'Gender', i18nKey: 'students.gender' },
     { key: 'dob', label: 'Date of Birth', i18nKey: 'students.dob' },
-    {
-      key: 'grade_level',
-      label: 'Grade Level',
-      i18nKey: 'students.gradeLevel',
-    },
+    { key: 'grade_level', label: 'Grade Level', i18nKey: 'students.gradeLevel' },
     { key: 'email', label: 'Email', i18nKey: 'students.email' },
     {
-      key: 'guardian',
-      label: 'Guardian',
-      i18nKey: 'students.guardian',
-      render: (row: Student) => {
-        const name = [row.guardian1_first_name, row.guardian1_last_name]
-          .filter(Boolean)
-          .join(' ');
-        return name || '-';
-      },
-    },
-    {
-      key: 'enrollment_status',
+      key: '_status',
       label: 'Status',
       i18nKey: 'students.status',
-      render: (row: Student) => (
-        <StatusBadge status={row.enrollment_status} />
-      ),
+      render: (row: DataRow) => <StatusBadge status={String(row._status ?? '-')} />,
     },
   ];
 }
 
 /**
- * Discovers custom_fields keys across the current page of data and
- * builds dynamic columns for them. Keys are sorted alphabetically.
+ * Build dynamic filter fields from model base_fields, skipping status-like fields.
  */
-function getCustomColumns(data: Student[]): Column<Student>[] {
-  const keys = new Set<string>();
-  for (const student of data) {
-    if (student.custom_fields) {
-      for (const k of Object.keys(student.custom_fields)) {
-        keys.add(k);
-      }
-    }
-  }
-  return Array.from(keys)
-    .sort()
-    .map((key) => ({
-      key: `custom:${key}`,
-      label: formatCustomLabel(key),
-      render: (row: Student) => {
-        const val = row.custom_fields?.[key];
-        if (val == null) return '-';
-        if (typeof val === 'object') return JSON.stringify(val);
-        return String(val);
-      },
-    }));
-}
-
-/**
- * Converts snake_case or camelCase field names to Title Case labels.
- * e.g. "school_name" -> "School Name", "emergencyPhone" -> "Emergency Phone"
- */
-function formatCustomLabel(key: string): string {
-  return key
-    .replace(/_/g, ' ')
-    .replace(/([a-z])([A-Z])/g, '$1 $2')
-    .replace(/\b\w/g, (c) => c.toUpperCase());
+function getDynamicFilterFields(model: ModelDefinition | undefined): ModelFieldDefinition[] {
+  if (!model) return [];
+  return model.base_fields.filter(
+    (f) => !SKIP_DYNAMIC_FIELDS.has(f.name) && f.name !== 'preferred_name',
+  );
 }
 
 export default function StudentsPage({ tenant }: StudentsPageProps) {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const [data, setData] = useState<Student[]>([]);
+  const location = useLocation();
+  const { user } = useAuth();
+  const { getModel, getCachedModel } = useModel();
+
+  // Data state
+  const [data, setData] = useState<DataRow[]>([]);
   const [total, setTotal] = useState(0);
   const [page, setPage] = useState(1);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [modelLoaded, setModelLoaded] = useState(false);
 
-  // Filter state
-  const [filterName, setFilterName] = useState('');
-  const [filterId, setFilterId] = useState('');
-  const [filterGrade, setFilterGrade] = useState('');
-  const [filterGender, setFilterGender] = useState('');
-  const [filterStatus, setFilterStatus] = useState('');
-  const [filterEmail, setFilterEmail] = useState('');
+  // Filter state — _status defaults to 'active'
+  const [filters, setFilters] = useState<Record<string, string>>({ _status: 'active' });
 
+  // Column popover state
+  const [showColumnPopover, setShowColumnPopover] = useState(false);
+  const columnToggleRef = useRef<HTMLDivElement>(null);
+
+  // Highlight state from navigation
+  const highlightEntityId = (location.state as { highlightEntityId?: string } | null)?.highlightEntityId ?? null;
+  const [activeHighlight, setActiveHighlight] = useState<string | null>(highlightEntityId);
+
+  // Model loading
+  useEffect(() => {
+    getModel(tenant, 'student').then(() => setModelLoaded(true)).catch(() => setModelLoaded(true));
+  }, [tenant, getModel]);
+
+  const model = getCachedModel('student');
+
+  // Build columns from model
+  const columns = useMemo<Column<DataRow>[]>(() => {
+    if (model) return buildColumnsFromModel(model);
+    return getFallbackColumns();
+  }, [model]);
+
+  const columnKeys = useMemo(() => columns.map((c) => c.key), [columns]);
+
+  // Table preferences
+  const userId = user?.user_id ?? 'anonymous';
+  const { prefs, updatePrefs, toggleColumn } = useTablePreferences(userId, tenant, columnKeys);
+
+  // Adaptive page size on mount
+  const containerRef = useRef<HTMLDivElement>(null);
+  const hasUserChangedPageSize = useRef(false);
+
+  useEffect(() => {
+    if (hasUserChangedPageSize.current) return;
+    if (prefs.pageSize !== DEFAULT_PAGE_SIZE) return; // user had a saved non-default
+    const el = containerRef.current;
+    if (!el) return;
+    const containerHeight = el.clientHeight;
+    const estimatedRowHeight = 48; // approximate row height in px
+    const headerOverhead = 260; // filters + toolbar + pagination + header
+    const availableHeight = containerHeight - headerOverhead;
+    if (availableHeight <= 0) return;
+    const fittingRows = Math.floor(availableHeight / estimatedRowHeight);
+    const rounded = Math.max(10, Math.min(50, Math.floor(fittingRows / 10) * 10));
+    if (rounded !== prefs.pageSize) {
+      updatePrefs({ pageSize: rounded as 10 | 20 | 30 | 40 | 50 });
+    }
+  }, [modelLoaded]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Load data
   const loadData = useCallback(
-    async (p: number) => {
+    async (p: number, currentFilters?: Record<string, string>) => {
       setLoading(true);
       setError(null);
+      const f = currentFilters ?? filters;
       try {
-        const res = await fetchStudents(tenant, PAGE_SIZE, (p - 1) * PAGE_SIZE);
-        setData(res.data ?? []);
+        const res = await queryStudents(tenant, {
+          ...f,
+          sort_by: prefs.sortBy,
+          sort_dir: prefs.sortDir,
+          limit: prefs.pageSize,
+          offset: (p - 1) * prefs.pageSize,
+        });
+        let rows = res.data ?? [];
+
+        // Highlight: prepend newly-added entity on page 1
+        if (activeHighlight && p === 1) {
+          const alreadyPresent = rows.some((r) => String(r.entity_id) === activeHighlight);
+          if (!alreadyPresent) {
+            // Fetch the specific entity via a query
+            try {
+              const highlighted = await queryStudents(tenant, {
+                limit: 1,
+                offset: 0,
+              });
+              const found = highlighted.data?.find(
+                (r) => String(r.entity_id) === activeHighlight,
+              );
+              if (found) {
+                rows = [found, ...rows];
+              }
+            } catch {
+              // ignore — highlight is best effort
+            }
+          }
+        }
+
+        setData(rows);
         setTotal(res.total ?? 0);
         setPage(p);
       } catch (err) {
         setError(
-          `Failed to load students. Is the backend at http://localhost:8080 running? (${err})`,
+          `Failed to load students. Is the datacore API at http://localhost:8081 running? (${err})`,
         );
         setData([]);
         setTotal(0);
@@ -147,136 +289,183 @@ export default function StudentsPage({ tenant }: StudentsPageProps) {
         setLoading(false);
       }
     },
-    [tenant],
+    [tenant, filters, prefs.sortBy, prefs.sortDir, prefs.pageSize, activeHighlight],
   );
 
+  // Fetch on mount and when deps change
   useEffect(() => {
-    loadData(1);
-  }, [loadData]);
+    if (modelLoaded) {
+      loadData(1);
+    }
+  }, [modelLoaded, loadData]);
+
+  // Close column popover on outside click
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (
+        columnToggleRef.current &&
+        !columnToggleRef.current.contains(e.target as Node)
+      ) {
+        setShowColumnPopover(false);
+      }
+    }
+    if (showColumnPopover) {
+      document.addEventListener('mousedown', handleClickOutside);
+      return () => document.removeEventListener('mousedown', handleClickOutside);
+    }
+  }, [showColumnPopover]);
+
+  // Filter handlers
+  function updateFilter(key: string, value: string) {
+    setFilters((prev) => ({ ...prev, [key]: value }));
+  }
 
   function handleSearch() {
     loadData(1);
   }
 
   function handleReset() {
-    setFilterName('');
-    setFilterId('');
-    setFilterGrade('');
-    setFilterGender('');
-    setFilterStatus('');
-    setFilterEmail('');
-    loadData(1);
+    const resetFilters = { _status: 'active' };
+    setFilters(resetFilters);
+    loadData(1, resetFilters);
   }
 
-  // Combine required + dynamic custom columns
-  const requiredCols = useMemo(() => getRequiredColumns(), []);
-  const customCols = useMemo(() => getCustomColumns(data), [data]);
-  const columns = useMemo(
-    () => [...requiredCols, ...customCols],
-    [requiredCols, customCols],
-  );
+  // Sort handler
+  function handleSortChange(column: string) {
+    const newDir =
+      prefs.sortBy === column && prefs.sortDir === 'asc' ? 'desc' : 'asc';
+    updatePrefs({ sortBy: column, sortDir: newDir });
+    setActiveHighlight(null); // clear highlight on sort change
+  }
+
+  // Page size handler
+  function handlePageSizeChange(size: number) {
+    hasUserChangedPageSize.current = true;
+    updatePrefs({ pageSize: size as 10 | 20 | 30 | 40 | 50 });
+  }
+
+  // Row class for highlight
+  function rowClassName(row: DataRow): string {
+    if (activeHighlight && String(row.entity_id) === activeHighlight) {
+      return 'data-table-row-highlight';
+    }
+    return '';
+  }
+
+  // Clear highlight on navigation away
+  useEffect(() => {
+    return () => {
+      // Replace state to remove highlightEntityId so back-nav doesn't re-highlight
+      if (highlightEntityId) {
+        window.history.replaceState({}, '');
+      }
+    };
+  }, [highlightEntityId]);
+
+  // Dynamic filter fields from model
+  const dynamicFilterFields = useMemo(() => getDynamicFilterFields(model), [model]);
 
   return (
-    <div className="students-page">
+    <div className="students-page" ref={containerRef}>
       <h1>{t('students.title')}</h1>
 
       <FilterForm onSearch={handleSearch} onReset={handleReset}>
-        <div className="filter-field">
-          <label>{t('students.searchName')}</label>
-          <input
-            type="text"
-            placeholder={t('students.searchNamePlaceholder')}
-            value={filterName}
-            onChange={(e) => setFilterName(e.target.value)}
-          />
-        </div>
-        <div className="filter-field">
-          <label>{t('students.searchId')}</label>
-          <input
-            type="text"
-            placeholder={t('students.searchIdPlaceholder')}
-            value={filterId}
-            onChange={(e) => setFilterId(e.target.value)}
-          />
-        </div>
-        <div className="filter-field">
-          <label>{t('students.searchGrade')}</label>
-          <select
-            value={filterGrade}
-            onChange={(e) => setFilterGrade(e.target.value)}
-          >
-            <option value="">{t('students.allGrades')}</option>
-            {[1, 2, 3, 4, 5, 6].map((g) => (
-              <option key={g} value={`Grade ${g}`}>
-                {t(`grade.grade${g}`)}
-              </option>
-            ))}
-            {[1, 2, 3].map((g) => (
-              <option key={`m${g}`} value={`Grade ${6 + g}`}>
-                {t(`grade.middle${g}`)}
-              </option>
-            ))}
-            {[1, 2, 3].map((g) => (
-              <option key={`h${g}`} value={`Grade ${9 + g}`}>
-                {t(`grade.high${g}`)}
-              </option>
-            ))}
-          </select>
-        </div>
-        <div className="filter-field">
-          <label>{t('students.searchGender')}</label>
-          <select
-            value={filterGender}
-            onChange={(e) => setFilterGender(e.target.value)}
-          >
-            <option value="">{t('students.allGenders')}</option>
-            <option value="Male">Male</option>
-            <option value="Female">Female</option>
-          </select>
-        </div>
+        {dynamicFilterFields.map((field) => (
+          <div className="filter-field" key={field.name}>
+            <label>{formatFieldLabel(field.name)}</label>
+            {field.type === 'selection' && field.options ? (
+              <select
+                value={filters[field.name] ?? ''}
+                onChange={(e) => updateFilter(field.name, e.target.value)}
+              >
+                <option value="">All</option>
+                {field.options.map((opt) => (
+                  <option key={opt} value={opt}>{opt}</option>
+                ))}
+              </select>
+            ) : (
+              <input
+                type="text"
+                placeholder={`Search ${formatFieldLabel(field.name).toLowerCase()}`}
+                value={filters[field.name] ?? ''}
+                onChange={(e) => updateFilter(field.name, e.target.value)}
+              />
+            )}
+          </div>
+        ))}
+        {/* Dedicated Status dropdown */}
         <div className="filter-field">
           <label>{t('students.searchStatus')}</label>
           <select
-            value={filterStatus}
-            onChange={(e) => setFilterStatus(e.target.value)}
+            value={filters._status ?? ''}
+            onChange={(e) => updateFilter('_status', e.target.value)}
           >
             <option value="">{t('students.allStatus')}</option>
-            <option value="Active">{t('students.status.active')}</option>
-            <option value="On Leave">{t('students.status.onLeave')}</option>
-            <option value="Suspended">{t('students.status.suspended')}</option>
-            <option value="Graduated">{t('students.status.graduated')}</option>
-            <option value="Dropped">{t('students.status.dropped')}</option>
+            {STATUS_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {t(opt.i18nKey)}
+              </option>
+            ))}
           </select>
         </div>
+        {/* Address search */}
         <div className="filter-field">
-          <label>{t('students.searchEmail')}</label>
+          <label>{t('students.addressSearch')}</label>
           <input
             type="text"
-            placeholder={t('students.searchEmailPlaceholder')}
-            value={filterEmail}
-            onChange={(e) => setFilterEmail(e.target.value)}
+            placeholder={t('students.addressSearchPlaceholder')}
+            value={filters.address ?? ''}
+            onChange={(e) => updateFilter('address', e.target.value)}
           />
         </div>
       </FilterForm>
 
       <div className="students-toolbar">
+        <div className="students-column-toggle" ref={columnToggleRef}>
+          <button onClick={() => setShowColumnPopover((prev) => !prev)}>
+            {t('students.columnSettings')}
+          </button>
+          {showColumnPopover && (
+            <div className="students-column-popover">
+              {columns.map((col) => (
+                <label key={col.key} className="students-column-option">
+                  <input
+                    type="checkbox"
+                    checked={!prefs.hiddenColumns.includes(col.key)}
+                    onChange={() => toggleColumn(col.key)}
+                  />
+                  {col.i18nKey ? t(col.i18nKey) : col.label}
+                </label>
+              ))}
+            </div>
+          )}
+        </div>
         <button>{t('students.batchExport')}</button>
         <button>{t('students.batchActions')}</button>
-        <button onClick={() => navigate('/students/add')}>{t('students.addStudent')}</button>
+        <button onClick={() => navigate('/students/add')}>
+          {t('students.addStudent')}
+        </button>
       </div>
 
       {error ? (
         <div className="student-error">{error}</div>
       ) : (
-        <DataTable<Student>
+        <DataTable<DataRow>
           columns={columns}
           data={data}
           total={total}
           page={page}
-          pageSize={PAGE_SIZE}
+          pageSize={prefs.pageSize}
           loading={loading}
-          onPageChange={loadData}
-          rowKey={(row) => row.student_id}
+          onPageChange={(p) => loadData(p)}
+          rowKey={(row) => String(row.entity_id ?? '')}
+          sortBy={prefs.sortBy}
+          sortDir={prefs.sortDir}
+          onSortChange={handleSortChange}
+          pageSizeOptions={[...PAGE_SIZE_OPTIONS]}
+          onPageSizeChange={handlePageSizeChange}
+          hiddenColumns={prefs.hiddenColumns}
+          rowClassName={rowClassName}
         />
       )}
     </div>

--- a/admindash/frontend/src/pages/StudentsPage.tsx
+++ b/admindash/frontend/src/pages/StudentsPage.tsx
@@ -254,19 +254,23 @@ export default function StudentsPage({ tenant }: StudentsPageProps) {
         });
         let rows = res.data ?? [];
 
-        // Highlight: prepend newly-added entity on page 1
+        // Highlight: move newly-added entity to top of list on page 1
         if (activeHighlight && p === 1) {
-          const alreadyPresent = rows.some((r) => String(r.entity_id) === activeHighlight);
-          if (!alreadyPresent) {
-            // Fetch the specific entity via a query
+          const idx = rows.findIndex((r) => String(r.entity_id) === activeHighlight);
+          if (idx > 0) {
+            // Already in results — move to top
+            const [item] = rows.splice(idx, 1);
+            rows = [item, ...rows];
+          } else if (idx === -1) {
+            // Not in current page (maybe filtered out) — fetch it directly
             try {
               const highlighted = await queryStudents(tenant, {
+                _status: 'all',
+                entity_id: activeHighlight,
                 limit: 1,
                 offset: 0,
               });
-              const found = highlighted.data?.find(
-                (r) => String(r.entity_id) === activeHighlight,
-              );
+              const found = highlighted.data?.[0];
               if (found) {
                 rows = [found, ...rows];
               }
@@ -274,6 +278,7 @@ export default function StudentsPage({ tenant }: StudentsPageProps) {
               // ignore — highlight is best effort
             }
           }
+          // idx === 0 means it's already at top, nothing to do
         }
 
         setData(rows);

--- a/admindash/frontend/src/pages/StudentsPage.tsx
+++ b/admindash/frontend/src/pages/StudentsPage.tsx
@@ -58,7 +58,8 @@ function buildColumnsFromModel(model: ModelDefinition): Column<DataRow>[] {
         render: (row: DataRow) => {
           const fullName =
             `${row.first_name ?? ''} ${row.last_name ?? ''}`.trim() || '-';
-          const avatarChar = fullName.charAt(0);
+          const lastName = String(row.last_name ?? '');
+          const avatarChar = (lastName.charAt(0) || fullName.charAt(0)).toUpperCase();
           return (
             <div className="student-name-cell">
               <div className="student-avatar">{avatarChar}</div>
@@ -415,16 +416,6 @@ export default function StudentsPage({ tenant }: StudentsPageProps) {
             ))}
           </select>
         </div>
-        {/* Address search */}
-        <div className="filter-field">
-          <label>{t('students.addressSearch')}</label>
-          <input
-            type="text"
-            placeholder={t('students.addressSearchPlaceholder')}
-            value={filters.address ?? ''}
-            onChange={(e) => updateFilter('address', e.target.value)}
-          />
-        </div>
       </FilterForm>
 
       <div className="students-toolbar">
@@ -466,7 +457,7 @@ export default function StudentsPage({ tenant }: StudentsPageProps) {
           loading={loading}
           onPageChange={(p) => loadData(p)}
           rowKey={(row) => String(row.entity_id ?? '')}
-          sortBy={prefs.sortBy}
+          sortBy={prefs.sortBy === 'last_name' ? 'name' : prefs.sortBy}
           sortDir={prefs.sortDir}
           onSortChange={handleSortChange}
           pageSizeOptions={[...PAGE_SIZE_OPTIONS]}

--- a/admindash/frontend/src/types/models.ts
+++ b/admindash/frontend/src/types/models.ts
@@ -88,13 +88,7 @@ export interface QueryStudentsParams {
   sort_dir?: 'asc' | 'desc';
   limit?: number;
   offset?: number;
-  first_name?: string;
-  last_name?: string;
-  student_id?: string;
-  email?: string;
-  grade_level?: string;
-  gender?: string;
-  address?: string;
+  [field: string]: string | number | undefined;
 }
 
 export interface QueryStudentsResponse {

--- a/admindash/frontend/src/types/models.ts
+++ b/admindash/frontend/src/types/models.ts
@@ -81,3 +81,23 @@ export interface CreateEntityResponse {
 export interface ExtractResponse {
   fields: Record<string, string>;
 }
+
+export interface QueryStudentsParams {
+  _status?: string;
+  sort_by?: string;
+  sort_dir?: 'asc' | 'desc';
+  limit?: number;
+  offset?: number;
+  first_name?: string;
+  last_name?: string;
+  student_id?: string;
+  email?: string;
+  grade_level?: string;
+  gender?: string;
+  address?: string;
+}
+
+export interface QueryStudentsResponse {
+  data: Record<string, unknown>[];
+  total: number;
+}

--- a/admindash/openspec/changes/student-list-view/.openspec.yaml
+++ b/admindash/openspec/changes/student-list-view/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-01

--- a/admindash/openspec/changes/student-list-view/design.md
+++ b/admindash/openspec/changes/student-list-view/design.md
@@ -1,0 +1,93 @@
+## Context
+
+StudentsPage currently fetches from a legacy Express backend at `localhost:8080` that reads from a static JSON file. The real student data lives in datacore's LanceDB vector store with a DuckDB query engine that supports SQL-level filtering, sorting, and pagination. The `QueryEngine.query()` method already flattens base_data (TOON) and custom_fields into queryable columns. Datacore's REST API has model and entity creation endpoints but no query/list endpoint.
+
+The DataTable component is a simple paginated table with fixed page size (10), no sort, no column toggle, and no row highlighting. It needs to evolve to support the new requirements while remaining generic.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Fetch student data from datacore instead of legacy backend
+- Server-side filtering by all base fields, with fuzzy address matching
+- Server-side sorting with default `last_name ASC`
+- Adaptive page sizing (default 20, configurable 10-50 in steps of 10)
+- Column visibility toggle with base-first ordering
+- Per-user table preferences persisted in localStorage
+- Highlighted newly-added row pinned to top until navigation or sort change
+
+**Non-Goals:**
+- Removing the legacy `localhost:8080` backend (other pages may still use it)
+- Full-text search across all fields (only base fields are searchable)
+- Inline editing of student records
+- Export/batch operations (existing buttons remain stubs)
+- Server-side fuzzy search infrastructure beyond DuckDB `LIKE`/`ILIKE` — address fuzzy matching uses SQL `ILIKE '%term%'` which is sufficient for city/state substring matching
+
+## Decisions
+
+### 1. Datacore query endpoint design
+
+**Decision**: Add `GET /api/entities/{tenant_id}/{entity_type}/query` with query params for filters, sort, pagination. Return `{ data: [...], total: int }`. Each item in `data` is a flat object with all base_data and custom_fields flattened to top-level keys, plus `entity_id`, `_status`, `_version`. The endpoint MUST also filter by `entity_type` in the WHERE clause since the entities table is shared across entity types.
+
+**Why**: Keeps the REST API simple. Query params map naturally to DuckDB WHERE/ORDER BY clauses. The existing `QueryEngine.query()` already handles SQL execution with pagination and total count. Flat response matches QueryEngine's natural output — no restructuring needed.
+
+**Alternatives considered**:
+- POST with JSON body for complex filters — overkill for field-level equality/LIKE filters
+- GraphQL — not justified for a single query pattern
+
+**Filter params**: `_status`, `first_name`, `last_name`, `student_id`, `email`, `grade_level`, `gender`, `address` (fuzzy). All optional. Equality match by default; `address` uses `ILIKE '%term%'` across address-related columns.
+
+**Sort params**: `sort_by` (column name, default `last_name`), `sort_dir` (`asc`|`desc`, default `asc`).
+
+**Pagination params**: `limit` (default 20, max 50), `offset` (default 0).
+
+### 2. Fuzzy address search
+
+**Decision**: Use DuckDB `ILIKE '%term%'` across `address`, `city`, `state`, `zip` columns (OR condition).
+
+**Why**: DuckDB ILIKE is fast enough for the data volumes here (< 10k records per tenant). No need for trigram indexes or external search engines.
+
+**Alternatives considered**:
+- DuckDB `jaro_winkler_similarity` — more accurate but slower and complex to configure thresholds
+- External search service (Meilisearch) — too much infrastructure for this use case
+
+### 3. Model definition caching via ModelContext
+
+**Decision**: Create a `ModelContext` React context that fetches and caches model definitions per entity type. The model is fetched once on first access within a login session and cached in memory. On logout (AuthContext clears), the context resets. Components (StudentsPage, AddStudentPage) read from ModelContext instead of calling `fetchStudentModel` directly.
+
+**Why**: Prevents mid-session model changes from causing inconsistencies. Avoids redundant API calls across components. sessionStorage was considered but adds serialization overhead; in-memory context clears naturally on logout/page reload.
+
+**Column ordering**: The cached `ModelDefinition` provides ordered `base_fields[]` and `custom_fields[]` arrays. The frontend uses these to determine column order (base first, then custom, each group in model-definition order) and to distinguish base vs custom for display purposes.
+
+### 4. Column visibility and preference storage
+
+**Decision**: Store preferences in localStorage under key `admindash_table_prefs_{user_id}_{tenant_id}` as JSON. Schema: `{ hiddenColumns: string[], pageSize: number, sortBy: string, sortDir: string }`. The `user_id` is read from AuthContext (`useAuth().user.user_id`).
+
+**Why**: Simple, no backend needed, scoped per user+tenant. Falls back to defaults when cleared.
+
+**Alternatives considered**:
+- sessionStorage — doesn't persist across browser sessions
+- Backend preference store — overhead not justified for table display settings
+
+### 5. Newly-added student highlighting
+
+
+**Decision**: After `createStudent` returns, store the new entity's `entity_id` in StudentsPage component state (passed via router state from AddStudentPage). The newly-added row is prepended to the data array and rendered with a CSS highlight class. The highlight and pinning clear when: (a) user navigates away from StudentsPage, or (b) user changes the sort field.
+
+**Why**: Client-side approach avoids polluting the API with "newest first" logic. Router state is the standard React Router mechanism for passing data between navigations.
+
+**Alternatives considered**:
+- URL query param `?highlight=id` — visible in URL, bookmarkable (undesirable)
+- Global context/store — overkill for a single transient value
+
+### 6. DataTable enhancements vs. new component
+
+**Decision**: Enhance the existing DataTable component with optional props: `sortBy`, `sortDir`, `onSortChange`, `pageSizeOptions`, `onPageSizeChange`, `hiddenColumns`, `onToggleColumn`, `rowClassName`. All optional to maintain backward compatibility.
+
+**Why**: DataTable is already used by StudentsPage and potentially other pages. Adding optional props keeps it generic without breaking existing usage.
+
+## Risks / Trade-offs
+
+- **DuckDB SQL injection via filter params** → Build WHERE clause with parameterized values, never interpolate user input directly into SQL strings
+- **Address fuzzy search is substring-only** → Users expecting typo-tolerant search may be surprised. Acceptable for MVP; can add Levenshtein/trigram later
+- **localStorage preferences can diverge from model changes** → If model definition adds/removes fields, hidden column list may reference stale names. On load, filter out any hiddenColumns entries that don't exist in current column set
+- **Large page sizes (50) may slow rendering** → DataTable already handles this reasonably; no virtual scrolling needed at 50 rows

--- a/admindash/openspec/changes/student-list-view/proposal.md
+++ b/admindash/openspec/changes/student-list-view/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+The Students page currently fetches data from a legacy backend (`localhost:8080`) with no server-side filtering, sorting, or status scoping. Users cannot search by base fields, hide columns, adjust page size, or see newly added students highlighted. The data source needs to shift to datacore's vector DB, and the table needs production-level UX: configurable columns, adaptive page sizes, persisted preferences, and real-time feedback when records are added.
+
+## What Changes
+
+- Replace `fetchStudents` (legacy backend) with a new datacore query endpoint that supports filtering, sorting, pagination, and status scoping
+- Default to `_status=active` filter with the Status dropdown pre-selected to "Active"
+- Default sort by `last_name` ascending
+- Adaptive page size: default 20 rows if viewport fits, otherwise best-effort fit; user can change in increments of 10 up to max 50
+- Newly added students appear at top of list with highlighted row background until user navigates away or changes sort field
+- Column order: base data fields first (left), then custom data fields (right)
+- Column visibility toggle — users can hide/show any column
+- Table display preferences (visible columns, page size, sort field/direction) persisted in localStorage per user
+- Search pane searches all base fields; address field supports fuzzy search (e.g., matching by city)
+
+## Capabilities
+
+### New Capabilities
+- `student-query-api`: Datacore REST endpoint for querying student entities with filtering, sorting, pagination, and fuzzy address search
+- `student-table-preferences`: localStorage-based persistence of table display preferences (column visibility, page size, sort) per user
+- `student-list-ux`: Enhanced StudentsPage table with adaptive page size, column toggle, newly-added highlighting, and base-field search
+
+### Modified Capabilities
+
+_(none — no existing specs require requirement changes)_
+
+## Impact
+
+- **admindash frontend**: StudentsPage rewrite (data fetching, search, table config); new DataTable features (column toggle, sortable headers, variable page size, row highlighting); new localStorage preference hook; updated API client
+- **datacore**: New `GET /api/entities/{tenant_id}/{entity_type}` query endpoint with filter/sort/pagination params; fuzzy address search support via DuckDB
+- **Types**: Student interface may gain address fields; new preference types
+- **No breaking changes**: The legacy `localhost:8080` endpoint can remain but will no longer be used by StudentsPage

--- a/admindash/openspec/changes/student-list-view/specs/student-list-ux/spec.md
+++ b/admindash/openspec/changes/student-list-view/specs/student-list-ux/spec.md
@@ -1,0 +1,89 @@
+## ADDED Requirements
+
+### Requirement: Default status filter pre-selected to Active
+When StudentsPage loads, the status dropdown SHALL be pre-selected to "Active" and the initial data fetch SHALL include `_status=active`.
+
+#### Scenario: Page load
+- **WHEN** user navigates to StudentsPage
+- **THEN** the Status dropdown shows "Active" and only active students are displayed
+
+#### Scenario: User selects different status
+- **WHEN** user selects "Graduated" in the Status dropdown
+- **THEN** data is re-fetched with `_status=graduated` and the table updates
+
+### Requirement: Adaptive page size with user control
+The default page size SHALL be 20 if the viewport can fit 20 rows; otherwise the system SHALL calculate the best-fit row count for the available vertical space. The user SHALL be able to change page size in increments of 10 (10, 20, 30, 40, 50) via a page size selector near the pagination controls.
+
+#### Scenario: Viewport fits 20 rows
+- **WHEN** viewport height allows 20 rows
+- **THEN** page size defaults to 20
+
+#### Scenario: Small viewport
+- **WHEN** viewport height only fits 12 rows
+- **THEN** page size defaults to 10 (rounded down to nearest valid increment)
+
+#### Scenario: User changes page size
+- **WHEN** user selects 30 from the page size selector
+- **THEN** table re-fetches with limit=30 and preference is saved
+
+### Requirement: Column order base-first then custom
+Table columns SHALL be ordered with all base data fields first (left), followed by custom data fields (right). Within each group, the order SHALL follow the model definition's field order.
+
+#### Scenario: Mixed base and custom fields
+- **WHEN** student data has base fields `first_name`, `last_name`, `email` and custom fields `school_name`, `emergency_phone`
+- **THEN** columns appear in order: first_name, last_name, email, school_name, emergency_phone
+
+### Requirement: Column visibility toggle
+Users SHALL be able to hide or show any column via a column settings control. Hidden columns SHALL not be rendered in the table. The column settings control SHALL show all available columns with checkboxes.
+
+#### Scenario: User hides a column
+- **WHEN** user unchecks "Email" in column settings
+- **THEN** the Email column is removed from the table and preference is saved
+
+#### Scenario: User shows a hidden column
+- **WHEN** user checks "Email" in column settings
+- **THEN** the Email column reappears in its original position
+
+### Requirement: Newly added student highlighted and pinned
+When a student is created via AddStudentPage and the user returns to StudentsPage, the newly created student SHALL appear at the top of the list with a visually distinct highlighted row background. The highlight and top-pinning SHALL persist until the user navigates away from StudentsPage or changes the sort field.
+
+#### Scenario: Return from AddStudentPage after creation
+- **WHEN** user creates a student and is redirected to StudentsPage
+- **THEN** the new student appears as the first row with a highlighted background
+
+#### Scenario: User changes sort field
+- **WHEN** a newly added student is pinned at top and user changes sort to `first_name`
+- **THEN** the highlight is removed and the student sorts into its natural position
+
+#### Scenario: User navigates away and returns
+- **WHEN** a newly added student is highlighted, user navigates to Home, then back to Students
+- **THEN** no student is highlighted; normal sort order applies
+
+### Requirement: Search pane filters by all base fields
+The search pane SHALL provide input fields for all base fields returned by the model definition. Filter values SHALL be sent as query params to the datacore query endpoint. The search pane SHALL include a Search button to apply filters and a Reset button to clear all filters.
+
+#### Scenario: User searches by name
+- **WHEN** user enters "Smith" in the Last Name search field and clicks Search
+- **THEN** the table shows only students whose last_name contains "Smith"
+
+#### Scenario: User resets filters
+- **WHEN** user clicks Reset
+- **THEN** all search fields are cleared and the table shows the default filtered results (active students)
+
+### Requirement: Address search supports fuzzy matching
+The search pane SHALL include an Address search field. The address search SHALL match against address, city, state, and zip fields using substring matching. For example, entering a city name SHALL match students in that city.
+
+#### Scenario: Search by city
+- **WHEN** user enters "Portland" in the Address search field
+- **THEN** students with "Portland" in their address, city, state, or zip are shown
+
+### Requirement: Sort by clicking column headers
+Users SHALL be able to sort the table by clicking any column header. Clicking a header SHALL toggle between ascending and descending order. The currently sorted column SHALL have a visual sort indicator.
+
+#### Scenario: Click unsorted column
+- **WHEN** user clicks the "Email" column header
+- **THEN** table sorts by email ascending and shows an ascending indicator
+
+#### Scenario: Click already-sorted column
+- **WHEN** table is sorted by email ascending and user clicks "Email" header again
+- **THEN** table sorts by email descending and indicator changes

--- a/admindash/openspec/changes/student-list-view/specs/student-query-api/spec.md
+++ b/admindash/openspec/changes/student-list-view/specs/student-query-api/spec.md
@@ -1,0 +1,75 @@
+## ADDED Requirements
+
+### Requirement: Query endpoint returns paginated student entities
+The datacore REST API SHALL expose `GET /api/entities/{tenant_id}/{entity_type}/query` that returns `{ data: [...], total: int }`. Each item in `data` SHALL be a flat object with all base_data and custom_fields flattened to top-level keys, plus `entity_id`, `_status`, and `_version`. The endpoint SHALL filter by `entity_type` in the WHERE clause since the entities table is shared across entity types. The `total` field SHALL reflect the count after filters are applied (before pagination).
+
+#### Scenario: Default query with no params
+- **WHEN** client sends `GET /api/entities/acme/student/query` with no query params
+- **THEN** response returns students with `_status=active`, sorted by `last_name ASC`, limit 20, offset 0
+
+#### Scenario: Custom pagination
+- **WHEN** client sends `GET /api/entities/acme/student/query?limit=10&offset=20`
+- **THEN** response returns at most 10 students starting from offset 20, with `total` reflecting all matching records
+
+### Requirement: Status filter defaults to active
+The endpoint SHALL accept a `_status` query param. When omitted, it SHALL default to `active`. When set to empty string or `all`, it SHALL return entities of all statuses.
+
+#### Scenario: Default status filter
+- **WHEN** client sends query with no `_status` param
+- **THEN** only entities with `_status=active` are returned
+
+#### Scenario: Explicit status filter
+- **WHEN** client sends `_status=graduated`
+- **THEN** only entities with `_status=graduated` are returned
+
+#### Scenario: All statuses
+- **WHEN** client sends `_status=all`
+- **THEN** entities of all statuses are returned
+
+### Requirement: Sort by any base field
+The endpoint SHALL accept `sort_by` (column name, default `last_name`) and `sort_dir` (`asc` or `desc`, default `asc`). The endpoint SHALL validate that `sort_by` references a known column and reject unknown columns with HTTP 400.
+
+#### Scenario: Default sort
+- **WHEN** client sends query with no sort params
+- **THEN** results are sorted by `last_name` ascending
+
+#### Scenario: Custom sort
+- **WHEN** client sends `sort_by=first_name&sort_dir=desc`
+- **THEN** results are sorted by `first_name` descending
+
+#### Scenario: Invalid sort column
+- **WHEN** client sends `sort_by=nonexistent_column`
+- **THEN** endpoint returns HTTP 400 with error message
+
+### Requirement: Filter by base fields
+The endpoint SHALL accept query params matching base field names (`first_name`, `last_name`, `student_id`, `email`, `grade_level`, `gender`). Each filter SHALL use case-insensitive substring match (`ILIKE '%value%'`). Multiple filters SHALL be combined with AND.
+
+#### Scenario: Single filter
+- **WHEN** client sends `first_name=jan`
+- **THEN** only students whose `first_name` contains "jan" (case-insensitive) are returned
+
+#### Scenario: Multiple filters
+- **WHEN** client sends `first_name=jan&grade_level=Grade 5`
+- **THEN** only students matching both conditions are returned
+
+### Requirement: Fuzzy address search
+The endpoint SHALL accept an `address` query param that searches across address-related columns (`address`, `city`, `state`, `zip`) using `ILIKE '%value%'` with OR logic. If none of these columns exist in the data, the filter SHALL be silently ignored.
+
+#### Scenario: Address search matches city
+- **WHEN** client sends `address=springfield`
+- **THEN** students with "springfield" in any of `address`, `city`, `state`, or `zip` columns are returned
+
+#### Scenario: Address columns not present
+- **WHEN** client sends `address=springfield` but no address-related columns exist in data
+- **THEN** the filter is ignored and all students (matching other filters) are returned
+
+### Requirement: Pagination limit bounds
+The endpoint SHALL enforce `limit` between 1 and 50. Values above 50 SHALL be clamped to 50. Values below 1 SHALL default to 20.
+
+#### Scenario: Limit exceeds max
+- **WHEN** client sends `limit=100`
+- **THEN** response returns at most 50 records
+
+#### Scenario: Limit below minimum
+- **WHEN** client sends `limit=0`
+- **THEN** response uses default limit of 20

--- a/admindash/openspec/changes/student-list-view/specs/student-table-preferences/spec.md
+++ b/admindash/openspec/changes/student-list-view/specs/student-table-preferences/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Preferences stored in localStorage per user and tenant
+Table display preferences SHALL be stored in localStorage under the key `admindash_table_prefs_{user_id}_{tenant_id}`. The stored value SHALL be a JSON object with the schema: `{ hiddenColumns: string[], pageSize: number, sortBy: string, sortDir: "asc" | "desc" }`.
+
+#### Scenario: Preferences saved on change
+- **WHEN** user hides a column, changes page size, or changes sort
+- **THEN** the updated preferences are immediately written to localStorage
+
+#### Scenario: Preferences loaded on page mount
+- **WHEN** user navigates to StudentsPage
+- **THEN** preferences are loaded from localStorage and applied to the table
+
+### Requirement: Default preferences when no cache exists
+When no localStorage entry exists (first visit or cache cleared), the system SHALL use defaults: all columns visible, page size 20, sort by `last_name` ascending, status filter `active`.
+
+#### Scenario: First visit
+- **WHEN** user opens StudentsPage with no cached preferences
+- **THEN** all columns are visible, page size is 20, sorted by last_name ASC
+
+#### Scenario: Cache cleared
+- **WHEN** user clears browser localStorage and reloads
+- **THEN** preferences revert to defaults
+
+### Requirement: Stale column references are pruned
+When loading preferences, any `hiddenColumns` entries that do not match a current column key SHALL be silently removed from the loaded preferences.
+
+#### Scenario: Model adds new field
+- **WHEN** cached `hiddenColumns` includes `"old_field"` but `old_field` no longer exists in the column set
+- **THEN** `"old_field"` is removed from `hiddenColumns` and the remaining preferences are applied
+
+### Requirement: Page size constrained to valid values
+The stored `pageSize` SHALL be one of: 10, 20, 30, 40, 50. If the cached value is not in this set, it SHALL default to 20.
+
+#### Scenario: Invalid cached page size
+- **WHEN** cached `pageSize` is 25
+- **THEN** page size defaults to 20

--- a/admindash/openspec/changes/student-list-view/tasks.md
+++ b/admindash/openspec/changes/student-list-view/tasks.md
@@ -1,0 +1,41 @@
+## 1. Datacore Query API
+
+- [ ] 1.1 Add `GET /api/entities/{tenant_id}/{entity_type}/query` endpoint to datacore routes with filter, sort, and pagination params; include `entity_type` in WHERE clause
+- [ ] 1.2 Build SQL WHERE clause from filter params with parameterized values (status default `active`, base field ILIKE, fuzzy address OR across address/city/state/zip); dynamically check which address columns exist before building OR clause
+- [ ] 1.3 Add sort validation (reject unknown columns with 400) and pagination clamping (limit 1-50, default 20)
+
+## 2. Admindash API Client
+
+- [ ] 2.1 Add `queryStudents()` function in `api/client.ts` targeting the new datacore query endpoint with all filter/sort/pagination params
+- [ ] 2.2 Update response types to match flat response shape from datacore (all fields at top level)
+
+## 3. ModelContext
+
+- [ ] 3.1 Create `ModelContext` — fetches and caches model definitions per entity type in memory; clears on logout; components read from context instead of calling `fetchStudentModel` directly
+- [ ] 3.2 Refactor AddStudentPage to read model definition from ModelContext instead of fetching directly
+
+## 4. Table Preferences
+
+- [ ] 4.1 Create `useTablePreferences` hook — reads/writes localStorage key `admindash_table_prefs_{user_id}_{tenant_id}` (user_id from AuthContext), returns preferences with defaults, prunes stale hiddenColumns, validates pageSize
+- [ ] 4.2 Add i18n keys for new UI elements (page size selector, column settings, address search, sort indicators)
+
+## 5. DataTable Enhancements
+
+- [ ] 5.1 Add optional sort props (`sortBy`, `sortDir`, `onSortChange`) — clickable column headers with sort indicator
+- [ ] 5.2 Add optional page size props (`pageSizeOptions`, `onPageSizeChange`) — page size selector near pagination
+- [ ] 5.3 Add optional `hiddenColumns` prop — filter out hidden columns from render
+- [ ] 5.4 Add optional `rowClassName` prop — callback `(row) => string` for per-row CSS class (used for highlight)
+
+## 6. StudentsPage Rewrite
+
+- [ ] 6.1 Replace `fetchStudents` with `queryStudents` from datacore; wire filter state to query params; default status to `active` with dropdown pre-selected
+- [ ] 6.2 Implement adaptive page size calculation based on viewport height (round down to nearest 10-increment, min 10, max 50)
+- [ ] 6.3 Build dynamic search pane from ModelContext base fields; add Address fuzzy search input
+- [ ] 6.4 Build column list from ModelContext (base_fields first, then custom_fields, in model definition order)
+- [ ] 6.5 Wire column visibility toggle UI (popover with checkboxes)
+- [ ] 6.6 Integrate `useTablePreferences` — load on mount, save on column/pageSize/sort changes
+- [ ] 6.7 Implement newly-added student highlight — read `entity_id` from router location state, prepend to data, apply highlight CSS class, clear on sort change or navigation
+
+## 7. AddStudentPage Integration
+
+- [ ] 7.1 Pass newly created `entity_id` via React Router navigate state when redirecting to `/students` after successful creation

--- a/datacore/docs/superpowers/plans/2026-04-01-semantic-search.md
+++ b/datacore/docs/superpowers/plans/2026-04-01-semantic-search.md
@@ -1,0 +1,945 @@
+# Semantic Search Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add vector embeddings to entity records and semantic search capability using Voyage AI `voyage-3`, enabling natural language queries over structured entity data.
+
+**Architecture:** New `Embedder` module handles text flattening and Voyage AI API calls. Store gets an `Embedder` dependency and auto-embeds on every `put_entity()` call. QueryEngine gets a `semantic_search()` method. New REST endpoint exposes search over HTTP. Existing entity data is deleted (pre-production) so all records start with vectors.
+
+**Tech Stack:** Python, LanceDB (vector search), Voyage AI `voyage-3` (1024-dim embeddings), `voyageai` SDK, FastAPI, pytest
+
+---
+
+## File Structure
+
+| Action | File | Responsibility |
+|--------|------|---------------|
+| Create | `src/datacore/embedder.py` | Text flattening + Voyage AI embedding generation |
+| Modify | `src/datacore/store.py` | Add vector column to schema, Embedder dependency, auto-embed on put_entity |
+| Modify | `src/datacore/query.py` | Add semantic_search() method |
+| Modify | `src/datacore/api/routes.py` | Add GET /api/search/{tenant_id} endpoint |
+| Modify | `src/datacore/api/__init__.py` | Pass embedder to Store in create_app |
+| Modify | `src/datacore/api/server.py` | Instantiate Embedder for server entry point |
+| Modify | `src/datacore/__init__.py` | Export Embedder |
+| Modify | `pyproject.toml` | Add voyageai dependency |
+| Modify | `tests/conftest.py` | Update store fixture to include mock embedder |
+| Create | `tests/test_embedder.py` | Unit tests for Embedder |
+| Create | `tests/test_semantic_search.py` | Tests for semantic_search() and search endpoint |
+| Modify | `tests/test_api.py` | Update app_client fixture for Embedder |
+| Modify | `tests/test_store_entities.py` | Update for Embedder dependency |
+
+---
+
+### Task 1: Add voyageai dependency and create Embedder module
+
+**Files:**
+- Modify: `pyproject.toml`
+- Create: `src/datacore/embedder.py`
+- Create: `tests/test_embedder.py`
+
+- [ ] **Step 1: Add voyageai to pyproject.toml**
+
+In `pyproject.toml`, add `voyageai` to dependencies:
+
+```toml
+dependencies = [
+    "lancedb>=0.6",
+    "pyarrow>=14.0",
+    "duckdb>=0.10",
+    "python-toon>=0.1",
+    "fastapi>=0.115",
+    "uvicorn>=0.34",
+    "voyageai>=0.3",
+]
+```
+
+- [ ] **Step 2: Install dependencies**
+
+Run: `uv sync --all-extras`
+Expected: voyageai installed successfully
+
+- [ ] **Step 3: Write tests for Embedder**
+
+Create `tests/test_embedder.py`:
+
+```python
+"""Unit tests for Embedder text flattening and embedding generation."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from datacore.embedder import Embedder
+
+
+def test_flatten_fields_combines_all_keys():
+    embedder = Embedder.__new__(Embedder)
+    text = embedder._flatten_fields({
+        "first_name": "Wei",
+        "last_name": "Chen",
+        "grade_level": "2nd",
+    })
+    assert "first_name: Wei" in text
+    assert "last_name: Chen" in text
+    assert "grade_level: 2nd" in text
+
+
+def test_flatten_fields_empty_dict():
+    embedder = Embedder.__new__(Embedder)
+    text = embedder._flatten_fields({})
+    assert text == ""
+
+
+def test_flatten_fields_skips_none_values():
+    embedder = Embedder.__new__(Embedder)
+    text = embedder._flatten_fields({"name": "Alice", "phone": None})
+    assert "name: Alice" in text
+    assert "phone" not in text
+
+
+@patch("datacore.embedder.voyageai")
+def test_embed_calls_voyage_api(mock_voyageai):
+    mock_client = MagicMock()
+    mock_result = MagicMock()
+    mock_result.embeddings = [[0.1] * 1024]
+    mock_client.embed.return_value = mock_result
+    mock_voyageai.Client.return_value = mock_client
+
+    embedder = Embedder()
+    vector = embedder.embed({"first_name": "Wei", "last_name": "Chen"})
+
+    assert len(vector) == 1024
+    mock_client.embed.assert_called_once()
+    call_args = mock_client.embed.call_args
+    assert call_args[0][0] == [embedder._flatten_fields({"first_name": "Wei", "last_name": "Chen"})]
+    assert call_args[1]["model"] == "voyage-3"
+    assert call_args[1]["input_type"] == "document"
+
+
+@patch("datacore.embedder.voyageai")
+def test_embed_batch(mock_voyageai):
+    mock_client = MagicMock()
+    mock_result = MagicMock()
+    mock_result.embeddings = [[0.1] * 1024, [0.2] * 1024]
+    mock_client.embed.return_value = mock_result
+    mock_voyageai.Client.return_value = mock_client
+
+    embedder = Embedder()
+    vectors = embedder.embed_batch([
+        {"first_name": "Wei"},
+        {"first_name": "Kenny"},
+    ])
+
+    assert len(vectors) == 2
+    assert len(vectors[0]) == 1024
+
+
+@patch("datacore.embedder.voyageai")
+def test_embed_query_uses_query_input_type(mock_voyageai):
+    mock_client = MagicMock()
+    mock_result = MagicMock()
+    mock_result.embeddings = [[0.1] * 1024]
+    mock_client.embed.return_value = mock_result
+    mock_voyageai.Client.return_value = mock_client
+
+    embedder = Embedder()
+    embedder.embed_query("students with allergies")
+
+    call_args = mock_client.embed.call_args
+    assert call_args[1]["input_type"] == "query"
+
+
+def test_embedder_raises_without_api_key():
+    with patch.dict("os.environ", {}, clear=True):
+        with patch("datacore.embedder.voyageai") as mock_voyageai:
+            mock_voyageai.Client.side_effect = Exception("API key required")
+            with pytest.raises(Exception):
+                Embedder()
+```
+
+- [ ] **Step 4: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_embedder.py -v --tb=short`
+Expected: FAIL — `ModuleNotFoundError: No module named 'datacore.embedder'`
+
+- [ ] **Step 5: Create Embedder module**
+
+Create `src/datacore/embedder.py`:
+
+```python
+"""Voyage AI embedding generation for entity data."""
+
+import voyageai
+
+MODEL = "voyage-3"
+DIMENSIONS = 1024
+
+
+class Embedder:
+    """Generates vector embeddings from entity field data using Voyage AI.
+
+    Reads VOYAGE_API_KEY from environment automatically.
+    """
+
+    def __init__(self):
+        self._client = voyageai.Client()
+
+    def _flatten_fields(self, fields: dict) -> str:
+        """Flatten a dict of fields into a single text string for embedding."""
+        parts = []
+        for key, value in fields.items():
+            if value is not None:
+                parts.append(f"{key}: {value}")
+        return ", ".join(parts)
+
+    def embed(self, fields: dict) -> list[float]:
+        """Embed a single entity's fields.
+
+        Args:
+            fields: merged base_data + custom_fields dict
+
+        Returns:
+            1024-dimension float vector
+        """
+        text = self._flatten_fields(fields)
+        result = self._client.embed(
+            [text], model=MODEL, input_type="document"
+        )
+        return result.embeddings[0]
+
+    def embed_batch(self, fields_list: list[dict]) -> list[list[float]]:
+        """Embed multiple entities' fields in one API call.
+
+        Args:
+            fields_list: list of merged field dicts
+
+        Returns:
+            list of 1024-dimension float vectors
+        """
+        texts = [self._flatten_fields(f) for f in fields_list]
+        result = self._client.embed(
+            texts, model=MODEL, input_type="document"
+        )
+        return result.embeddings
+
+    def embed_query(self, query: str) -> list[float]:
+        """Embed a search query string.
+
+        Uses input_type="query" for optimal retrieval performance.
+
+        Args:
+            query: natural language search query
+
+        Returns:
+            1024-dimension float vector
+        """
+        result = self._client.embed(
+            [query], model=MODEL, input_type="query"
+        )
+        return result.embeddings[0]
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_embedder.py -v --tb=short`
+Expected: ALL PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add pyproject.toml src/datacore/embedder.py tests/test_embedder.py
+git commit -m "feat: add Embedder module with Voyage AI voyage-3 integration"
+```
+
+---
+
+### Task 2: Add vector column to schema and Embedder to Store
+
+**Files:**
+- Modify: `src/datacore/store.py:35-40` (ENTITIES_SCHEMA)
+- Modify: `src/datacore/store.py:55-67` (Store.__init__)
+- Modify: `src/datacore/store.py:243-309` (put_entity)
+- Modify: `tests/conftest.py` (store fixture)
+- Modify: `tests/test_store_entities.py` (update for embedder)
+
+- [ ] **Step 1: Update tests to pass a mock embedder to Store**
+
+In `tests/conftest.py`, add a mock embedder and pass it to Store:
+
+```python
+import tempfile
+from unittest.mock import MagicMock
+
+import pytest
+from datacore import Store, QueryEngine
+
+
+@pytest.fixture
+def mock_embedder():
+    embedder = MagicMock()
+    embedder.embed.return_value = [0.0] * 1024
+    embedder.embed_batch.return_value = []
+    return embedder
+
+
+@pytest.fixture
+def tmp_dir():
+    with tempfile.TemporaryDirectory() as d:
+        yield d
+
+
+@pytest.fixture
+def store(tmp_dir, mock_embedder):
+    return Store(
+        data_dir=tmp_dir,
+        embedder=mock_embedder,
+        max_model_versions=5,
+        default_max_entity_versions=3,
+        entity_version_limits={"student": 3, "staff": 2},
+    )
+
+
+@pytest.fixture
+def engine(store):
+    return QueryEngine(store)
+
+
+@pytest.fixture
+def seeded_store(store):
+    """Store with pre-loaded model definitions and entity records."""
+    cid = "seed-change"
+    store.put_model(
+        tenant_id="t1",
+        entity_type="student",
+        model_definition={
+            "base_fields": [
+                {"name": "first_name", "type": "str", "required": True},
+                {"name": "last_name", "type": "str", "required": True},
+                {"name": "grade", "type": "str", "required": False},
+            ],
+            "custom_fields": [],
+        },
+        change_id=cid,
+    )
+    store.put_model(
+        tenant_id="t1",
+        entity_type="staff",
+        model_definition={
+            "base_fields": [
+                {"name": "name", "type": "str", "required": True},
+                {"name": "role", "type": "str", "required": True},
+            ],
+            "custom_fields": [],
+        },
+        change_id=cid,
+    )
+    store.put_entity(
+        tenant_id="t1", entity_type="student", entity_id="S001",
+        base_data={"first_name": "Alice", "last_name": "Smith", "grade": "5"},
+        custom_fields={"city": "Springfield", "bus_day": "tuesday"},
+    )
+    store.put_entity(
+        tenant_id="t1", entity_type="student", entity_id="S002",
+        base_data={"first_name": "Bob", "last_name": "Jones", "grade": "3"},
+        custom_fields={"city": "Shelbyville", "bus_day": "monday"},
+    )
+    store.put_entity(
+        tenant_id="t1", entity_type="student", entity_id="S003",
+        base_data={"first_name": "Charlie", "last_name": "Brown", "grade": "5"},
+        custom_fields={"city": "Springfield", "bus_day": "tuesday"},
+    )
+    return store
+
+
+@pytest.fixture
+def seeded_engine(seeded_store):
+    return QueryEngine(seeded_store)
+```
+
+- [ ] **Step 2: Update test_store_entities.py for tests that create Store directly**
+
+In `tests/test_store_entities.py`, update `test_entity_version_trimming_default_limit` which creates its own Store:
+
+```python
+def test_entity_version_trimming_default_limit(tmp_dir):
+    from unittest.mock import MagicMock
+    mock_embedder = MagicMock()
+    mock_embedder.embed.return_value = [0.0] * 1024
+    # Create a Store with no entity_version_limits — default is 5
+    s = Store(data_dir=tmp_dir, embedder=mock_embedder)
+    for i in range(8):
+        s.put_entity(
+            tenant_id="t1",
+            entity_type="course",
+            entity_id="C001",
+            base_data={"name": f"Course-v{i+1}"},
+        )
+
+    history = s.get_entity_history("t1", "course", "C001")
+    assert len(history) <= 5
+```
+
+- [ ] **Step 3: Run entity tests to verify they fail**
+
+Run: `uv run pytest tests/test_store_entities.py -v --tb=short -x`
+Expected: FAIL — Store.__init__ does not accept `embedder` parameter yet
+
+- [ ] **Step 4: Update ENTITIES_SCHEMA and Store**
+
+In `src/datacore/store.py`:
+
+Update ENTITIES_SCHEMA (lines 35-40):
+```python
+# Default schema for entities table
+ENTITIES_SCHEMA = pa.schema([
+    pa.field("entity_type", pa.string()),
+    pa.field("entity_id", pa.string()),
+    pa.field("base_data", pa.string()),         # TOON-encoded document
+    pa.field("custom_fields", pa.string()),    # TOON-encoded document
+    pa.field("vector", pa.list_(pa.float32(), 1024)),
+] + _META_FIELDS)
+```
+
+Update Store.__init__ (lines 55-67) — add embedder parameter:
+```python
+def __init__(
+    self,
+    data_dir: str | Path = DEFAULT_DATA_DIR,
+    embedder=None,
+    max_model_versions: int = 100,
+    default_max_entity_versions: int = 5,
+    entity_version_limits: dict[str, int] | None = None,
+):
+    self.data_dir = Path(data_dir)
+    self.data_dir.mkdir(parents=True, exist_ok=True)
+    self._db = lancedb.connect(str(self.data_dir))
+    self.embedder = embedder
+    self.max_model_versions = max_model_versions
+    self.default_max_entity_versions = default_max_entity_versions
+    self.entity_version_limits = entity_version_limits or {}
+```
+
+Update put_entity (lines 290-302) — add auto-embed before insert:
+```python
+        # Generate embedding from entity fields
+        all_fields = dict(base_data)
+        all_fields.update(custom_fields or {})
+        vector = self.embedder.embed(all_fields) if self.embedder else [0.0] * 1024
+
+        # Insert new active — custom fields stored as TOON format
+        record = {
+            "entity_type": entity_type,
+            "entity_id": entity_id,
+            "base_data": toon.encode(base_data),
+            "custom_fields": toon.encode(custom_fields or {}),
+            "vector": vector,
+            "_version": next_version,
+            "_status": "active",
+            "_change_id": change_id,
+            "_created_at": now,
+            "_updated_at": now,
+        }
+        table.add([record])
+```
+
+Also update the return section — exclude vector from the returned dict (it's large and not useful to callers):
+```python
+        record["base_data"] = base_data
+        record["custom_fields"] = custom_fields or {}
+        del record["vector"]
+        return record
+```
+
+- [ ] **Step 5: Run entity tests to verify they pass**
+
+Run: `uv run pytest tests/test_store_entities.py -v --tb=short`
+Expected: ALL PASS
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `uv run pytest --tb=short -q`
+Expected: Some tests may fail in test_api.py and test_smoke.py (they create Store without embedder). Fix those in the next step.
+
+- [ ] **Step 7: Update test_api.py app_client fixture**
+
+In `tests/test_api.py`, update the fixture:
+```python
+@pytest.fixture
+def app_client():
+    from unittest.mock import MagicMock
+    with tempfile.TemporaryDirectory() as tmp:
+        mock_embedder = MagicMock()
+        mock_embedder.embed.return_value = [0.0] * 1024
+        store = Store(data_dir=tmp, embedder=mock_embedder)
+        app = create_app(store)
+        yield TestClient(app), store
+```
+
+- [ ] **Step 8: Update test_smoke.py**
+
+Read `tests/test_smoke.py` and update the Store() construction to include a mock embedder. Add `from unittest.mock import MagicMock` and pass `embedder=mock_embedder` where Store is instantiated.
+
+- [ ] **Step 9: Run full test suite**
+
+Run: `uv run pytest --tb=short -q`
+Expected: ALL PASS
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/datacore/store.py tests/conftest.py tests/test_store_entities.py tests/test_api.py tests/test_smoke.py
+git commit -m "feat: add vector column to entities schema, Embedder dependency on Store"
+```
+
+---
+
+### Task 3: Add semantic_search() to QueryEngine
+
+**Files:**
+- Modify: `src/datacore/query.py`
+- Create: `tests/test_semantic_search.py`
+
+- [ ] **Step 1: Write tests for semantic_search**
+
+Create `tests/test_semantic_search.py`:
+
+```python
+"""Tests for semantic search via QueryEngine."""
+
+import tempfile
+from unittest.mock import MagicMock
+
+import pytest
+
+from datacore import Store, QueryEngine
+
+
+def _make_embedder(vectors_map=None):
+    """Create a mock embedder that returns predictable vectors.
+
+    vectors_map: dict mapping text substrings to vectors.
+    Default: returns different vectors per call to simulate real embeddings.
+    """
+    embedder = MagicMock()
+    call_count = [0]
+
+    def mock_embed(fields):
+        call_count[0] += 1
+        # Return slightly different vectors for each entity
+        vec = [0.0] * 1024
+        vec[0] = float(call_count[0])
+        return vec
+
+    def mock_embed_query(query):
+        # Return a vector close to entity 1 by default
+        vec = [0.0] * 1024
+        vec[0] = 1.0
+        return vec
+
+    embedder.embed.side_effect = mock_embed
+    embedder.embed_query.side_effect = mock_embed_query
+    return embedder
+
+
+@pytest.fixture
+def search_setup():
+    with tempfile.TemporaryDirectory() as tmp:
+        embedder = _make_embedder()
+        store = Store(data_dir=tmp, embedder=embedder)
+        engine = QueryEngine(store)
+
+        store.put_entity("t1", "student", "S001",
+            base_data={"first_name": "Alice", "last_name": "Smith"},
+            custom_fields={"city": "Springfield"})
+        store.put_entity("t1", "student", "S002",
+            base_data={"first_name": "Bob", "last_name": "Jones"},
+            custom_fields={"city": "Portland"})
+        store.put_entity("t1", "teacher", "T001",
+            base_data={"first_name": "Carol", "last_name": "White"},
+            custom_fields={})
+
+        yield engine, store, embedder
+
+
+def test_semantic_search_returns_results(search_setup):
+    engine, store, embedder = search_setup
+    result = engine.semantic_search(
+        tenant_id="t1",
+        query="students in Springfield",
+    )
+    assert "results" in result
+    assert "total" in result
+    assert result["total"] > 0
+    assert "_distance" in result["results"][0]
+
+
+def test_semantic_search_respects_limit(search_setup):
+    engine, store, embedder = search_setup
+    result = engine.semantic_search(
+        tenant_id="t1",
+        query="students",
+        limit=1,
+    )
+    assert len(result["results"]) == 1
+
+
+def test_semantic_search_filters_by_entity_type(search_setup):
+    engine, store, embedder = search_setup
+    result = engine.semantic_search(
+        tenant_id="t1",
+        query="people",
+        entity_type="student",
+    )
+    for r in result["results"]:
+        assert r["entity_type"] == "student"
+
+
+def test_semantic_search_returns_decoded_data(search_setup):
+    engine, store, embedder = search_setup
+    result = engine.semantic_search(
+        tenant_id="t1",
+        query="Alice",
+        limit=10,
+    )
+    # base_data and custom_fields should be decoded dicts, not TOON strings
+    for r in result["results"]:
+        assert isinstance(r["base_data"], dict)
+        assert isinstance(r["custom_fields"], dict)
+
+
+def test_semantic_search_excludes_vector_from_results(search_setup):
+    engine, store, embedder = search_setup
+    result = engine.semantic_search(
+        tenant_id="t1",
+        query="Alice",
+    )
+    for r in result["results"]:
+        assert "vector" not in r
+
+
+def test_semantic_search_only_active_records(search_setup):
+    engine, store, embedder = search_setup
+    # Update Alice to create an archived version
+    store.put_entity("t1", "student", "S001",
+        base_data={"first_name": "Alice", "last_name": "Smith-Updated"},
+        custom_fields={"city": "Springfield"})
+
+    result = engine.semantic_search(
+        tenant_id="t1",
+        query="Alice",
+        limit=10,
+    )
+    for r in result["results"]:
+        assert r["_status"] == "active"
+
+
+def test_semantic_search_empty_table(search_setup):
+    engine, store, embedder = search_setup
+    result = engine.semantic_search(
+        tenant_id="t99",
+        query="anything",
+    )
+    assert result["results"] == []
+    assert result["total"] == 0
+
+
+def test_semantic_search_calls_embed_query(search_setup):
+    engine, store, embedder = search_setup
+    engine.semantic_search(tenant_id="t1", query="find students")
+    embedder.embed_query.assert_called_with("find students")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_semantic_search.py -v --tb=short -x`
+Expected: FAIL — QueryEngine has no `semantic_search` method
+
+- [ ] **Step 3: Implement semantic_search on QueryEngine**
+
+In `src/datacore/query.py`, add import and update `__init__`:
+
+```python
+"""DuckDB + Arrow SQL query engine over LanceDB tables."""
+
+import json
+
+import duckdb
+import pyarrow as pa
+import toon
+
+from datacore.store import Store
+
+
+class TableNotFoundError(Exception):
+    """Raised when a query targets a table that doesn't exist."""
+
+
+class QueryEngine:
+    """SQL query engine over LanceDB tables using DuckDB + Apache Arrow."""
+
+    def __init__(self, store: Store):
+        self.store = store
+```
+
+Add `semantic_search` method after the `query` method:
+
+```python
+    def semantic_search(
+        self,
+        tenant_id: str,
+        query: str,
+        entity_type: str | None = None,
+        limit: int = 10,
+        distance_threshold: float | None = None,
+    ) -> dict:
+        """Search entities by semantic similarity to a natural language query.
+
+        Args:
+            tenant_id: tenant scope
+            query: natural language search text
+            entity_type: optional filter to scope by entity type
+            limit: max results to return (default 10)
+            distance_threshold: optional max distance to include
+
+        Returns:
+            {"results": [...], "total": int} with _distance per result
+        """
+        table_name = self.store._entities_table_name(tenant_id)
+        if table_name not in self.store._table_names():
+            return {"results": [], "total": 0}
+
+        # Embed the query
+        query_vector = self.store.embedder.embed_query(query)
+
+        # Run vector search
+        table = self.store._db.open_table(table_name)
+        search = table.search(query_vector).limit(limit)
+
+        # Apply entity_type filter
+        where_clauses = ["_status = 'active'"]
+        if entity_type:
+            where_clauses.append(f"entity_type = '{entity_type}'")
+        search = search.where(" AND ".join(where_clauses))
+
+        rows = search.to_list()
+
+        # Apply distance threshold if specified
+        if distance_threshold is not None:
+            rows = [r for r in rows if r.get("_distance", 0) <= distance_threshold]
+
+        # Decode TOON fields and clean up results
+        results = []
+        for row in rows:
+            row["base_data"] = toon.decode(row["base_data"]) if row["base_data"] else {}
+            row["custom_fields"] = toon.decode(row["custom_fields"]) if row["custom_fields"] else {}
+            row.pop("vector", None)
+            results.append(row)
+
+        return {"results": results, "total": len(results)}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_semantic_search.py -v --tb=short`
+Expected: ALL PASS
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `uv run pytest --tb=short -q`
+Expected: ALL PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/datacore/query.py tests/test_semantic_search.py
+git commit -m "feat: add semantic_search() to QueryEngine with vector search"
+```
+
+---
+
+### Task 4: Add search REST endpoint
+
+**Files:**
+- Modify: `src/datacore/api/routes.py`
+- Modify: `tests/test_semantic_search.py` (add API test)
+
+- [ ] **Step 1: Write API test for search endpoint**
+
+Append to `tests/test_semantic_search.py`:
+
+```python
+from fastapi.testclient import TestClient
+from datacore.api import create_app
+
+
+def test_search_endpoint_returns_results(search_setup):
+    engine, store, embedder = search_setup
+    app = create_app(store)
+    client = TestClient(app)
+
+    response = client.get("/api/search/t1?q=students+in+Springfield")
+    assert response.status_code == 200
+    data = response.json()
+    assert "results" in data
+    assert "total" in data
+    assert data["total"] > 0
+
+
+def test_search_endpoint_with_entity_type_filter(search_setup):
+    engine, store, embedder = search_setup
+    app = create_app(store)
+    client = TestClient(app)
+
+    response = client.get("/api/search/t1?q=people&entity_type=student")
+    assert response.status_code == 200
+    for r in response.json()["results"]:
+        assert r["entity_type"] == "student"
+
+
+def test_search_endpoint_with_limit(search_setup):
+    engine, store, embedder = search_setup
+    app = create_app(store)
+    client = TestClient(app)
+
+    response = client.get("/api/search/t1?q=students&limit=1")
+    assert response.status_code == 200
+    assert len(response.json()["results"]) <= 1
+
+
+def test_search_endpoint_requires_query(search_setup):
+    engine, store, embedder = search_setup
+    app = create_app(store)
+    client = TestClient(app)
+
+    response = client.get("/api/search/t1")
+    assert response.status_code == 422  # missing required query param
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_semantic_search.py -k "endpoint" -v --tb=short`
+Expected: FAIL — 404 (no route registered)
+
+- [ ] **Step 3: Implement search endpoint**
+
+In `src/datacore/api/routes.py`, add the QueryEngine import at the top and the search route inside `register_routes`:
+
+Add to imports:
+```python
+from datacore.query import QueryEngine
+```
+
+Add route inside `register_routes`, after the existing routes:
+```python
+    @app.get("/api/search/{tenant_id}")
+    def search_entities(
+        tenant_id: str,
+        q: str = Query(..., description="Search query text"),
+        entity_type: str | None = Query(None, description="Filter by entity type"),
+        limit: int = Query(10, ge=1, le=100, description="Max results"),
+    ):
+        engine = QueryEngine(store)
+        result = engine.semantic_search(
+            tenant_id=tenant_id,
+            query=q,
+            entity_type=entity_type,
+            limit=limit,
+        )
+        return result
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_semantic_search.py -v --tb=short`
+Expected: ALL PASS
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `uv run pytest --tb=short -q`
+Expected: ALL PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/datacore/api/routes.py tests/test_semantic_search.py
+git commit -m "feat: add GET /api/search/{tenant_id} semantic search endpoint"
+```
+
+---
+
+### Task 5: Update server entry point, exports, and final verification
+
+**Files:**
+- Modify: `src/datacore/api/server.py`
+- Modify: `src/datacore/__init__.py`
+
+- [ ] **Step 1: Update server.py to include Embedder**
+
+Rewrite `src/datacore/api/server.py`:
+
+```python
+"""Uvicorn entry point for the datacore API."""
+
+from datacore.api import create_app
+from datacore.embedder import Embedder
+from datacore.store import Store
+
+app = create_app(Store(embedder=Embedder()))
+```
+
+- [ ] **Step 2: Update package exports**
+
+In `src/datacore/__init__.py`:
+
+```python
+"""Datacore — centralized storage and query engine for NeoApex."""
+
+from datacore.store import Store
+from datacore.query import QueryEngine
+from datacore.api import create_app
+from datacore.embedder import Embedder
+
+__all__ = ["Store", "QueryEngine", "create_app", "Embedder"]
+```
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `uv run pytest --tb=short -q`
+Expected: ALL PASS
+
+- [ ] **Step 4: Verify app can start (without API key — should fail clearly)**
+
+Run: `uv run python3 -c "from datacore import Embedder; print('Embedder importable')"`
+Expected: `Embedder importable`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/datacore/api/server.py src/datacore/__init__.py
+git commit -m "feat: update server entry point and exports for Embedder"
+```
+
+---
+
+### Task 6: Delete old entity data
+
+**Files:**
+- None (data operation only)
+
+- [ ] **Step 1: Delete existing acme_entities data**
+
+```bash
+rm -rf data/lancedb/acme_entities.lance
+```
+
+- [ ] **Step 2: Verify deletion**
+
+Run: `uv run python3 -c "import lancedb; db = lancedb.connect('data/lancedb'); print(db.table_names())"`
+Expected: Should only show `acme_models` (no `acme_entities`)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A data/lancedb/
+git commit -m "chore: delete old acme_entities data (no vector column)"
+```

--- a/datacore/docs/superpowers/specs/2026-03-31-semantic-search-design.md
+++ b/datacore/docs/superpowers/specs/2026-03-31-semantic-search-design.md
@@ -1,0 +1,154 @@
+# Semantic Search for Entity Analytics
+
+## Context
+
+Datacore is a tenant-scoped LanceDB storage library for NeoApex. It currently supports exact-match SQL queries via QueryEngine but has no semantic search capability. The add-student-entry feature requires semantic analytics — finding similar entities, querying by meaning, and filtering by natural language descriptions.
+
+LanceDB natively supports vector search alongside structured data, making it possible to add embeddings without introducing a separate vector store.
+
+## Goals
+
+- Add vector embeddings to entity records for semantic similarity search
+- Support natural language queries over structured entity data (e.g., "students with special needs")
+- Support finding similar entities (e.g., "students similar to Kenny Lee")
+- Expose semantic search via both Python API and REST endpoint
+
+## Non-Goals
+
+- LLM processing of search results (future — requires chat UI design)
+- Document retrieval / PDF chunk search (separate RAG use case)
+- Auto-routing between SQL and semantic search (caller decides)
+- Batch re-index command (auto-embed on write is sufficient)
+- Authentication / authorization
+
+## Decisions
+
+### Decision 1: Voyage AI `voyage-3` embeddings
+
+Use Voyage AI `voyage-3` model (1024 dimensions) via the `voyageai` SDK. API key read from `VOYAGE_API_KEY` environment variable.
+
+Chosen over OpenAI embeddings (slightly lower retrieval quality) and local sentence-transformers (heavy PyTorch dependency). At a few thousand records per tenant, cost is negligible (~$0.003 per 1,000 records).
+
+### Decision 2: Vector column on existing entities table (Approach 1)
+
+Add a `vector` column to `ENTITIES_SCHEMA` rather than creating a separate vector index table. This keeps one table per tenant, enables single-query vector search + filter, and avoids sync complexity between tables.
+
+### Decision 3: Auto-embed on every write
+
+Store constructor requires an `Embedder` instance. Every `put_entity()` call auto-embeds by flattening `base_data` + `custom_fields` into text and generating a vector. No optional/null vectors — every entity row is guaranteed to have an embedding.
+
+### Decision 4: Embed all fields
+
+Embedding input combines all fields from `base_data` and `custom_fields` into a single text string:
+
+```
+"entity_type: student, first_name: Wei, last_name: Chen, grade_level: 2nd, school: Hoover, medical_conditions: None"
+```
+
+Text flattening logic lives in the Embedder module.
+
+### Decision 5: Two separate search interfaces
+
+SQL query (existing `QueryEngine.query()`) and semantic search (new `QueryEngine.semantic_search()`) are separate methods and endpoints. The caller decides which to use. No auto-routing.
+
+- Exact filters → SQL: `POST /api/query/{tenant_id}`
+- Fuzzy/meaning-based → semantic: `GET /api/search/{tenant_id}?q=...`
+
+## Architecture
+
+### New module: `src/datacore/embedder.py`
+
+Responsible for text flattening and embedding generation.
+
+```python
+class Embedder:
+    def __init__(self):  # reads VOYAGE_API_KEY from env
+    def embed(self, fields: dict) -> list[float]  # single entity
+    def embed_batch(self, fields_list: list[dict]) -> list[list[float]]  # batch
+```
+
+- Flattens dict keys/values into a single text string
+- Calls Voyage AI `voyage-3` API
+- Raises clear error if `VOYAGE_API_KEY` is not set
+
+### Schema change: `ENTITIES_SCHEMA`
+
+Add vector column:
+
+```python
+ENTITIES_SCHEMA = pa.schema([
+    pa.field("entity_type", pa.string()),
+    pa.field("entity_id", pa.string()),
+    pa.field("base_data", pa.string()),
+    pa.field("custom_fields", pa.string()),
+    pa.field("vector", pa.list_(pa.float32(), 1024)),
+] + _META_FIELDS)
+```
+
+### Store changes
+
+- `Store.__init__` requires an `Embedder` instance
+- `put_entity()` auto-embeds: flattens `base_data` + `custom_fields` → calls `embedder.embed()` → stores vector alongside entity data
+- No changes to read methods — they return whatever's in the row including the vector
+
+### QueryEngine changes
+
+New method:
+
+```python
+def semantic_search(
+    self,
+    tenant_id: str,
+    query: str,
+    entity_type: str | None = None,
+    limit: int = 10,
+    distance_threshold: float | None = None,
+) -> dict:
+```
+
+- Embeds the query text via `Embedder`
+- Runs LanceDB vector search on `{tenant_id}_entities`
+- Optional `entity_type` filter
+- Returns `{"results": [...], "total": int}` with `_distance` per result
+- Results sorted by distance (most similar first)
+
+### REST endpoint
+
+```
+GET /api/search/{tenant_id}?q=...&entity_type=...&limit=10
+```
+
+- `q` — required, search text
+- `entity_type` — optional filter
+- `limit` — optional, default 10
+
+Returns:
+```json
+{
+  "results": [
+    {
+      "entity_id": "...",
+      "entity_type": "student",
+      "base_data": {},
+      "custom_fields": {},
+      "_distance": 0.12
+    }
+  ],
+  "total": 3
+}
+```
+
+### Dependencies
+
+Add `voyageai` SDK to `pyproject.toml`.
+
+### Data migration
+
+Delete existing `acme_entities` table data (3 records without vectors). Start fresh — all new entities will have vectors from auto-embed.
+
+## Risks / Trade-offs
+
+- **Voyage AI dependency** — external API required for all entity writes. If the API is down, `put_entity()` fails. Acceptable for current scale; could add a queue/retry later.
+- **Breaking change to Store constructor** — `Store.__init__` now requires an `Embedder` instance. All existing callers (tests, `create_app`, papermite) must be updated. Pre-production, so this is safe.
+- **Embedding all fields** — some fields (like `entity_id`) add noise. Acceptable trade-off for simplicity; can refine field selection later if search quality suffers.
+- **No LLM layer** — semantic search returns raw results without synthesis. Future work with chat UI.

--- a/datacore/src/datacore/api/routes.py
+++ b/datacore/src/datacore/api/routes.py
@@ -2,11 +2,12 @@
 
 import uuid
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from datacore.store import Store
+from datacore.query import QueryEngine, TableNotFoundError
 
 
 class CreateEntityRequest(BaseModel):
@@ -37,3 +38,66 @@ def register_routes(app: FastAPI, store: Store) -> None:
             custom_fields=body.custom_fields,
         )
         return JSONResponse(status_code=201, content=result)
+
+    @app.get("/api/entities/{tenant_id}/{entity_type}/query")
+    def query_entities(
+        tenant_id: str,
+        entity_type: str,
+        request: Request,
+        _status: str = "active",
+        sort_by: str = "last_name",
+        sort_dir: str = "asc",
+        limit: int = 20,
+        offset: int = 0,
+    ):
+        # Clamp pagination
+        if limit < 1:
+            limit = 20
+        if limit > 50:
+            limit = 50
+        if offset < 0:
+            offset = 0
+        if sort_dir not in ("asc", "desc"):
+            sort_dir = "asc"
+
+        qe = QueryEngine(store)
+
+        # Load and flatten table to discover available columns
+        arrow_table = store.get_table_as_arrow(tenant_id, "entities")
+        if arrow_table is None:
+            return {"data": [], "total": 0}
+
+        flat = qe._flatten_custom_fields(arrow_table)
+        available_cols = set(flat.column_names)
+
+        # Validate sort column
+        if sort_by not in available_cols:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid sort column: '{sort_by}'",
+            )
+
+        # Build WHERE clauses
+        conditions = [f"entity_type = '{entity_type}'"]
+
+        if _status and _status != "all":
+            safe_status = _status.replace("'", "''")
+            conditions.append(f"_status = '{safe_status}'")
+
+        # Dynamic field filters — any query param matching a column name
+        reserved = {"_status", "sort_by", "sort_dir", "limit", "offset"}
+        for key, val in request.query_params.items():
+            if key in reserved or not val:
+                continue
+            if key in available_cols:
+                safe_val = val.replace("'", "''")
+                conditions.append(f"{key} ILIKE '%{safe_val}%'")
+
+        where = " AND ".join(conditions)
+        sql = f"SELECT * FROM data WHERE {where} ORDER BY {sort_by} {sort_dir.upper()}"
+
+        try:
+            result = qe.query(tenant_id, "entities", sql, limit=limit, offset=offset)
+            return {"data": result["rows"], "total": result["total"]}
+        except TableNotFoundError:
+            return {"data": [], "total": 0}

--- a/datacore/src/datacore/api/server.py
+++ b/datacore/src/datacore/api/server.py
@@ -1,0 +1,6 @@
+"""Uvicorn entry point for the datacore API."""
+
+from datacore.api import create_app
+from datacore.store import Store
+
+app = create_app(Store())

--- a/datacore/src/datacore/query.py
+++ b/datacore/src/datacore/query.py
@@ -111,10 +111,7 @@ class QueryEngine:
             else:
                 parsed.append({})
 
-        if not all_keys:
-            return arrow_table
-
-        # Add each custom field as a new column
+        # Add each custom field as a new column (skip if none found)
         for key in all_keys:
             values = []
             for row in parsed:

--- a/datacore/tests/test_api.py
+++ b/datacore/tests/test_api.py
@@ -130,3 +130,90 @@ def test_create_entity_persists_to_store(app_client):
     assert active is not None
     assert active["base_data"]["first_name"] == "Alice"
     assert active["custom_fields"]["city"] == "Springfield"
+
+
+# --- Query endpoint tests ---
+
+
+def test_query_default_returns_active_students(app_client):
+    client, store = app_client
+    store.put_entity("t1", "student", "s1", {"first_name": "Zara", "last_name": "Adams"}, {})
+    store.put_entity("t1", "student", "s2", {"first_name": "Alice", "last_name": "Brown"}, {})
+    store.put_entity("t1", "student", "s3", {"first_name": "Bob", "last_name": "Clark"}, {})
+
+    resp = client.get("/api/entities/t1/student/query")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 3
+    assert len(body["data"]) == 3
+    assert body["data"][0]["last_name"] == "Adams"
+    assert body["data"][1]["last_name"] == "Brown"
+
+
+def test_query_filters_by_entity_type(app_client):
+    client, store = app_client
+    store.put_entity("t1", "student", "s1", {"last_name": "A"}, {})
+    store.put_entity("t1", "teacher", "t1", {"last_name": "B"}, {})
+
+    resp = client.get("/api/entities/t1/student/query")
+    assert resp.status_code == 200
+    assert resp.json()["total"] == 1
+    assert resp.json()["data"][0]["entity_type"] == "student"
+
+
+def test_query_sort(app_client):
+    client, store = app_client
+    store.put_entity("t1", "student", "s1", {"first_name": "Zara", "last_name": "A"}, {})
+    store.put_entity("t1", "student", "s2", {"first_name": "Alice", "last_name": "B"}, {})
+
+    resp = client.get("/api/entities/t1/student/query?sort_by=first_name&sort_dir=desc")
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert data[0]["first_name"] == "Zara"
+
+
+def test_query_invalid_sort_column(app_client):
+    client, store = app_client
+    store.put_entity("t1", "student", "s1", {"last_name": "A"}, {})
+    resp = client.get("/api/entities/t1/student/query?sort_by=nonexistent")
+    assert resp.status_code == 400
+
+
+def test_query_pagination(app_client):
+    client, store = app_client
+    for i in range(5):
+        store.put_entity("t1", "student", f"s{i}", {"last_name": f"Name{i:02d}"}, {})
+
+    resp = client.get("/api/entities/t1/student/query?limit=2&offset=2")
+    body = resp.json()
+    assert body["total"] == 5
+    assert len(body["data"]) == 2
+
+
+def test_query_limit_clamped(app_client):
+    client, store = app_client
+    store.put_entity("t1", "student", "s1", {"last_name": "A"}, {})
+    resp = client.get("/api/entities/t1/student/query?limit=100")
+    assert resp.status_code == 200
+
+
+def test_query_base_field_filter(app_client):
+    client, store = app_client
+    store.put_entity("t1", "student", "s1", {"first_name": "Jane", "last_name": "Doe"}, {})
+    store.put_entity("t1", "student", "s2", {"first_name": "John", "last_name": "Smith"}, {})
+
+    resp = client.get("/api/entities/t1/student/query?first_name=jan")
+    body = resp.json()
+    assert body["total"] == 1
+    assert body["data"][0]["first_name"] == "Jane"
+
+
+def test_query_address_substring_match(app_client):
+    client, store = app_client
+    store.put_entity("t1", "student", "s1", {"last_name": "A", "address": "123 Main St, San Jose, CA"}, {})
+    store.put_entity("t1", "student", "s2", {"last_name": "B", "address": "456 Oak Ave, Portland, OR"}, {})
+
+    resp = client.get("/api/entities/t1/student/query?address=san jose")
+    body = resp.json()
+    assert body["total"] == 1
+    assert "San Jose" in body["data"][0]["address"]


### PR DESCRIPTION
## Summary
- **Student List View**: Datacore-backed table with server-side filtering/sorting/pagination, dynamic search pane from model definition, column visibility toggle, localStorage preferences per user, newly-added student highlighting, adaptive page size
- **Datacore Query API**: Generic `GET /api/entities/{tenant_id}/{entity_type}/query` with dynamic ILIKE filters, sort validation, pagination clamping
- **ModelContext**: Session-scoped model definition cache (cleared on logout)
- **DataTable Enhancements**: Sortable column headers, page size selector, hidden columns, row highlighting
- **Bug fixes**: QueryEngine base_data flattening when custom_fields empty, address search using model field name, sort indicator on composite name column

## Test plan
- [ ] Newly added student appears at top of list with highlighted background
- [ ] Sort by clicking column headers — arrow indicator shows, data re-fetches
- [ ] Filter by any base field (name, address, etc.) — ILIKE substring matching
- [ ] Status dropdown defaults to Active, can switch to other statuses or Show All
- [ ] Column visibility toggle — hide/show columns, preference persists in localStorage
- [ ] Page size selector — 10/20/30/40/50, preference persists
- [ ] Clear localStorage and reload — all preferences revert to defaults
- [ ] i18n works for both en-US and zh-CN

🤖 Generated with [Claude Code](https://claude.com/claude-code)