### PR TITLE
feat: add semantic search with Voyage AI embeddings

### DIFF
--- a/datacore/pyproject.toml
+++ b/datacore/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "python-toon>=0.1",
     "fastapi>=0.115",
     "uvicorn>=0.34",
+    "voyageai>=0.3",
 ]
 
 [project.optional-dependencies]

--- a/datacore/src/datacore/__init__.py
+++ b/datacore/src/datacore/__init__.py
@@ -3,5 +3,6 @@
 from datacore.store import Store
 from datacore.query import QueryEngine
 from datacore.api import create_app
+from datacore.embedder import Embedder
 
-__all__ = ["Store", "QueryEngine", "create_app"]
+__all__ = ["Store", "QueryEngine", "create_app", "Embedder"]

--- a/datacore/src/datacore/api/routes.py
+++ b/datacore/src/datacore/api/routes.py
@@ -2,7 +2,7 @@
 
 import uuid
 
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
@@ -101,3 +101,19 @@ def register_routes(app: FastAPI, store: Store) -> None:
             return {"data": result["rows"], "total": result["total"]}
         except TableNotFoundError:
             return {"data": [], "total": 0}
+
+    @app.get("/api/search/{tenant_id}")
+    def search_entities(
+        tenant_id: str,
+        q: str = Query(..., description="Search query text"),
+        entity_type: str | None = Query(None, description="Filter by entity type"),
+        limit: int = Query(10, ge=1, le=100, description="Max results"),
+    ):
+        engine = QueryEngine(store)
+        result = engine.semantic_search(
+            tenant_id=tenant_id,
+            query=q,
+            entity_type=entity_type,
+            limit=limit,
+        )
+        return result

--- a/datacore/src/datacore/api/server.py
+++ b/datacore/src/datacore/api/server.py
@@ -1,6 +1,7 @@
 """Uvicorn entry point for the datacore API."""
 
 from datacore.api import create_app
+from datacore.embedder import Embedder
 from datacore.store import Store
 
-app = create_app(Store())
+app = create_app(Store(embedder=Embedder()))

--- a/datacore/src/datacore/embedder.py
+++ b/datacore/src/datacore/embedder.py
@@ -1,0 +1,47 @@
+"""Voyage AI embedding generation for entity data."""
+
+import voyageai
+
+MODEL = "voyage-3"
+DIMENSIONS = 1024
+
+
+class Embedder:
+    """Generates vector embeddings from entity field data using Voyage AI.
+
+    Reads VOYAGE_API_KEY from environment automatically.
+    """
+
+    def __init__(self):
+        self._client = voyageai.Client()
+
+    def _flatten_fields(self, fields: dict) -> str:
+        """Flatten a dict of fields into a single text string for embedding."""
+        parts = []
+        for key, value in fields.items():
+            if value is not None:
+                parts.append(f"{key}: {value}")
+        return ", ".join(parts)
+
+    def embed(self, fields: dict) -> list[float]:
+        """Embed a single entity's fields. Returns 1024-dim vector."""
+        text = self._flatten_fields(fields)
+        result = self._client.embed(
+            [text], model=MODEL, input_type="document"
+        )
+        return result.embeddings[0]
+
+    def embed_batch(self, fields_list: list[dict]) -> list[list[float]]:
+        """Embed multiple entities' fields in one API call."""
+        texts = [self._flatten_fields(f) for f in fields_list]
+        result = self._client.embed(
+            texts, model=MODEL, input_type="document"
+        )
+        return result.embeddings
+
+    def embed_query(self, query: str) -> list[float]:
+        """Embed a search query string. Uses input_type="query"."""
+        result = self._client.embed(
+            [query], model=MODEL, input_type="query"
+        )
+        return result.embeddings[0]

--- a/datacore/src/datacore/query.py
+++ b/datacore/src/datacore/query.py
@@ -87,6 +87,64 @@ class QueryEngine:
 
         return {"rows": rows, "total": total}
 
+    def semantic_search(
+        self,
+        tenant_id: str,
+        query: str,
+        entity_type: str | None = None,
+        limit: int = 10,
+        distance_threshold: float | None = None,
+    ) -> dict:
+        """Search entities by semantic similarity to a natural language query.
+
+        Args:
+            tenant_id: tenant scope
+            query: natural language search text
+            entity_type: optional filter to scope by entity type
+            limit: max results to return (default 10)
+            distance_threshold: optional max distance to include. Note: applied
+                after LanceDB's limit, so fewer than `limit` results may be returned.
+
+        Returns:
+            {"results": [...], "total": int} with _distance per result
+        """
+        table_name = self.store._entities_table_name(tenant_id)
+        if table_name not in self.store._table_names():
+            return {"results": [], "total": 0}
+
+        if not self.store.embedder:
+            raise ValueError("semantic_search requires an Embedder instance on the Store")
+
+        # Embed the query
+        query_vector = self.store.embedder.embed_query(query)
+
+        # Run vector search
+        table = self.store._db.open_table(table_name)
+        search = table.search(query_vector).limit(limit)
+
+        # Apply entity_type filter
+        where_clauses = ["_status = 'active'"]
+        if entity_type:
+            safe_type = entity_type.replace("'", "''")
+            where_clauses.append(f"entity_type = '{safe_type}'")
+        search = search.where(" AND ".join(where_clauses))
+
+        rows = search.to_list()
+
+        # Apply distance threshold if specified
+        if distance_threshold is not None:
+            rows = [r for r in rows if r.get("_distance", float("inf")) <= distance_threshold]
+
+        # Decode TOON fields and clean up results
+        results = []
+        for row in rows:
+            row["base_data"] = toon.decode(row["base_data"]) if row["base_data"] else {}
+            row["custom_fields"] = toon.decode(row["custom_fields"]) if row["custom_fields"] else {}
+            row.pop("vector", None)
+            results.append(row)
+
+        return {"results": results, "total": len(results)}
+
     def _flatten_custom_fields(self, arrow_table: pa.Table) -> pa.Table:
         """Flatten custom_fields TOON into individual columns.
 

--- a/datacore/src/datacore/store.py
+++ b/datacore/src/datacore/store.py
@@ -37,6 +37,7 @@ ENTITIES_SCHEMA = pa.schema([
     pa.field("entity_id", pa.string()),
     pa.field("base_data", pa.string()),         # TOON-encoded document
     pa.field("custom_fields", pa.string()),    # TOON-encoded document
+    pa.field("vector", pa.list_(pa.float32(), 1024)),
 ] + _META_FIELDS)
 
 
@@ -55,6 +56,7 @@ class Store:
     def __init__(
         self,
         data_dir: str | Path = DEFAULT_DATA_DIR,
+        embedder=None,
         max_model_versions: int = 100,
         default_max_entity_versions: int = 5,
         entity_version_limits: dict[str, int] | None = None,
@@ -62,6 +64,7 @@ class Store:
         self.data_dir = Path(data_dir)
         self.data_dir.mkdir(parents=True, exist_ok=True)
         self._db = lancedb.connect(str(self.data_dir))
+        self.embedder = embedder
         self.max_model_versions = max_model_versions
         self.default_max_entity_versions = default_max_entity_versions
         self.entity_version_limits = entity_version_limits or {}
@@ -287,12 +290,18 @@ class Store:
                 row["_updated_at"] = now
             table.add(active_rows)
 
+        # Generate embedding from entity fields
+        all_fields = dict(base_data)
+        all_fields.update(custom_fields or {})
+        vector = self.embedder.embed(all_fields) if self.embedder else [0.0] * 1024
+
         # Insert new active — custom fields stored as TOON format
         record = {
             "entity_type": entity_type,
             "entity_id": entity_id,
             "base_data": toon.encode(base_data),
             "custom_fields": toon.encode(custom_fields or {}),
+            "vector": vector,
             "_version": next_version,
             "_status": "active",
             "_change_id": change_id,
@@ -306,6 +315,7 @@ class Store:
 
         record["base_data"] = base_data
         record["custom_fields"] = custom_fields or {}
+        del record["vector"]
         return record
 
     def get_active_entity(

--- a/datacore/tests/conftest.py
+++ b/datacore/tests/conftest.py
@@ -1,6 +1,16 @@
 import tempfile
+from unittest.mock import MagicMock
+
 import pytest
 from datacore import Store, QueryEngine
+
+
+@pytest.fixture
+def mock_embedder():
+    embedder = MagicMock()
+    embedder.embed.return_value = [0.0] * 1024
+    embedder.embed_batch.return_value = []
+    return embedder
 
 
 @pytest.fixture
@@ -10,9 +20,10 @@ def tmp_dir():
 
 
 @pytest.fixture
-def store(tmp_dir):
+def store(tmp_dir, mock_embedder):
     return Store(
         data_dir=tmp_dir,
+        embedder=mock_embedder,
         max_model_versions=5,
         default_max_entity_versions=3,
         entity_version_limits={"student": 3, "staff": 2},

--- a/datacore/tests/test_api.py
+++ b/datacore/tests/test_api.py
@@ -11,8 +11,11 @@ from datacore.api import create_app
 
 @pytest.fixture
 def app_client():
+    from unittest.mock import MagicMock
     with tempfile.TemporaryDirectory() as tmp:
-        store = Store(data_dir=tmp)
+        mock_embedder = MagicMock()
+        mock_embedder.embed.return_value = [0.0] * 1024
+        store = Store(data_dir=tmp, embedder=mock_embedder)
         app = create_app(store)
         yield TestClient(app), store
 

--- a/datacore/tests/test_embedder.py
+++ b/datacore/tests/test_embedder.py
@@ -1,0 +1,94 @@
+"""Tests for the Embedder module."""
+
+from unittest.mock import MagicMock, patch
+
+
+class TestFlattenFields:
+    def _make_embedder(self):
+        with patch("voyageai.Client"):
+            from datacore.embedder import Embedder
+            return Embedder()
+
+    def test_flatten_fields_combines_all_keys(self):
+        embedder = self._make_embedder()
+        result = embedder._flatten_fields({"name": "Alice", "role": "admin"})
+        assert "name: Alice" in result
+        assert "role: admin" in result
+
+    def test_flatten_fields_empty_dict(self):
+        embedder = self._make_embedder()
+        result = embedder._flatten_fields({})
+        assert result == ""
+
+    def test_flatten_fields_skips_none_values(self):
+        embedder = self._make_embedder()
+        result = embedder._flatten_fields({"name": "Bob", "email": None})
+        assert "name: Bob" in result
+        assert "email" not in result
+
+
+class TestEmbedder:
+    def _make_embedder_with_mock(self):
+        """Return (embedder, mock_client) with voyageai.Client mocked."""
+        with patch("voyageai.Client") as MockClient:
+            mock_client = MagicMock()
+            MockClient.return_value = mock_client
+            from datacore.embedder import Embedder
+            embedder = Embedder()
+            embedder._client = mock_client
+            return embedder, mock_client
+
+    def _fake_embed_result(self, vectors):
+        result = MagicMock()
+        result.embeddings = vectors
+        return result
+
+    def test_embed_calls_voyage_api(self):
+        embedder, mock_client = self._make_embedder_with_mock()
+        mock_client.embed.return_value = self._fake_embed_result([[0.1] * 1024])
+
+        embedder.embed({"title": "Engineer"})
+
+        mock_client.embed.assert_called_once()
+        call_kwargs = mock_client.embed.call_args
+        assert call_kwargs.kwargs.get("model") == "voyage-3" or call_kwargs.args[1] == "voyage-3" or "voyage-3" in str(call_kwargs)
+        # Verify model and input_type positionally or as kwargs
+        _, kwargs = call_kwargs
+        assert kwargs.get("model") == "voyage-3"
+        assert kwargs.get("input_type") == "document"
+
+    def test_embed_batch(self):
+        embedder, mock_client = self._make_embedder_with_mock()
+        vectors = [[float(i)] * 1024 for i in range(3)]
+        mock_client.embed.return_value = self._fake_embed_result(vectors)
+
+        result = embedder.embed_batch([
+            {"name": "A"},
+            {"name": "B"},
+            {"name": "C"},
+        ])
+
+        assert isinstance(result, list)
+        assert len(result) == 3
+        assert result[0] == vectors[0]
+
+    def test_embed_query_uses_query_input_type(self):
+        embedder, mock_client = self._make_embedder_with_mock()
+        mock_client.embed.return_value = self._fake_embed_result([[0.5] * 1024])
+
+        embedder.embed_query("find senior engineers")
+
+        mock_client.embed.assert_called_once()
+        _, kwargs = mock_client.embed.call_args
+        assert kwargs.get("input_type") == "query"
+        assert kwargs.get("model") == "voyage-3"
+
+    def test_embedder_raises_without_api_key(self):
+        import pytest
+        with patch("voyageai.Client", side_effect=Exception("No API key")):
+            from datacore import embedder as embedder_module
+            import importlib
+            # Reload to get fresh class
+            importlib.reload(embedder_module)
+            with pytest.raises(Exception):
+                embedder_module.Embedder()

--- a/datacore/tests/test_semantic_search.py
+++ b/datacore/tests/test_semantic_search.py
@@ -1,0 +1,143 @@
+"""Tests for semantic search via QueryEngine."""
+
+import tempfile
+from unittest.mock import MagicMock
+
+import pytest
+
+from datacore import Store, QueryEngine
+
+
+def _make_embedder(vectors_map=None):
+    """Create a mock embedder that returns predictable vectors.
+
+    vectors_map: dict mapping text substrings to vectors.
+    Default: returns different vectors per call to simulate real embeddings.
+    """
+    embedder = MagicMock()
+    call_count = [0]
+
+    def mock_embed(fields):
+        call_count[0] += 1
+        # Return slightly different vectors for each entity
+        vec = [0.0] * 1024
+        vec[0] = float(call_count[0])
+        return vec
+
+    def mock_embed_query(query):
+        # Return a vector close to entity 1 by default
+        vec = [0.0] * 1024
+        vec[0] = 1.0
+        return vec
+
+    embedder.embed.side_effect = mock_embed
+    embedder.embed_query.side_effect = mock_embed_query
+    return embedder
+
+
+@pytest.fixture
+def search_setup():
+    with tempfile.TemporaryDirectory() as tmp:
+        embedder = _make_embedder()
+        store = Store(data_dir=tmp, embedder=embedder)
+        engine = QueryEngine(store)
+
+        store.put_entity("t1", "student", "S001",
+            base_data={"first_name": "Alice", "last_name": "Smith"},
+            custom_fields={"city": "Springfield"})
+        store.put_entity("t1", "student", "S002",
+            base_data={"first_name": "Bob", "last_name": "Jones"},
+            custom_fields={"city": "Portland"})
+        store.put_entity("t1", "teacher", "T001",
+            base_data={"first_name": "Carol", "last_name": "White"},
+            custom_fields={})
+
+        yield engine, store, embedder
+
+
+def test_semantic_search_returns_results(search_setup):
+    engine, store, embedder = search_setup
+    result = engine.semantic_search(
+        tenant_id="t1",
+        query="students in Springfield",
+    )
+    assert "results" in result
+    assert "total" in result
+    assert result["total"] > 0
+    assert "_distance" in result["results"][0]
+
+
+def test_semantic_search_respects_limit(search_setup):
+    engine, store, embedder = search_setup
+    result = engine.semantic_search(
+        tenant_id="t1",
+        query="students",
+        limit=1,
+    )
+    assert len(result["results"]) == 1
+
+
+def test_semantic_search_filters_by_entity_type(search_setup):
+    engine, store, embedder = search_setup
+    result = engine.semantic_search(
+        tenant_id="t1",
+        query="people",
+        entity_type="student",
+    )
+    for r in result["results"]:
+        assert r["entity_type"] == "student"
+
+
+def test_semantic_search_returns_decoded_data(search_setup):
+    engine, store, embedder = search_setup
+    result = engine.semantic_search(
+        tenant_id="t1",
+        query="Alice",
+        limit=10,
+    )
+    # base_data and custom_fields should be decoded dicts, not TOON strings
+    for r in result["results"]:
+        assert isinstance(r["base_data"], dict)
+        assert isinstance(r["custom_fields"], dict)
+
+
+def test_semantic_search_excludes_vector_from_results(search_setup):
+    engine, store, embedder = search_setup
+    result = engine.semantic_search(
+        tenant_id="t1",
+        query="Alice",
+    )
+    for r in result["results"]:
+        assert "vector" not in r
+
+
+def test_semantic_search_only_active_records(search_setup):
+    engine, store, embedder = search_setup
+    # Update Alice to create an archived version
+    store.put_entity("t1", "student", "S001",
+        base_data={"first_name": "Alice", "last_name": "Smith-Updated"},
+        custom_fields={"city": "Springfield"})
+
+    result = engine.semantic_search(
+        tenant_id="t1",
+        query="Alice",
+        limit=10,
+    )
+    for r in result["results"]:
+        assert r["_status"] == "active"
+
+
+def test_semantic_search_empty_table(search_setup):
+    engine, store, embedder = search_setup
+    result = engine.semantic_search(
+        tenant_id="t99",
+        query="anything",
+    )
+    assert result["results"] == []
+    assert result["total"] == 0
+
+
+def test_semantic_search_calls_embed_query(search_setup):
+    engine, store, embedder = search_setup
+    engine.semantic_search(tenant_id="t1", query="find students")
+    embedder.embed_query.assert_called_with("find students")

--- a/datacore/tests/test_semantic_search.py
+++ b/datacore/tests/test_semantic_search.py
@@ -141,3 +141,50 @@ def test_semantic_search_calls_embed_query(search_setup):
     engine, store, embedder = search_setup
     engine.semantic_search(tenant_id="t1", query="find students")
     embedder.embed_query.assert_called_with("find students")
+
+
+from fastapi.testclient import TestClient
+from datacore.api import create_app
+
+
+def test_search_endpoint_returns_results(search_setup):
+    engine, store, embedder = search_setup
+    app = create_app(store)
+    client = TestClient(app)
+
+    response = client.get("/api/search/t1?q=students+in+Springfield")
+    assert response.status_code == 200
+    data = response.json()
+    assert "results" in data
+    assert "total" in data
+    assert data["total"] > 0
+
+
+def test_search_endpoint_with_entity_type_filter(search_setup):
+    engine, store, embedder = search_setup
+    app = create_app(store)
+    client = TestClient(app)
+
+    response = client.get("/api/search/t1?q=people&entity_type=student")
+    assert response.status_code == 200
+    for r in response.json()["results"]:
+        assert r["entity_type"] == "student"
+
+
+def test_search_endpoint_with_limit(search_setup):
+    engine, store, embedder = search_setup
+    app = create_app(store)
+    client = TestClient(app)
+
+    response = client.get("/api/search/t1?q=students&limit=1")
+    assert response.status_code == 200
+    assert len(response.json()["results"]) <= 1
+
+
+def test_search_endpoint_requires_query(search_setup):
+    engine, store, embedder = search_setup
+    app = create_app(store)
+    client = TestClient(app)
+
+    response = client.get("/api/search/t1")
+    assert response.status_code == 422  # missing required query param

--- a/datacore/tests/test_smoke.py
+++ b/datacore/tests/test_smoke.py
@@ -2,14 +2,18 @@
 
 import tempfile
 from pathlib import Path
+from unittest.mock import MagicMock
 
 from datacore import Store, QueryEngine
 
 
 def test_full_workflow():
     with tempfile.TemporaryDirectory() as tmp:
+        mock_embedder = MagicMock()
+        mock_embedder.embed.return_value = [0.0] * 1024
         store = Store(
             data_dir=tmp,
+            embedder=mock_embedder,
             max_model_versions=100,
             default_max_entity_versions=5,
             entity_version_limits={"student": 3},

--- a/datacore/tests/test_store_entities.py
+++ b/datacore/tests/test_store_entities.py
@@ -128,8 +128,11 @@ def test_entity_version_trimming_different_limits(store):
 # ── 8. Default version limit (no entity_version_limits) applies 5 ─────────────
 
 def test_entity_version_trimming_default_limit(tmp_dir):
+    from unittest.mock import MagicMock
+    mock_embedder = MagicMock()
+    mock_embedder.embed.return_value = [0.0] * 1024
     # Create a Store with no entity_version_limits — default is 5
-    s = Store(data_dir=tmp_dir)
+    s = Store(data_dir=tmp_dir, embedder=mock_embedder)
     for i in range(8):
         s.put_entity(
             tenant_id="t1",


### PR DESCRIPTION
## Summary
- Add `Embedder` module using Voyage AI `voyage-3` (1024 dimensions) for vector embeddings
- Add `vector` column to entities schema with auto-embed on every `put_entity()` call
- Add `semantic_search()` method on `QueryEngine` for vector similarity search with entity_type filter, limit, and distance threshold
- Add `GET /api/search/{tenant_id}?q=...` REST endpoint for semantic search
- Update server entry point and package exports to include `Embedder`

## Test Plan
- [ ] 98 tests pass (`uv run pytest`)
- [ ] Verify `GET /api/search/{tenant_id}?q=students+in+Springfield` returns ranked results
- [ ] Verify `entity_type` filter scopes results correctly
- [ ] Verify missing `q` param returns 422
- [ ] Set `VOYAGE_API_KEY` env var and verify live embedding works

🤖 Generated with [Claude Code](https://claude.com/claude-code)