### PR TITLE
refactor: centralize service config into services.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -224,3 +224,4 @@ uploads/
 # Lockfiles (uv)
 uv.lock
 sampledoc/
+.logs

--- a/README.md
+++ b/README.md
@@ -116,20 +116,20 @@ All services sit behind a reverse proxy/load balancer on port 443 in production.
 ### Using the start script (recommended)
 
 ```bash
-# Interactive mode — prompts to kill existing and choose which to start
+# Default — kills all existing services, starts everything
 ./start-services.sh
 
-# Non-interactive mode — kills all existing services, starts everything
-./start-services.sh --yes
+# Interactive mode — prompts to kill existing and choose which to start
+./start-services.sh -i
 # or
-./start-services.sh -y
+./start-services.sh --interactive
 ```
 
 The script:
 1. Reads ports from `services.json`
 2. Checks for services already running on those ports
-3. In interactive mode, asks whether to kill some or all; in non-interactive mode, kills all automatically
-4. Starts selected (or all) services in the background
+3. By default, kills all and starts all automatically; with `-i`, asks which to kill/start
+4. Starts services in the background
 5. Shows a status table when done
 6. Logs output to `.logs/` directory (e.g., `.logs/datacore.log`)
 

--- a/README.md
+++ b/README.md
@@ -1,131 +1,146 @@
 # NeoApex
 
-An AI-powered platform for afterschool program management — from document ingestion and tenant onboarding to enrollment, analytics, and operations.
+Multi-service education/enrollment management platform.
 
-## Modules
+## Services
 
-| Module | Type | Frontend | Backend | Stack |
-|--------|------|----------|---------|-------|
-| [papermite](#papermite) | Full-stack | `:5173` | `:8000` | React 19 + FastAPI |
-| [launchpad](#launchpad) | Full-stack | `:5175` | `:8001` | React 19 + FastAPI |
-| [admindash](#admindash) | Frontend | `:5174` | — | React 19 + Vite |
-| [datacore](#datacore) | Backend | — | `:8081` | FastAPI + LanceDB |
-| [apexflow](#apexflow) | Planned | — | — | — |
-| [enrollx](#enrollx) | Planned | — | — | — |
-| [familyhub](#familyhub) | Planned | — | — | — |
-| [ui-tokens](#ui-tokens) | Shared lib | — | — | CSS variables |
-| [sampledoc](#sampledoc) | Sample data | — | — | PDFs |
+| Service | Description | Port | Block |
+|---|---|---|---|
+| LaunchPad frontend | Tenant onboarding & admin UI | 6000 | 60xx |
+| LaunchPad backend | Tenant lifecycle & identity API | 6010 | 60xx |
+| AdminDash frontend | Operations dashboard UI | 6100 | 61xx |
+| Papermite frontend | Document ingestion UI | 6200 | 62xx |
+| Papermite backend | Document ingestion API | 6210 | 62xx |
+| DataCore backend | Storage, query engine & auth server | 6300 | 63xx |
 
----
+**Port convention:** Each service owns a 100-port block. Frontend = `X00`, backend = `X10`.
 
-## papermite
+## Configuration
 
-**Document ingestion gateway.** Transforms afterschool program documents (PDF, DOCX, TXT) into structured, tenant-scoped Pydantic data models using AI-powered extraction.
+### services.json
 
-- **Frontend** `localhost:5173` — Upload documents, review AI-extracted draft models, and finalize schemas. Draft state stored in IndexedDB.
-- **Backend** `localhost:8000` — FastAPI. Parses documents via Docling, extracts entities via Pydantic-AI. Supports Claude Haiku/Sonnet (default), GPT-4.1/5, and Ollama.
+All service hostnames and ports are defined in `services.json` at the repo root:
 
-```bash
-# Backend
-cd papermite && uv run uvicorn main:app --reload --port 8000
-
-# Frontend
-cd papermite/frontend && npm run dev   # → localhost:5173
+```json
+{
+  "services": {
+    "launchpad-frontend": { "host": "localhost", "port": 6000 },
+    "launchpad-backend": { "host": "localhost", "port": 6010 },
+    "admindash-frontend": { "host": "localhost", "port": 6100 },
+    "papermite-frontend": { "host": "localhost", "port": 6200 },
+    "papermite-backend": { "host": "localhost", "port": 6210 },
+    "datacore": { "host": "localhost", "port": 6300 }
+  }
+}
 ```
 
----
+**To change a port for local development**, edit `services.json` and restart the affected services. All services read from this file — no need to update multiple config files.
 
-## launchpad
+### Backend Configuration
 
-**Tenant lifecycle and identity service.** Handles authentication, tenant provisioning, and user management.
+Python backends read `services.json` at startup. Environment variables override for production deployment.
 
-- **Frontend** `localhost:5175` — Tenant onboarding UI. Uses `@neoapex/ui-tokens` for shared design.
-- **Backend** `localhost:8001` — FastAPI with JWT auth (24h expiry). Integrates with datacore for model registry. Endpoints: `/api/auth`, `/api/tenants`, `/api/users`, `/api/health`.
+#### DataCore
 
-```bash
-# Backend
-cd launchpad && uv run uvicorn main:app --reload --port 8001
+| Variable | Description | Default |
+|---|---|---|
+| `DATACORE_JWT_SECRET` | JWT signing secret | `neoapex-dev-secret-change-in-prod` |
+| `DATACORE_JWT_EXPIRY_HOURS` | JWT token expiry in hours | `24` |
+| `NEOAPEX_LANCEDB_DIR` | LanceDB data directory | `datacore/data/lancedb` |
+| `CORS_ALLOWED_ORIGINS` | Comma-separated CORS origins (overrides services.json) | Built from frontend entries |
 
-# Frontend
-cd launchpad/frontend && npm run dev   # → localhost:5175
-```
+#### LaunchPad Backend
 
----
+| Variable | Description | Default |
+|---|---|---|
+| `LAUNCHPAD_DATACORE_AUTH_URL` | DataCore auth endpoint | `http://localhost:6300/auth` |
+| `LAUNCHPAD_PAPERMITE_FRONTEND_URL` | Papermite frontend URL (for redirects) | `http://localhost:6200` |
+| `LAUNCHPAD_PORT` | LaunchPad backend port | `6010` |
+| `NEOAPEX_LANCEDB_DIR` | LanceDB data directory | `datacore/data/lancedb` |
+| `CORS_ALLOWED_ORIGINS` | Comma-separated CORS origins (overrides services.json) | Built from frontend entries |
 
-## admindash
+#### Papermite Backend
 
-**Operations dashboard.** Management interface for viewing students, guardians, programs, and enrollments across tenants.
+| Variable | Description | Default |
+|---|---|---|
+| `PAPERMITE_DATACORE_AUTH_URL` | DataCore auth endpoint | `http://localhost:6300/auth` |
+| `PAPERMITE_PORT` | Papermite backend port | `6210` |
+| `NEOAPEX_LANCEDB_DIR` | LanceDB data directory | `datacore/data/lancedb` |
+| `CORS_ALLOWED_ORIGINS` | Comma-separated CORS origins (overrides services.json) | Built from frontend entries |
 
-- **Frontend only** `localhost:5174` — React SPA. Consumes APIs from datacore (`:8081`), papermite (`:8000`), and a central API server (`:8080`). Supports i18n (en-US, zh-CN).
+### Frontend Configuration
 
-```bash
-cd admindash && npm run dev   # → localhost:5174
-```
+React frontends read `services.json` at build time via Vite's JSON import. For production builds, use `VITE_` prefixed environment variables to override.
 
----
+#### LaunchPad Frontend
 
-## datacore
+| Variable | Description | Default |
+|---|---|---|
+| `VITE_LAUNCHPAD_BACKEND_URL` | LaunchPad backend base URL | `http://localhost:6010` |
+| `VITE_PAPERMITE_FRONTEND_URL` | Papermite frontend URL (for cross-app navigation) | `http://localhost:6200` |
 
-**Centralized storage and query engine.** Manages vector storage, embeddings, and analytics for the platform.
+#### Papermite Frontend
 
-- **Backend only** `localhost:8081` — FastAPI. Uses LanceDB for vector storage and DuckDB/PyArrow for analytics. Provides entity persistence, versioning, and similarity search. Consumed by admindash, papermite, launchpad, and future modules.
+| Variable | Description | Default |
+|---|---|---|
+| `VITE_PAPERMITE_BACKEND_URL` | Papermite backend base URL | `http://localhost:6210` |
 
-```bash
-cd datacore && uv run uvicorn main:app --reload --port 8081
-```
+#### AdminDash Frontend
 
----
+| Variable | Description | Default |
+|---|---|---|
+| `VITE_DATACORE_URL` | DataCore API base URL | `http://localhost:6300` |
+| `VITE_DATACORE_AUTH_URL` | DataCore auth endpoint | `http://localhost:6300/auth` |
+| `VITE_PAPERMITE_BACKEND_URL` | Papermite backend base URL | `http://localhost:6210` |
 
-## apexflow
+### CORS
 
-**Workflow orchestration** — planned, not yet implemented.
-
----
-
-## enrollx
-
-**Smart application processing** — planned, not yet implemented.
-
----
-
-## familyhub
-
-**Parent portal** — planned, not yet implemented.
-
----
-
-## ui-tokens
-
-Shared CSS design token package used across frontend modules.
-
-- **Package**: `@neoapex/ui-tokens`
-- **Exports**: `tokens.css` (CSS custom properties)
-- **Used by**: `launchpad/frontend`, `papermite/frontend`
+All backends build their CORS allowed origins dynamically from the frontend entries in `services.json`. In production, set `CORS_ALLOWED_ORIGINS` as a comma-separated list to override:
 
 ```bash
-# Link locally during development
-cd ui-tokens && npm link
-cd ../launchpad/frontend && npm link @neoapex/ui-tokens
+CORS_ALLOWED_ORIGINS=https://app.neoapex.com,https://admin.neoapex.com
 ```
 
----
+## Production Deployment
 
-## sampledoc
+In production (AWS ECS, Lambda, EKS, etc.), `services.json` is not used. Instead:
 
-Sample documents for testing the papermite extraction pipeline:
-- `2025-2026 Afterschool Admission Packet.pdf`
-- `Kenny's Application.pdf`
-- `Wei's Application.pdf`
+1. **Backend services** read configuration from environment variables set in the deployment configuration (ECS task definitions, Kubernetes ConfigMaps, etc.)
+2. **Frontend apps** are built with `VITE_` env vars injected at build time in CI/CD
+3. **CORS origins** are set via `CORS_ALLOWED_ORIGINS` env var on each backend
 
----
+All services sit behind a reverse proxy/load balancer on port 443 in production.
 
-## Port Reference
+## Quick Start
 
-| Service | Port |
-|---------|------|
-| papermite frontend | 5173 |
-| admindash frontend | 5174 |
-| launchpad frontend | 5175 |
-| papermite backend | 8000 |
-| launchpad backend | 8001 |
-| datacore backend | 8081 |
+```bash
+# Start all services (from repo root)
+
+# 1. DataCore (port 6300)
+cd datacore && uv run python3 -c "
+from datacore import Store, create_app
+from datacore.auth.seed import seed_test_user
+import uvicorn
+store = Store()
+seed_test_user(store)
+app = create_app(store)
+uvicorn.run(app, host='127.0.0.1', port=6300)
+"
+
+# 2. LaunchPad backend (port 6010)
+cd launchpad/backend && uvicorn app.main:app --port 6010
+
+# 3. Papermite backend (port 6210)
+cd papermite/backend && uvicorn app.main:app --port 6210
+
+# 4. LaunchPad frontend (port 6000)
+cd launchpad/frontend && npm run dev
+
+# 5. Papermite frontend (port 6200)
+cd papermite/frontend && npm run dev
+
+# 6. AdminDash frontend (port 6100)
+cd admindash/frontend && npm run dev
+```
+
+Test login: `jane@acme.edu` / `admin123`

--- a/README.md
+++ b/README.md
@@ -113,9 +113,29 @@ All services sit behind a reverse proxy/load balancer on port 443 in production.
 
 ## Quick Start
 
-```bash
-# Start all services (from repo root)
+### Using the start script (recommended)
 
+```bash
+# Interactive mode — prompts to kill existing and choose which to start
+./start-services.sh
+
+# Non-interactive mode — kills all existing services, starts everything
+./start-services.sh --yes
+# or
+./start-services.sh -y
+```
+
+The script:
+1. Reads ports from `services.json`
+2. Checks for services already running on those ports
+3. In interactive mode, asks whether to kill some or all; in non-interactive mode, kills all automatically
+4. Starts selected (or all) services in the background
+5. Shows a status table when done
+6. Logs output to `.logs/` directory (e.g., `.logs/datacore.log`)
+
+### Starting services manually
+
+```bash
 # 1. DataCore (port 6300)
 cd datacore && uv run python3 -c "
 from datacore import Store, create_app

--- a/admindash/frontend/src/api/client.ts
+++ b/admindash/frontend/src/api/client.ts
@@ -11,9 +11,11 @@ import type {
   SimilaritySearchResponse,
 } from '../types/models.ts';
 
+import { DATACORE_URL, PAPERMITE_BACKEND_URL } from '../config.ts';
+
 const API_BASE = 'http://localhost:8080';
-const DATACORE_API_BASE = 'http://localhost:8081';
-const PAPERMITE_API_BASE = 'http://localhost:8000';
+const DATACORE_API_BASE = DATACORE_URL;
+const PAPERMITE_API_BASE = PAPERMITE_BACKEND_URL;
 
 export async function fetchStudents(
   tenant: string,

--- a/admindash/frontend/src/config.ts
+++ b/admindash/frontend/src/config.ts
@@ -1,0 +1,10 @@
+import services from '../../../services.json';
+
+function svcUrl(key: string): string {
+  const svc = services.services[key as keyof typeof services.services];
+  return `http://${svc.host}:${svc.port}`;
+}
+
+export const DATACORE_URL = import.meta.env.VITE_DATACORE_URL || svcUrl("datacore");
+export const DATACORE_AUTH_URL = import.meta.env.VITE_DATACORE_AUTH_URL || `${DATACORE_URL}/auth`;
+export const PAPERMITE_BACKEND_URL = import.meta.env.VITE_PAPERMITE_BACKEND_URL || svcUrl("papermite-backend");

--- a/admindash/frontend/src/contexts/AuthContext.tsx
+++ b/admindash/frontend/src/contexts/AuthContext.tsx
@@ -1,7 +1,6 @@
 import { createContext, useContext, useState, useCallback, useEffect, type ReactNode } from 'react';
 import type { TestUser } from '../types/models.ts';
-
-const DATACORE_AUTH_URL = 'http://localhost:8081/auth';
+import { DATACORE_AUTH_URL } from '../config.ts';
 const TOKEN_KEY = 'neoapex_token';
 
 interface AuthState {

--- a/admindash/frontend/src/pages/StudentsPage.tsx
+++ b/admindash/frontend/src/pages/StudentsPage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { DATACORE_URL } from '../config.ts';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useTranslation } from '../hooks/useTranslation.ts';
 import { useAuth } from '../contexts/AuthContext.tsx';
@@ -287,7 +288,7 @@ export default function StudentsPage({ tenant }: StudentsPageProps) {
         setPage(p);
       } catch (err) {
         setError(
-          `Failed to load students. Is the datacore API at http://localhost:8081 running? (${err})`,
+          `Failed to load students. Is the datacore API at ${DATACORE_URL} running? (${err})`,
         );
         setData([]);
         setTotal(0);

--- a/admindash/frontend/vite.config.ts
+++ b/admindash/frontend/vite.config.ts
@@ -1,9 +1,10 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import services from '../../services.json'
 
 export default defineConfig({
   plugins: [react()],
   server: {
-    port: 5174,
+    port: services.services["admindash-frontend"].port,
   },
 })

--- a/datacore/src/datacore/api/__init__.py
+++ b/datacore/src/datacore/api/__init__.py
@@ -1,5 +1,9 @@
 """FastAPI REST API layer for datacore."""
 
+import json
+import os
+from pathlib import Path
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -8,16 +12,34 @@ from datacore.api.routes import register_routes
 from datacore.api.auth_routes import register_auth_routes
 
 
+def _load_cors_origins() -> list[str]:
+    """Build CORS allowed origins from services.json or env var override."""
+    env_origins = os.environ.get("CORS_ALLOWED_ORIGINS")
+    if env_origins:
+        return [o.strip() for o in env_origins.split(",") if o.strip()]
+
+    config_path = Path(__file__).resolve().parent.parent.parent.parent.parent / "services.json"
+    if not config_path.exists():
+        return []
+
+    with open(config_path) as f:
+        config = json.load(f)
+
+    frontend_keys = [k for k in config["services"] if k.endswith("-frontend")]
+    origins = []
+    for key in frontend_keys:
+        svc = config["services"][key]
+        origins.append(f"http://{svc['host']}:{svc['port']}")
+    return origins
+
+
 def create_app(store: Store) -> FastAPI:
     """Create and configure the FastAPI application."""
     app = FastAPI(title="datacore")
 
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=[
-            "http://localhost:5173",
-            "http://localhost:5174",
-        ],
+        allow_origins=_load_cors_origins(),
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],

--- a/datacore/tests/test_api.py
+++ b/datacore/tests/test_api.py
@@ -31,11 +31,11 @@ def test_cors_allows_admindash_origin(app_client):
     response = client.options(
         "/api/models/t1/student",
         headers={
-            "Origin": "http://localhost:5174",
+            "Origin": "http://localhost:6100",
             "Access-Control-Request-Method": "GET",
         },
     )
-    assert response.headers.get("access-control-allow-origin") == "http://localhost:5174"
+    assert response.headers.get("access-control-allow-origin") == "http://localhost:6100"
 
 
 def test_cors_allows_papermite_origin(app_client):
@@ -43,11 +43,11 @@ def test_cors_allows_papermite_origin(app_client):
     response = client.options(
         "/api/models/t1/student",
         headers={
-            "Origin": "http://localhost:5173",
+            "Origin": "http://localhost:6200",
             "Access-Control-Request-Method": "GET",
         },
     )
-    assert response.headers.get("access-control-allow-origin") == "http://localhost:5173"
+    assert response.headers.get("access-control-allow-origin") == "http://localhost:6200"
 
 
 def test_get_model_returns_active_definition(app_client):

--- a/docs/superpowers/plans/2026-04-05-shared-service-config.md
+++ b/docs/superpowers/plans/2026-04-05-shared-service-config.md
@@ -1,0 +1,905 @@
+# Shared Service Config Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace all hardcoded hostnames, ports, and service URLs with a centralized `services.json` config, with env var overrides for production.
+
+**Architecture:** A root-level `services.json` defines all service endpoints. Python backends read it at startup via a shared helper; frontends read it at build time via Vite JSON import. Environment variables override for production. CORS origins are built dynamically from the frontend entries.
+
+**Tech Stack:** Python, FastAPI, Vite, TypeScript, JSON
+
+**Spec:** `docs/superpowers/specs/2026-04-05-shared-service-config-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `services.json` (repo root) | Single source of truth for all service host/port mappings |
+| `README.md` (repo root) | Documents port mapping, config, env vars, deployment |
+| `datacore/src/datacore/api/__init__.py` | Read services.json for CORS origins |
+| `launchpad/backend/app/config.py` | Read services.json for DataCore URL, Papermite URL, CORS |
+| `launchpad/backend/app/main.py` | CORS from config instead of hardcoded regex |
+| `papermite/backend/app/config.py` | Read services.json for DataCore URL, CORS |
+| `papermite/backend/app/main.py` | CORS from config instead of hardcoded origins |
+| `launchpad/frontend/vite.config.ts` | Port from services.json |
+| `launchpad/frontend/src/api/client.ts` | API URL from env/config |
+| `launchpad/frontend/src/App.tsx` | Papermite URL from env/config |
+| `launchpad/frontend/src/pages/TenantSettingsPage.tsx` | Papermite URL from env/config |
+| `papermite/frontend/vite.config.ts` | Port from services.json |
+| `papermite/frontend/src/api/client.ts` | API URL from env/config |
+| `papermite/frontend/src/pages/LoginPage.tsx` | Use client.ts BASE_URL instead of hardcoded |
+| `admindash/frontend/vite.config.ts` | Port from services.json |
+| `admindash/frontend/src/api/client.ts` | API URLs from env/config |
+| `admindash/frontend/src/contexts/AuthContext.tsx` | Auth URL from env/config |
+| `admindash/frontend/src/pages/StudentsPage.tsx` | Remove hardcoded URL from error message |
+
+---
+
+### Task 1: Create services.json
+
+**Files:**
+- Create: `services.json`
+
+- [ ] **Step 1: Create the config file**
+
+Create `services.json` at the repo root:
+
+```json
+{
+  "services": {
+    "launchpad-frontend": { "host": "localhost", "port": 6000 },
+    "launchpad-backend": { "host": "localhost", "port": 6010 },
+    "admindash-frontend": { "host": "localhost", "port": 6100 },
+    "papermite-frontend": { "host": "localhost", "port": 6200 },
+    "papermite-backend": { "host": "localhost", "port": 6210 },
+    "datacore": { "host": "localhost", "port": 6300 }
+  }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add services.json
+git commit -m "chore: add services.json with centralized port config"
+```
+
+---
+
+### Task 2: Update DataCore backend to read services.json for CORS
+
+**Files:**
+- Modify: `datacore/src/datacore/api/__init__.py`
+
+- [ ] **Step 1: Update create_app to accept optional CORS origins**
+
+Replace `datacore/src/datacore/api/__init__.py`:
+
+```python
+"""FastAPI REST API layer for datacore."""
+
+import json
+import os
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from datacore.store import Store
+from datacore.api.routes import register_routes
+from datacore.api.auth_routes import register_auth_routes
+
+
+def _load_cors_origins() -> list[str]:
+    """Build CORS allowed origins from services.json or env var override."""
+    env_origins = os.environ.get("CORS_ALLOWED_ORIGINS")
+    if env_origins:
+        return [o.strip() for o in env_origins.split(",") if o.strip()]
+
+    config_path = Path(__file__).resolve().parent.parent.parent.parent.parent / "services.json"
+    if not config_path.exists():
+        return []
+
+    with open(config_path) as f:
+        config = json.load(f)
+
+    frontend_keys = [k for k in config["services"] if k.endswith("-frontend")]
+    origins = []
+    for key in frontend_keys:
+        svc = config["services"][key]
+        origins.append(f"http://{svc['host']}:{svc['port']}")
+    return origins
+
+
+def create_app(store: Store) -> FastAPI:
+    """Create and configure the FastAPI application."""
+    app = FastAPI(title="datacore")
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=_load_cors_origins(),
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    register_routes(app, store)
+    register_auth_routes(app, store)
+
+    return app
+```
+
+- [ ] **Step 2: Run existing DataCore tests**
+
+Run: `cd datacore && uv run python -m pytest tests/ -q`
+Expected: All tests pass. The CORS tests in `test_api.py` will need updating in a later step since they check old ports.
+
+- [ ] **Step 3: Update CORS tests for new ports**
+
+In `datacore/tests/test_api.py`, update the CORS test assertions. The tests currently check ports 5173 and 5174. Update them to check ports 6200 (papermite-frontend) and 6100 (admindash-frontend):
+
+Find the test `test_cors_allows_admindash_origin` and change:
+- `"Origin": "http://localhost:5174"` → `"Origin": "http://localhost:6100"`
+- `assert response.headers.get("access-control-allow-origin") == "http://localhost:5174"` → `assert response.headers.get("access-control-allow-origin") == "http://localhost:6100"`
+
+Find the test `test_cors_allows_papermite_origin` and change:
+- `"Origin": "http://localhost:5173"` → `"Origin": "http://localhost:6200"`
+- `assert response.headers.get("access-control-allow-origin") == "http://localhost:5173"` → `assert response.headers.get("access-control-allow-origin") == "http://localhost:6200"`
+
+- [ ] **Step 4: Run tests again**
+
+Run: `cd datacore && uv run python -m pytest tests/ -q`
+Expected: All tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add datacore/src/datacore/api/__init__.py datacore/tests/test_api.py
+git commit -m "refactor(datacore): read CORS origins from services.json"
+```
+
+---
+
+### Task 3: Update LaunchPad backend config and CORS
+
+**Files:**
+- Modify: `launchpad/backend/app/config.py`
+- Modify: `launchpad/backend/app/main.py`
+
+- [ ] **Step 1: Update LaunchPad config to read services.json**
+
+Replace `launchpad/backend/app/config.py`:
+
+```python
+"""Launchpad configuration — settings and datacore path."""
+import json
+import os
+from pathlib import Path
+from pydantic_settings import BaseSettings
+
+
+def _load_services() -> dict:
+    config_path = Path(__file__).resolve().parent.parent.parent.parent / "services.json"
+    if config_path.exists():
+        with open(config_path) as f:
+            return json.load(f)["services"]
+    return {}
+
+
+_services = _load_services()
+
+
+def _svc_url(key: str) -> str:
+    svc = _services.get(key, {})
+    host = svc.get("host", "localhost")
+    port = svc.get("port", 6010)
+    return f"http://{host}:{port}"
+
+
+def _cors_origins() -> list[str]:
+    env_origins = os.environ.get("CORS_ALLOWED_ORIGINS")
+    if env_origins:
+        return [o.strip() for o in env_origins.split(",") if o.strip()]
+    return [_svc_url(k) for k in _services if k.endswith("-frontend")]
+
+
+class Settings(BaseSettings):
+    datacore_auth_url: str = _svc_url("datacore") + "/auth"
+    datacore_store_path: Path = Path(os.environ.get(
+        "NEOAPEX_LANCEDB_DIR",
+        str(Path(__file__).resolve().parent.parent.parent.parent
+            / "datacore" / "data" / "lancedb"),
+    ))
+    papermite_frontend_url: str = _svc_url("papermite-frontend")
+    port: int = _services.get("launchpad-backend", {}).get("port", 6010)
+    cors_origins: list[str] = _cors_origins()
+    model_config = {"env_prefix": "LAUNCHPAD_"}
+
+settings = Settings()
+```
+
+- [ ] **Step 2: Update LaunchPad main.py to use config CORS**
+
+Replace the CORS middleware section in `launchpad/backend/app/main.py`:
+
+```python
+"""FastAPI application entry point for Launchpad."""
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from app.api import auth, tenants, users
+from app.config import settings
+
+app = FastAPI(
+    title="Launchpad",
+    description="Tenant lifecycle and identity service for the NeoApex platform",
+    version="0.1.0",
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=settings.cors_origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+app.include_router(auth.router, prefix="/api", tags=["auth"])
+app.include_router(tenants.router, prefix="/api", tags=["tenants"])
+app.include_router(users.router, prefix="/api", tags=["users"])
+
+@app.get("/api/health")
+def health():
+    return {"status": "ok"}
+```
+
+- [ ] **Step 3: Update any references to `papermite_url` → `papermite_frontend_url`**
+
+Search LaunchPad backend for references to the old `settings.papermite_url` and update to `settings.papermite_frontend_url`. Check `app/api/tenants.py` and other files.
+
+Run: `grep -r "papermite_url" launchpad/backend/app/ --include="*.py"`
+
+Update any matches.
+
+- [ ] **Step 4: Verify LaunchPad starts**
+
+Run: `cd launchpad/backend && python -c "from app.main import app; print('OK')"`
+Expected: `OK`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add launchpad/backend/app/config.py launchpad/backend/app/main.py
+git commit -m "refactor(launchpad): read config and CORS from services.json"
+```
+
+---
+
+### Task 4: Update Papermite backend config and CORS
+
+**Files:**
+- Modify: `papermite/backend/app/config.py`
+- Modify: `papermite/backend/app/main.py`
+
+- [ ] **Step 1: Update Papermite config to read services.json**
+
+Replace `papermite/backend/app/config.py`:
+
+```python
+import json
+import os
+from pathlib import Path
+from pydantic_settings import BaseSettings
+
+
+def _load_services() -> dict:
+    config_path = Path(__file__).resolve().parent.parent.parent.parent / "services.json"
+    if config_path.exists():
+        with open(config_path) as f:
+            return json.load(f)["services"]
+    return {}
+
+
+_services = _load_services()
+
+
+def _svc_url(key: str) -> str:
+    svc = _services.get(key, {})
+    host = svc.get("host", "localhost")
+    port = svc.get("port", 6210)
+    return f"http://{host}:{port}"
+
+
+def _cors_origins() -> list[str]:
+    env_origins = os.environ.get("CORS_ALLOWED_ORIGINS")
+    if env_origins:
+        return [o.strip() for o in env_origins.split(",") if o.strip()]
+    return [_svc_url(k) for k in _services if k.endswith("-frontend")]
+
+
+class Settings(BaseSettings):
+    datacore_auth_url: str = _svc_url("datacore") + "/auth"
+    default_model: str = "anthropic:claude-haiku-4-5-20251001"
+    available_models: list[str] = [
+        "anthropic:claude-haiku-4-5-20251001",
+        "anthropic:claude-sonnet-4-6",
+        "openai:gpt-4.1",
+        "openai:gpt-5",
+        "ollama:llama3.2",
+    ]
+    upload_dir: Path = Path(__file__).parent.parent / "uploads"
+    lancedb_dir: Path = Path(os.environ.get(
+        "NEOAPEX_LANCEDB_DIR",
+        str(Path(__file__).resolve().parent.parent.parent.parent / "datacore" / "data" / "lancedb"),
+    ))
+    port: int = _services.get("papermite-backend", {}).get("port", 6210)
+    cors_origins: list[str] = _cors_origins()
+
+    model_config = {"env_prefix": "PAPERMITE_"}
+
+
+settings = Settings()
+```
+
+- [ ] **Step 2: Update Papermite main.py to use config CORS**
+
+Replace the CORS middleware section in `papermite/backend/app/main.py`:
+
+```python
+"""FastAPI application entry point for Papermite."""
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from app.api import auth, upload, extraction, finalize, extract
+from app.config import settings
+
+app = FastAPI(
+    title="Papermite",
+    description="Document ingestion gateway for the NeoApex platform",
+    version="0.1.0",
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=settings.cors_origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+app.include_router(auth.router, prefix="/api", tags=["auth"])
+app.include_router(upload.router, prefix="/api", tags=["upload"])
+app.include_router(extraction.router, prefix="/api", tags=["schema"])
+app.include_router(finalize.router, prefix="/api", tags=["finalize"])
+app.include_router(extract.router, prefix="/api", tags=["extract"])
+```
+
+- [ ] **Step 3: Verify Papermite starts**
+
+Run: `cd papermite/backend && python -c "from app.main import app; print('OK')"`
+Expected: `OK`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add papermite/backend/app/config.py papermite/backend/app/main.py
+git commit -m "refactor(papermite): read config and CORS from services.json"
+```
+
+---
+
+### Task 5: Update LaunchPad frontend
+
+**Files:**
+- Modify: `launchpad/frontend/vite.config.ts`
+- Modify: `launchpad/frontend/src/api/client.ts`
+- Modify: `launchpad/frontend/src/App.tsx`
+- Modify: `launchpad/frontend/src/pages/TenantSettingsPage.tsx`
+
+- [ ] **Step 1: Update vite.config.ts to read port from services.json**
+
+Replace `launchpad/frontend/vite.config.ts`:
+
+```typescript
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import services from '../../services.json'
+
+export default defineConfig({
+  plugins: [react()],
+  server: { port: services.services["launchpad-frontend"].port },
+})
+```
+
+- [ ] **Step 2: Update client.ts to use env var with services.json fallback**
+
+In `launchpad/frontend/src/api/client.ts`, replace the `BASE_URL` constant:
+
+```typescript
+import services from '../../../../services.json';
+
+const BASE_URL = import.meta.env.VITE_LAUNCHPAD_BACKEND_URL
+  || `http://${services.services["launchpad-backend"].host}:${services.services["launchpad-backend"].port}/api`;
+```
+
+- [ ] **Step 3: Create a config helper for service URLs**
+
+Create `launchpad/frontend/src/config.ts`:
+
+```typescript
+import services from '../../../services.json';
+
+function svcUrl(key: string): string {
+  const svc = services.services[key as keyof typeof services.services];
+  return `http://${svc.host}:${svc.port}`;
+}
+
+export const LAUNCHPAD_BACKEND_URL = import.meta.env.VITE_LAUNCHPAD_BACKEND_URL || svcUrl("launchpad-backend");
+export const LAUNCHPAD_API_URL = `${LAUNCHPAD_BACKEND_URL}/api`;
+export const PAPERMITE_FRONTEND_URL = import.meta.env.VITE_PAPERMITE_FRONTEND_URL || svcUrl("papermite-frontend");
+```
+
+- [ ] **Step 4: Update client.ts to use config**
+
+In `launchpad/frontend/src/api/client.ts`, replace the import and BASE_URL:
+
+```typescript
+import { LAUNCHPAD_API_URL } from "../config";
+
+const BASE_URL = LAUNCHPAD_API_URL;
+```
+
+Remove the `services.json` import added in step 2 (the config module handles it now).
+
+- [ ] **Step 5: Update App.tsx**
+
+In `launchpad/frontend/src/App.tsx`, find the hardcoded `papermiteUrl="http://localhost:5173"` and replace:
+
+```typescript
+import { PAPERMITE_FRONTEND_URL } from "./config";
+```
+
+Then change:
+```typescript
+papermiteUrl="http://localhost:5173"
+```
+to:
+```typescript
+papermiteUrl={PAPERMITE_FRONTEND_URL}
+```
+
+- [ ] **Step 6: Update TenantSettingsPage.tsx**
+
+In `launchpad/frontend/src/pages/TenantSettingsPage.tsx`, find the hardcoded redirect URL and replace:
+
+```typescript
+import { PAPERMITE_FRONTEND_URL } from "../config";
+```
+
+Then change:
+```typescript
+window.location.href = `http://localhost:5173/?tenant_id=${user.tenant_id}&token=${encodeURIComponent(token || "")}&return_url=${encodeURIComponent(returnUrl)}`;
+```
+to:
+```typescript
+window.location.href = `${PAPERMITE_FRONTEND_URL}/?tenant_id=${user.tenant_id}&token=${encodeURIComponent(token || "")}&return_url=${encodeURIComponent(returnUrl)}`;
+```
+
+- [ ] **Step 7: Verify TypeScript compiles**
+
+Run: `cd launchpad/frontend && npx tsc -b`
+Expected: No errors
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add launchpad/frontend/vite.config.ts launchpad/frontend/src/config.ts launchpad/frontend/src/api/client.ts launchpad/frontend/src/App.tsx launchpad/frontend/src/pages/TenantSettingsPage.tsx
+git commit -m "refactor(launchpad): read service URLs from services.json"
+```
+
+---
+
+### Task 6: Update Papermite frontend
+
+**Files:**
+- Modify: `papermite/frontend/vite.config.ts`
+- Create: `papermite/frontend/src/config.ts`
+- Modify: `papermite/frontend/src/api/client.ts`
+- Modify: `papermite/frontend/src/pages/LoginPage.tsx`
+
+- [ ] **Step 1: Update vite.config.ts**
+
+Replace `papermite/frontend/vite.config.ts`:
+
+```typescript
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import services from '../../services.json'
+
+export default defineConfig({
+  plugins: [react()],
+  server: { port: services.services["papermite-frontend"].port },
+})
+```
+
+- [ ] **Step 2: Create config.ts**
+
+Create `papermite/frontend/src/config.ts`:
+
+```typescript
+import services from '../../../services.json';
+
+function svcUrl(key: string): string {
+  const svc = services.services[key as keyof typeof services.services];
+  return `http://${svc.host}:${svc.port}`;
+}
+
+export const PAPERMITE_BACKEND_URL = import.meta.env.VITE_PAPERMITE_BACKEND_URL || svcUrl("papermite-backend");
+export const PAPERMITE_API_URL = `${PAPERMITE_BACKEND_URL}/api`;
+```
+
+- [ ] **Step 3: Update client.ts**
+
+In `papermite/frontend/src/api/client.ts`, replace the BASE_URL:
+
+```typescript
+import { PAPERMITE_API_URL } from "../config";
+
+const BASE_URL = PAPERMITE_API_URL;
+```
+
+Remove the old `const BASE_URL = "http://localhost:8000/api";` line.
+
+- [ ] **Step 4: Update LoginPage.tsx**
+
+In `papermite/frontend/src/pages/LoginPage.tsx`, find the hardcoded fetch URL:
+
+```typescript
+const res = await fetch("http://localhost:8000/api/login", {
+```
+
+Replace with an import from client.ts. The `login` function in `client.ts` already handles this call, so check if LoginPage uses the client function or duplicates it. If it duplicates, refactor to use the `login` function from `client.ts`. If it must stay inline, import `PAPERMITE_API_URL` from config:
+
+```typescript
+import { PAPERMITE_API_URL } from "../config";
+```
+
+Then change:
+```typescript
+const res = await fetch("http://localhost:8000/api/login", {
+```
+to:
+```typescript
+const res = await fetch(`${PAPERMITE_API_URL}/login`, {
+```
+
+- [ ] **Step 5: Verify TypeScript compiles**
+
+Run: `cd papermite/frontend && npx tsc -b`
+Expected: No errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add papermite/frontend/vite.config.ts papermite/frontend/src/config.ts papermite/frontend/src/api/client.ts papermite/frontend/src/pages/LoginPage.tsx
+git commit -m "refactor(papermite): read service URLs from services.json"
+```
+
+---
+
+### Task 7: Update AdminDash frontend
+
+**Files:**
+- Modify: `admindash/frontend/vite.config.ts`
+- Create: `admindash/frontend/src/config.ts`
+- Modify: `admindash/frontend/src/api/client.ts`
+- Modify: `admindash/frontend/src/contexts/AuthContext.tsx`
+- Modify: `admindash/frontend/src/pages/StudentsPage.tsx`
+
+- [ ] **Step 1: Update vite.config.ts**
+
+Replace `admindash/frontend/vite.config.ts`:
+
+```typescript
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import services from '../../services.json'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: services.services["admindash-frontend"].port,
+  },
+})
+```
+
+- [ ] **Step 2: Create config.ts**
+
+Create `admindash/frontend/src/config.ts`:
+
+```typescript
+import services from '../../../services.json';
+
+function svcUrl(key: string): string {
+  const svc = services.services[key as keyof typeof services.services];
+  return `http://${svc.host}:${svc.port}`;
+}
+
+export const DATACORE_URL = import.meta.env.VITE_DATACORE_URL || svcUrl("datacore");
+export const DATACORE_AUTH_URL = import.meta.env.VITE_DATACORE_AUTH_URL || `${DATACORE_URL}/auth`;
+export const PAPERMITE_BACKEND_URL = import.meta.env.VITE_PAPERMITE_BACKEND_URL || svcUrl("papermite-backend");
+```
+
+- [ ] **Step 3: Update client.ts**
+
+In `admindash/frontend/src/api/client.ts`, replace the hardcoded constants:
+
+```typescript
+import { DATACORE_URL, PAPERMITE_BACKEND_URL } from '../config.ts';
+
+const API_BASE = 'http://localhost:8080';
+const DATACORE_API_BASE = DATACORE_URL;
+const PAPERMITE_API_BASE = PAPERMITE_BACKEND_URL;
+```
+
+Note: `API_BASE` at `localhost:8080` is a legacy reference with no actual backend. Leave it for now or replace with a TODO comment — this is a pre-existing issue unrelated to this task.
+
+- [ ] **Step 4: Update AuthContext.tsx**
+
+In `admindash/frontend/src/contexts/AuthContext.tsx`, replace the hardcoded URL:
+
+```typescript
+import { DATACORE_AUTH_URL } from '../config.ts';
+```
+
+Remove the old constant:
+```typescript
+const DATACORE_AUTH_URL = 'http://localhost:8081/auth';
+```
+
+The rest of the file stays the same since it already uses `DATACORE_AUTH_URL`.
+
+- [ ] **Step 5: Update StudentsPage.tsx**
+
+In `admindash/frontend/src/pages/StudentsPage.tsx`, find the hardcoded URL in the error message at line 290:
+
+```typescript
+`Failed to load students. Is the datacore API at http://localhost:8081 running? (${err})`
+```
+
+Replace with:
+
+```typescript
+import { DATACORE_URL } from '../config.ts';
+```
+
+```typescript
+`Failed to load students. Is the datacore API at ${DATACORE_URL} running? (${err})`
+```
+
+- [ ] **Step 6: Verify TypeScript compiles**
+
+Run: `cd admindash/frontend && npx tsc -b`
+Expected: No errors
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add admindash/frontend/vite.config.ts admindash/frontend/src/config.ts admindash/frontend/src/api/client.ts admindash/frontend/src/contexts/AuthContext.tsx admindash/frontend/src/pages/StudentsPage.tsx
+git commit -m "refactor(admindash): read service URLs from services.json"
+```
+
+---
+
+### Task 8: Write README
+
+**Files:**
+- Create: `README.md`
+
+- [ ] **Step 1: Create README.md at repo root**
+
+Create `README.md`:
+
+```markdown
+# NeoApex
+
+Multi-service education/enrollment management platform.
+
+## Services
+
+| Service | Description | Port | Block |
+|---|---|---|---|
+| LaunchPad frontend | Tenant onboarding & admin UI | 6000 | 60xx |
+| LaunchPad backend | Tenant lifecycle & identity API | 6010 | 60xx |
+| AdminDash frontend | Operations dashboard UI | 6100 | 61xx |
+| Papermite frontend | Document ingestion UI | 6200 | 62xx |
+| Papermite backend | Document ingestion API | 6210 | 62xx |
+| DataCore backend | Storage, query engine & auth server | 6300 | 63xx |
+
+**Port convention:** Each service owns a 100-port block. Frontend = `X00`, backend = `X10`.
+
+## Configuration
+
+### services.json
+
+All service hostnames and ports are defined in `services.json` at the repo root:
+
+```json
+{
+  "services": {
+    "launchpad-frontend": { "host": "localhost", "port": 6000 },
+    "launchpad-backend": { "host": "localhost", "port": 6010 },
+    "admindash-frontend": { "host": "localhost", "port": 6100 },
+    "papermite-frontend": { "host": "localhost", "port": 6200 },
+    "papermite-backend": { "host": "localhost", "port": 6210 },
+    "datacore": { "host": "localhost", "port": 6300 }
+  }
+}
+```
+
+**To change a port for local development**, edit `services.json` and restart the affected services. All services read from this file — no need to update multiple config files.
+
+### Backend Configuration
+
+Python backends read `services.json` at startup. Environment variables override for production deployment.
+
+#### DataCore
+
+| Variable | Description | Default |
+|---|---|---|
+| `DATACORE_JWT_SECRET` | JWT signing secret | `neoapex-dev-secret-change-in-prod` |
+| `DATACORE_JWT_EXPIRY_HOURS` | JWT token expiry in hours | `24` |
+| `NEOAPEX_LANCEDB_DIR` | LanceDB data directory | `datacore/data/lancedb` |
+| `CORS_ALLOWED_ORIGINS` | Comma-separated CORS origins (overrides services.json) | Built from frontend entries |
+
+#### LaunchPad Backend
+
+| Variable | Description | Default |
+|---|---|---|
+| `LAUNCHPAD_DATACORE_AUTH_URL` | DataCore auth endpoint | `http://localhost:6300/auth` |
+| `LAUNCHPAD_PAPERMITE_FRONTEND_URL` | Papermite frontend URL (for redirects) | `http://localhost:6200` |
+| `LAUNCHPAD_PORT` | LaunchPad backend port | `6010` |
+| `NEOAPEX_LANCEDB_DIR` | LanceDB data directory | `datacore/data/lancedb` |
+| `CORS_ALLOWED_ORIGINS` | Comma-separated CORS origins (overrides services.json) | Built from frontend entries |
+
+#### Papermite Backend
+
+| Variable | Description | Default |
+|---|---|---|
+| `PAPERMITE_DATACORE_AUTH_URL` | DataCore auth endpoint | `http://localhost:6300/auth` |
+| `PAPERMITE_PORT` | Papermite backend port | `6210` |
+| `NEOAPEX_LANCEDB_DIR` | LanceDB data directory | `datacore/data/lancedb` |
+| `CORS_ALLOWED_ORIGINS` | Comma-separated CORS origins (overrides services.json) | Built from frontend entries |
+
+### Frontend Configuration
+
+React frontends read `services.json` at build time via Vite's JSON import. For production builds, use `VITE_` prefixed environment variables to override.
+
+#### LaunchPad Frontend
+
+| Variable | Description | Default |
+|---|---|---|
+| `VITE_LAUNCHPAD_BACKEND_URL` | LaunchPad backend base URL | `http://localhost:6010` |
+| `VITE_PAPERMITE_FRONTEND_URL` | Papermite frontend URL (for cross-app navigation) | `http://localhost:6200` |
+
+#### Papermite Frontend
+
+| Variable | Description | Default |
+|---|---|---|
+| `VITE_PAPERMITE_BACKEND_URL` | Papermite backend base URL | `http://localhost:6210` |
+
+#### AdminDash Frontend
+
+| Variable | Description | Default |
+|---|---|---|
+| `VITE_DATACORE_URL` | DataCore API base URL | `http://localhost:6300` |
+| `VITE_DATACORE_AUTH_URL` | DataCore auth endpoint | `http://localhost:6300/auth` |
+| `VITE_PAPERMITE_BACKEND_URL` | Papermite backend base URL | `http://localhost:6210` |
+
+### CORS
+
+All backends build their CORS allowed origins dynamically from the frontend entries in `services.json`. In production, set `CORS_ALLOWED_ORIGINS` as a comma-separated list to override:
+
+```bash
+CORS_ALLOWED_ORIGINS=https://app.neoapex.com,https://admin.neoapex.com
+```
+
+## Production Deployment
+
+In production (AWS ECS, Lambda, EKS, etc.), `services.json` is not used. Instead:
+
+1. **Backend services** read configuration from environment variables set in the deployment configuration (ECS task definitions, Kubernetes ConfigMaps, etc.)
+2. **Frontend apps** are built with `VITE_` env vars injected at build time in CI/CD
+3. **CORS origins** are set via `CORS_ALLOWED_ORIGINS` env var on each backend
+
+All services sit behind a reverse proxy/load balancer on port 443 in production.
+
+## Quick Start
+
+```bash
+# Start all services (from repo root)
+
+# 1. DataCore (port 6300)
+cd datacore && uv run python3 -c "
+from datacore import Store, create_app
+from datacore.auth.seed import seed_test_user
+import uvicorn
+store = Store()
+seed_test_user(store)
+app = create_app(store)
+uvicorn.run(app, host='127.0.0.1', port=6300)
+"
+
+# 2. LaunchPad backend (port 6010)
+cd launchpad/backend && uvicorn app.main:app --port 6010
+
+# 3. Papermite backend (port 6210)
+cd papermite/backend && uvicorn app.main:app --port 6210
+
+# 4. LaunchPad frontend (port 6000)
+cd launchpad/frontend && npm run dev
+
+# 5. Papermite frontend (port 6200)
+cd papermite/frontend && npm run dev
+
+# 6. AdminDash frontend (port 6100)
+cd admindash/frontend && npm run dev
+```
+
+Test login: `jane@acme.edu` / `admin123`
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: add README with service config, ports, and deployment guide"
+```
+
+---
+
+### Task 9: Verify all services start on new ports
+
+- [ ] **Step 1: Start DataCore on port 6300**
+
+Run: `cd datacore && uv run python3 -c "from datacore import Store, create_app; from datacore.auth.seed import seed_test_user; import uvicorn; store = Store(); seed_test_user(store); app = create_app(store); uvicorn.run(app, host='127.0.0.1', port=6300)"`
+
+- [ ] **Step 2: Verify DataCore auth works**
+
+```bash
+curl -s -X POST http://localhost:6300/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email":"jane@acme.edu","password":"admin123"}' | python3 -m json.tool
+```
+
+Expected: Returns token and user
+
+- [ ] **Step 3: Start LaunchPad backend on port 6010**
+
+Run: `cd launchpad/backend && uvicorn app.main:app --port 6010`
+
+- [ ] **Step 4: Start Papermite backend on port 6210**
+
+Run: `cd papermite/backend && uvicorn app.main:app --port 6210`
+
+- [ ] **Step 5: Start all frontends**
+
+```bash
+cd launchpad/frontend && npm run dev   # Should start on 6000
+cd papermite/frontend && npm run dev   # Should start on 6200
+cd admindash/frontend && npm run dev   # Should start on 6100
+```
+
+- [ ] **Step 6: Verify login on each frontend**
+
+Open each in browser and login with `jane@acme.edu` / `admin123`:
+- LaunchPad: `http://localhost:6000`
+- AdminDash: `http://localhost:6100`
+- Papermite: `http://localhost:6200`
+
+- [ ] **Step 7: Run all DataCore tests**
+
+Run: `cd datacore && uv run python -m pytest tests/ -q`
+Expected: All tests pass

--- a/docs/superpowers/specs/2026-04-05-shared-service-config-design.md
+++ b/docs/superpowers/specs/2026-04-05-shared-service-config-design.md
@@ -1,0 +1,170 @@
+# Shared Service Config: Centralized Port and URL Management
+
+**Date:** 2026-04-05
+**Status:** Approved
+
+## Problem
+
+All NeoApex services hardcode hostnames, ports, and URLs of other services they depend on. This is scattered across Python config files, TypeScript constants, CORS configurations, and Vite configs. Changing a single port requires updating multiple files across multiple projects.
+
+## Decision
+
+Introduce a single `services.json` at the repo root as the source of truth for all service hostnames and ports. All backends and frontends read from this file. Environment variables override for production deployment.
+
+## Port Mapping
+
+| Service | Port | Block |
+|---|---|---|
+| LaunchPad frontend | 6000 | 60xx |
+| LaunchPad backend | 6010 | 60xx |
+| AdminDash frontend | 6100 | 61xx |
+| Papermite frontend | 6200 | 62xx |
+| Papermite backend | 6210 | 62xx |
+| DataCore backend | 6300 | 63xx |
+
+**Pattern:** Each service owns a 100-port block. Frontend = `X00`, backend = `X10`. Customer-facing apps (LaunchPad, AdminDash) get the lowest, cleanest ports.
+
+## services.json
+
+Location: `/NeoApex/services.json` (repo root)
+
+```json
+{
+  "services": {
+    "launchpad-frontend": { "host": "localhost", "port": 6000 },
+    "launchpad-backend": { "host": "localhost", "port": 6010 },
+    "admindash-frontend": { "host": "localhost", "port": 6100 },
+    "papermite-frontend": { "host": "localhost", "port": 6200 },
+    "papermite-backend": { "host": "localhost", "port": 6210 },
+    "datacore": { "host": "localhost", "port": 6300 }
+  }
+}
+```
+
+## How Services Read the Config
+
+### Python Backends (DataCore, LaunchPad, Papermite)
+
+Each backend reads `services.json` at startup to determine:
+- URLs of services it depends on (e.g., DataCore auth URL)
+- Frontend origins for CORS configuration
+
+Environment variables override `services.json` values for production.
+
+### React Frontends (LaunchPad, Papermite, AdminDash)
+
+Vite imports `services.json` at build time. Each frontend derives:
+- API base URLs for backends it calls
+- Its own dev server port (in `vite.config.ts`)
+
+`VITE_` prefixed env vars override at build time for production.
+
+## Changes Per Service
+
+### DataCore backend
+- Read `services.json` for its own port
+- Build CORS allowed origins dynamically from all frontend entries in config
+- Remove hardcoded CORS origins from `api/__init__.py`
+
+### LaunchPad backend
+- Read `services.json` for DataCore URL, Papermite frontend URL, own port
+- Remove `datacore_auth_url`, `papermite_url`, `port` from `config.py`
+- Build CORS allowed origins from frontend entries in config
+
+### Papermite backend
+- Read `services.json` for DataCore URL, own port
+- Remove `datacore_auth_url` from `config.py`
+- Build CORS allowed origins from frontend entries in config
+
+### LaunchPad frontend
+- Read `services.json` for LaunchPad backend URL, Papermite frontend URL
+- Remove hardcoded `BASE_URL` from `client.ts`
+- Remove hardcoded Papermite URL from `App.tsx` and `TenantSettingsPage.tsx`
+- Vite dev port from config
+
+### Papermite frontend
+- Read `services.json` for Papermite backend URL
+- Remove hardcoded `BASE_URL` from `client.ts`
+- Remove hardcoded URL from `LoginPage.tsx`
+- Vite dev port from config
+
+### AdminDash frontend
+- Read `services.json` for DataCore URL, Papermite backend URL
+- Remove hardcoded URLs from `client.ts` and `AuthContext.tsx`
+- Vite dev port from config
+
+## Environment Variable Overrides
+
+### Backend Environment Variables
+
+#### DataCore
+| Variable | Description | Default (from services.json) |
+|---|---|---|
+| `DATACORE_HOST` | DataCore bind host | `localhost` |
+| `DATACORE_PORT` | DataCore bind port | `6300` |
+| `DATACORE_JWT_SECRET` | JWT signing secret | `neoapex-dev-secret-change-in-prod` |
+| `DATACORE_JWT_EXPIRY_HOURS` | JWT token expiry | `24` |
+| `NEOAPEX_LANCEDB_DIR` | LanceDB data directory | `datacore/data/lancedb` |
+
+#### LaunchPad Backend
+| Variable | Description | Default (from services.json) |
+|---|---|---|
+| `LAUNCHPAD_HOST` | LaunchPad bind host | `localhost` |
+| `LAUNCHPAD_PORT` | LaunchPad bind port | `6010` |
+| `LAUNCHPAD_DATACORE_URL` | DataCore base URL | `http://localhost:6300` |
+| `LAUNCHPAD_PAPERMITE_FRONTEND_URL` | Papermite frontend URL (for redirects) | `http://localhost:6200` |
+| `NEOAPEX_LANCEDB_DIR` | LanceDB data directory | `datacore/data/lancedb` |
+
+#### Papermite Backend
+| Variable | Description | Default (from services.json) |
+|---|---|---|
+| `PAPERMITE_HOST` | Papermite bind host | `localhost` |
+| `PAPERMITE_PORT` | Papermite bind port | `6210` |
+| `PAPERMITE_DATACORE_URL` | DataCore base URL | `http://localhost:6300` |
+| `NEOAPEX_LANCEDB_DIR` | LanceDB data directory | `datacore/data/lancedb` |
+
+### Frontend Environment Variables (VITE_ prefix)
+
+#### LaunchPad Frontend
+| Variable | Description | Default (from services.json) |
+|---|---|---|
+| `VITE_LAUNCHPAD_BACKEND_URL` | LaunchPad backend API URL | `http://localhost:6010` |
+| `VITE_PAPERMITE_FRONTEND_URL` | Papermite frontend URL (for redirects) | `http://localhost:6200` |
+
+#### Papermite Frontend
+| Variable | Description | Default (from services.json) |
+|---|---|---|
+| `VITE_PAPERMITE_BACKEND_URL` | Papermite backend API URL | `http://localhost:6210` |
+
+#### AdminDash Frontend
+| Variable | Description | Default (from services.json) |
+|---|---|---|
+| `VITE_DATACORE_URL` | DataCore API URL | `http://localhost:6300` |
+| `VITE_PAPERMITE_BACKEND_URL` | Papermite backend API URL | `http://localhost:6210` |
+| `VITE_DATACORE_AUTH_URL` | DataCore auth URL | `http://localhost:6300/auth` |
+
+### CORS Configuration
+
+All backends build their CORS allowed origins dynamically by reading the frontend entries from `services.json`:
+
+```python
+# Example: builds ["http://localhost:6000", "http://localhost:6100", "http://localhost:6200"]
+frontend_services = ["launchpad-frontend", "admindash-frontend", "papermite-frontend"]
+cors_origins = [f"http://{svc['host']}:{svc['port']}" for name, svc in config["services"].items() if name in frontend_services]
+```
+
+In production, CORS origins can be overridden via environment variable:
+| Variable | Description |
+|---|---|
+| `CORS_ALLOWED_ORIGINS` | Comma-separated list of allowed origins (overrides services.json) |
+
+## README
+
+A `README.md` at the repo root documents:
+- Service port mapping table
+- `services.json` format and location
+- How to change ports for local development
+- Backend env var table per service
+- Frontend env var table per service (VITE_ prefix)
+- Production deployment: how env vars override `services.json`
+- CORS configuration

--- a/launchpad/backend/app/config.py
+++ b/launchpad/backend/app/config.py
@@ -1,17 +1,45 @@
 """Launchpad configuration — settings and datacore path."""
+import json
 import os
 from pathlib import Path
 from pydantic_settings import BaseSettings
 
+
+def _load_services() -> dict:
+    config_path = Path(__file__).resolve().parent.parent.parent.parent / "services.json"
+    if config_path.exists():
+        with open(config_path) as f:
+            return json.load(f)["services"]
+    return {}
+
+
+_services = _load_services()
+
+
+def _svc_url(key: str) -> str:
+    svc = _services.get(key, {})
+    host = svc.get("host", "localhost")
+    port = svc.get("port", 6010)
+    return f"http://{host}:{port}"
+
+
+def _cors_origins() -> list[str]:
+    env_origins = os.environ.get("CORS_ALLOWED_ORIGINS")
+    if env_origins:
+        return [o.strip() for o in env_origins.split(",") if o.strip()]
+    return [_svc_url(k) for k in _services if k.endswith("-frontend")]
+
+
 class Settings(BaseSettings):
-    datacore_auth_url: str = "http://localhost:8081/auth"
+    datacore_auth_url: str = _svc_url("datacore") + "/auth"
     datacore_store_path: Path = Path(os.environ.get(
         "NEOAPEX_LANCEDB_DIR",
         str(Path(__file__).resolve().parent.parent.parent.parent
             / "datacore" / "data" / "lancedb"),
     ))
-    papermite_url: str = "http://localhost:5173"
-    port: int = 8001
+    papermite_frontend_url: str = _svc_url("papermite-frontend")
+    port: int = _services.get("launchpad-backend", {}).get("port", 6010)
+    cors_origins: list[str] = _cors_origins()
     model_config = {"env_prefix": "LAUNCHPAD_"}
 
 settings = Settings()

--- a/launchpad/backend/app/main.py
+++ b/launchpad/backend/app/main.py
@@ -3,6 +3,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.api import auth, tenants, users
+from app.config import settings
 
 app = FastAPI(
     title="Launchpad",
@@ -12,8 +13,7 @@ app = FastAPI(
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[],
-    allow_origin_regex=r"http://[^/]+:(5173|5174|5175|5176)",
+    allow_origins=settings.cors_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/launchpad/frontend/src/App.tsx
+++ b/launchpad/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { BrowserRouter, Routes, Route, Link, Navigate } from "react-router-dom";
 import type { User, OnboardingStatus } from "./types/models";
 import { getCurrentUser, getStoredToken, storeToken, clearToken, getOnboardingStatus } from "./api/client";
+import { PAPERMITE_FRONTEND_URL } from "./config";
 import OnboardingPage from "./pages/OnboardingPage";
 import LoginPage from "./pages/LoginPage";
 import SignupPage from "./pages/SignupPage";
@@ -66,7 +67,7 @@ export default function App() {
       <OnboardingPage
         user={user}
         onboarding={onboarding}
-        papermiteUrl="http://localhost:5173"
+        papermiteUrl={PAPERMITE_FRONTEND_URL}
         onComplete={() => {
           getOnboardingStatus(user.tenant_id).then(setOnboarding);
         }}

--- a/launchpad/frontend/src/api/client.ts
+++ b/launchpad/frontend/src/api/client.ts
@@ -1,6 +1,7 @@
 import type { User, OnboardingStatus } from "../types/models";
+import { LAUNCHPAD_API_URL } from "../config";
 
-const BASE_URL = "http://localhost:8001/api";
+const BASE_URL = LAUNCHPAD_API_URL;
 const TOKEN_KEY = "neoapex_token";
 
 export function getStoredToken(): string | null {

--- a/launchpad/frontend/src/config.ts
+++ b/launchpad/frontend/src/config.ts
@@ -1,0 +1,10 @@
+import services from '../../../services.json';
+
+function svcUrl(key: string): string {
+  const svc = services.services[key as keyof typeof services.services];
+  return `http://${svc.host}:${svc.port}`;
+}
+
+export const LAUNCHPAD_BACKEND_URL = import.meta.env.VITE_LAUNCHPAD_BACKEND_URL || svcUrl("launchpad-backend");
+export const LAUNCHPAD_API_URL = `${LAUNCHPAD_BACKEND_URL}/api`;
+export const PAPERMITE_FRONTEND_URL = import.meta.env.VITE_PAPERMITE_FRONTEND_URL || svcUrl("papermite-frontend");

--- a/launchpad/frontend/src/pages/TenantSettingsPage.tsx
+++ b/launchpad/frontend/src/pages/TenantSettingsPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import type { User, EntityModelDefinition } from "../types/models";
 import { getTenantModel, getTenantProfile, updateTenantProfile, getTenantModelInfo, getStoredToken } from "../api/client";
+import { PAPERMITE_FRONTEND_URL } from "../config";
 import DynamicEntityForm from "../components/DynamicEntityForm";
 
 interface Props { user: User; }
@@ -28,7 +29,7 @@ export default function TenantSettingsPage({ user }: Props) {
   const handleEditModel = () => {
     const token = getStoredToken();
     const returnUrl = `${window.location.origin}/settings/tenant`;
-    window.location.href = `http://localhost:5173/?tenant_id=${user.tenant_id}&token=${encodeURIComponent(token || "")}&return_url=${encodeURIComponent(returnUrl)}`;
+    window.location.href = `${PAPERMITE_FRONTEND_URL}/?tenant_id=${user.tenant_id}&token=${encodeURIComponent(token || "")}&return_url=${encodeURIComponent(returnUrl)}`;
   };
 
   if (!model) return <p>Loading...</p>;

--- a/launchpad/frontend/tsconfig.app.json
+++ b/launchpad/frontend/tsconfig.app.json
@@ -11,6 +11,7 @@
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
     "verbatimModuleSyntax": true,
     "moduleDetection": "force",
     "noEmit": true,

--- a/launchpad/frontend/tsconfig.node.json
+++ b/launchpad/frontend/tsconfig.node.json
@@ -10,6 +10,7 @@
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
     "verbatimModuleSyntax": true,
     "moduleDetection": "force",
     "noEmit": true,

--- a/launchpad/frontend/vite.config.ts
+++ b/launchpad/frontend/vite.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import services from '../../services.json'
 
 export default defineConfig({
   plugins: [react()],
-  server: { port: 5175 },
+  server: { port: services.services["launchpad-frontend"].port },
 })

--- a/papermite/backend/app/config.py
+++ b/papermite/backend/app/config.py
@@ -1,10 +1,36 @@
+import json
 import os
 from pathlib import Path
 from pydantic_settings import BaseSettings
 
 
+def _load_services() -> dict:
+    config_path = Path(__file__).resolve().parent.parent.parent.parent / "services.json"
+    if config_path.exists():
+        with open(config_path) as f:
+            return json.load(f)["services"]
+    return {}
+
+
+_services = _load_services()
+
+
+def _svc_url(key: str) -> str:
+    svc = _services.get(key, {})
+    host = svc.get("host", "localhost")
+    port = svc.get("port", 6210)
+    return f"http://{host}:{port}"
+
+
+def _cors_origins() -> list[str]:
+    env_origins = os.environ.get("CORS_ALLOWED_ORIGINS")
+    if env_origins:
+        return [o.strip() for o in env_origins.split(",") if o.strip()]
+    return [_svc_url(k) for k in _services if k.endswith("-frontend")]
+
+
 class Settings(BaseSettings):
-    datacore_auth_url: str = "http://localhost:8081/auth"
+    datacore_auth_url: str = _svc_url("datacore") + "/auth"
     default_model: str = "anthropic:claude-haiku-4-5-20251001"
     available_models: list[str] = [
         "anthropic:claude-haiku-4-5-20251001",
@@ -18,6 +44,8 @@ class Settings(BaseSettings):
         "NEOAPEX_LANCEDB_DIR",
         str(Path(__file__).resolve().parent.parent.parent.parent / "datacore" / "data" / "lancedb"),
     ))
+    port: int = _services.get("papermite-backend", {}).get("port", 6210)
+    cors_origins: list[str] = _cors_origins()
 
     model_config = {"env_prefix": "PAPERMITE_"}
 

--- a/papermite/backend/app/main.py
+++ b/papermite/backend/app/main.py
@@ -3,6 +3,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.api import auth, upload, extraction, finalize, extract
+from app.config import settings
 
 app = FastAPI(
     title="Papermite",
@@ -12,7 +13,7 @@ app = FastAPI(
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:5173", "http://localhost:5174"],
+    allow_origins=settings.cors_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/papermite/frontend/src/api/client.ts
+++ b/papermite/frontend/src/api/client.ts
@@ -10,7 +10,9 @@ import type {
   TestUser,
 } from "../types/models";
 
-const BASE_URL = "http://localhost:8000/api";
+import { PAPERMITE_API_URL } from "../config";
+
+const BASE_URL = PAPERMITE_API_URL;
 const TOKEN_KEY = "neoapex_token";
 
 // ─── Token helpers ────────────────────────────────────────────

--- a/papermite/frontend/src/config.ts
+++ b/papermite/frontend/src/config.ts
@@ -1,0 +1,9 @@
+import services from '../../../services.json';
+
+function svcUrl(key: string): string {
+  const svc = services.services[key as keyof typeof services.services];
+  return `http://${svc.host}:${svc.port}`;
+}
+
+export const PAPERMITE_BACKEND_URL = import.meta.env.VITE_PAPERMITE_BACKEND_URL || svcUrl("papermite-backend");
+export const PAPERMITE_API_URL = `${PAPERMITE_BACKEND_URL}/api`;

--- a/papermite/frontend/src/pages/LoginPage.tsx
+++ b/papermite/frontend/src/pages/LoginPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import type { TestUser } from "../types/models";
+import { PAPERMITE_API_URL } from "../config";
 import "./LoginPage.css";
 
 interface Props {
@@ -26,7 +27,7 @@ export default function LoginPage({ onLogin }: Props) {
     setError("");
 
     try {
-      const res = await fetch("http://localhost:8000/api/login", {
+      const res = await fetch(`${PAPERMITE_API_URL}/login`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email: email.trim(), password }),

--- a/papermite/frontend/tsconfig.app.json
+++ b/papermite/frontend/tsconfig.app.json
@@ -22,7 +22,8 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "resolveJsonModule": true
   },
   "include": ["src"]
 }

--- a/papermite/frontend/tsconfig.node.json
+++ b/papermite/frontend/tsconfig.node.json
@@ -20,7 +20,8 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "resolveJsonModule": true
   },
   "include": ["vite.config.ts"]
 }

--- a/papermite/frontend/vite.config.ts
+++ b/papermite/frontend/vite.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import services from '../../services.json'
 
-// https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: { port: services.services["papermite-frontend"].port },
 })

--- a/services.json
+++ b/services.json
@@ -1,0 +1,10 @@
+{
+  "services": {
+    "launchpad-frontend": { "host": "localhost", "port": 6000 },
+    "launchpad-backend": { "host": "localhost", "port": 6010 },
+    "admindash-frontend": { "host": "localhost", "port": 6100 },
+    "papermite-frontend": { "host": "localhost", "port": 6200 },
+    "papermite-backend": { "host": "localhost", "port": 6210 },
+    "datacore": { "host": "localhost", "port": 6300 }
+  }
+}

--- a/start-services.sh
+++ b/start-services.sh
@@ -1,0 +1,313 @@
+#!/usr/bin/env bash
+#
+# Start NeoApex services.
+#
+# Usage:
+#   ./start-services.sh          # Interactive mode (default)
+#   ./start-services.sh --yes    # Non-interactive: kill existing, start all
+#   ./start-services.sh -y       # Same as --yes
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# ── Parse args ────────────────────────────────────────────────
+
+INTERACTIVE=true
+for arg in "$@"; do
+  case "$arg" in
+    -y|--yes) INTERACTIVE=false ;;
+    -h|--help)
+      echo "Usage: $0 [--yes|-y]"
+      echo "  --yes, -y   Non-interactive mode: kill existing services and start all"
+      exit 0
+      ;;
+    *) echo "Unknown option: $arg"; exit 1 ;;
+  esac
+done
+
+# ── Read ports from services.json ─────────────────────────────
+
+if ! command -v python3 &>/dev/null; then
+  echo "Error: python3 is required"
+  exit 1
+fi
+
+read_port() {
+  python3 -c "import json; print(json.load(open('services.json'))['services']['$1']['port'])"
+}
+
+DATACORE_PORT=$(read_port "datacore")
+LAUNCHPAD_BE_PORT=$(read_port "launchpad-backend")
+PAPERMITE_BE_PORT=$(read_port "papermite-backend")
+LAUNCHPAD_FE_PORT=$(read_port "launchpad-frontend")
+PAPERMITE_FE_PORT=$(read_port "papermite-frontend")
+ADMINDASH_FE_PORT=$(read_port "admindash-frontend")
+
+# Service definitions: name, port, type (backend/frontend)
+SERVICES=(
+  "datacore:$DATACORE_PORT:backend"
+  "launchpad-backend:$LAUNCHPAD_BE_PORT:backend"
+  "papermite-backend:$PAPERMITE_BE_PORT:backend"
+  "launchpad-frontend:$LAUNCHPAD_FE_PORT:frontend"
+  "papermite-frontend:$PAPERMITE_FE_PORT:frontend"
+  "admindash-frontend:$ADMINDASH_FE_PORT:frontend"
+)
+
+# ── Helpers ───────────────────────────────────────────────────
+
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+RED='\033[0;31m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+info()  { echo -e "${CYAN}[info]${NC}  $1"; }
+ok()    { echo -e "${GREEN}[ok]${NC}    $1"; }
+warn()  { echo -e "${YELLOW}[warn]${NC}  $1"; }
+fail()  { echo -e "${RED}[fail]${NC}  $1"; }
+
+find_pid_on_port() {
+  lsof -ti :"$1" 2>/dev/null || true
+}
+
+kill_port() {
+  local port=$1
+  local pids
+  pids=$(find_pid_on_port "$port")
+  if [ -n "$pids" ]; then
+    echo "$pids" | xargs kill 2>/dev/null || true
+    sleep 0.5
+    # Force kill if still running
+    pids=$(find_pid_on_port "$port")
+    if [ -n "$pids" ]; then
+      echo "$pids" | xargs kill -9 2>/dev/null || true
+      sleep 0.3
+    fi
+  fi
+}
+
+wait_for_port() {
+  local port=$1
+  local name=$2
+  local max_wait=15
+  local waited=0
+  while [ $waited -lt $max_wait ]; do
+    if lsof -ti :"$port" &>/dev/null; then
+      return 0
+    fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+  return 1
+}
+
+# ── Step 1: Check for running services ────────────────────────
+
+echo ""
+echo -e "${BOLD}Checking for running services...${NC}"
+echo ""
+
+RUNNING=()
+for entry in "${SERVICES[@]}"; do
+  IFS=: read -r name port type <<< "$entry"
+  pid=$(find_pid_on_port "$port")
+  if [ -n "$pid" ]; then
+    RUNNING+=("$entry")
+    warn "$name is running on port $port (PID: $(echo $pid | tr '\n' ' '))"
+  fi
+done
+
+if [ ${#RUNNING[@]} -eq 0 ]; then
+  ok "No services currently running"
+else
+  echo ""
+  if $INTERACTIVE; then
+    echo -e "${BOLD}Running services found. What would you like to do?${NC}"
+    echo "  1) Kill all running services"
+    echo "  2) Choose which to kill"
+    echo "  3) Skip (leave running)"
+    read -rp "Choice [1/2/3]: " choice
+    echo ""
+
+    case "$choice" in
+      1)
+        for entry in "${RUNNING[@]}"; do
+          IFS=: read -r name port type <<< "$entry"
+          info "Stopping $name on port $port..."
+          kill_port "$port"
+          ok "Stopped $name"
+        done
+        ;;
+      2)
+        for entry in "${RUNNING[@]}"; do
+          IFS=: read -r name port type <<< "$entry"
+          read -rp "Kill $name on port $port? [y/N]: " yn
+          if [[ "$yn" =~ ^[Yy] ]]; then
+            info "Stopping $name on port $port..."
+            kill_port "$port"
+            ok "Stopped $name"
+          else
+            info "Skipping $name"
+          fi
+        done
+        ;;
+      3)
+        info "Leaving running services as-is"
+        ;;
+      *)
+        info "Invalid choice, skipping"
+        ;;
+    esac
+  else
+    info "Non-interactive mode: stopping all running services..."
+    for entry in "${RUNNING[@]}"; do
+      IFS=: read -r name port type <<< "$entry"
+      info "Stopping $name on port $port..."
+      kill_port "$port"
+      ok "Stopped $name"
+    done
+  fi
+fi
+
+# ── Step 2: Start services ───────────────────────────────────
+
+echo ""
+echo -e "${BOLD}Starting services...${NC}"
+echo ""
+
+LOG_DIR="$SCRIPT_DIR/.logs"
+mkdir -p "$LOG_DIR"
+
+start_service() {
+  local name=$1
+  local port=$2
+
+  # Skip if already running
+  if lsof -ti :"$port" &>/dev/null; then
+    warn "$name already running on port $port, skipping"
+    return 0
+  fi
+
+  local log_file="$LOG_DIR/$name.log"
+
+  case "$name" in
+    datacore)
+      info "Starting $name on port $port..."
+      cd "$SCRIPT_DIR/datacore"
+      uv run python3 -c "
+from datacore import Store, create_app
+from datacore.auth.seed import seed_test_user
+import uvicorn
+store = Store()
+seed_test_user(store)
+app = create_app(store)
+uvicorn.run(app, host='127.0.0.1', port=$port)
+" > "$log_file" 2>&1 &
+      cd "$SCRIPT_DIR"
+      ;;
+    launchpad-backend)
+      info "Starting $name on port $port..."
+      cd "$SCRIPT_DIR/launchpad/backend"
+      source "$SCRIPT_DIR/launchpad/.venv/bin/activate" 2>/dev/null || true
+      uvicorn app.main:app --port "$port" > "$log_file" 2>&1 &
+      cd "$SCRIPT_DIR"
+      ;;
+    papermite-backend)
+      info "Starting $name on port $port..."
+      cd "$SCRIPT_DIR/papermite/backend"
+      source "$SCRIPT_DIR/papermite/.venv/bin/activate" 2>/dev/null || true
+      uvicorn app.main:app --port "$port" > "$log_file" 2>&1 &
+      cd "$SCRIPT_DIR"
+      ;;
+    launchpad-frontend)
+      info "Starting $name on port $port..."
+      cd "$SCRIPT_DIR/launchpad/frontend"
+      npm run dev > "$log_file" 2>&1 &
+      cd "$SCRIPT_DIR"
+      ;;
+    papermite-frontend)
+      info "Starting $name on port $port..."
+      cd "$SCRIPT_DIR/papermite/frontend"
+      npm run dev > "$log_file" 2>&1 &
+      cd "$SCRIPT_DIR"
+      ;;
+    admindash-frontend)
+      info "Starting $name on port $port..."
+      cd "$SCRIPT_DIR/admindash/frontend"
+      npm run dev > "$log_file" 2>&1 &
+      cd "$SCRIPT_DIR"
+      ;;
+  esac
+
+  if wait_for_port "$port" "$name"; then
+    ok "$name started on port $port"
+  else
+    fail "$name failed to start on port $port (check $log_file)"
+  fi
+}
+
+if $INTERACTIVE; then
+  echo "Which services would you like to start?"
+  echo "  1) All services"
+  echo "  2) Choose individually"
+  read -rp "Choice [1/2]: " start_choice
+  echo ""
+
+  case "$start_choice" in
+    1)
+      for entry in "${SERVICES[@]}"; do
+        IFS=: read -r name port type <<< "$entry"
+        start_service "$name" "$port"
+      done
+      ;;
+    2)
+      for entry in "${SERVICES[@]}"; do
+        IFS=: read -r name port type <<< "$entry"
+        read -rp "Start $name on port $port? [Y/n]: " yn
+        if [[ ! "$yn" =~ ^[Nn] ]]; then
+          start_service "$name" "$port"
+        else
+          info "Skipping $name"
+        fi
+      done
+      ;;
+    *)
+      info "Invalid choice, starting all"
+      for entry in "${SERVICES[@]}"; do
+        IFS=: read -r name port type <<< "$entry"
+        start_service "$name" "$port"
+      done
+      ;;
+  esac
+else
+  for entry in "${SERVICES[@]}"; do
+    IFS=: read -r name port type <<< "$entry"
+    start_service "$name" "$port"
+  done
+fi
+
+# ── Summary ──────────────────────────────────────────────────
+
+echo ""
+echo -e "${BOLD}Service Status${NC}"
+echo "┌────────────────────────┬──────┬─────────┐"
+echo "│ Service                │ Port │ Status  │"
+echo "├────────────────────────┼──────┼─────────┤"
+
+for entry in "${SERVICES[@]}"; do
+  IFS=: read -r name port type <<< "$entry"
+  if lsof -ti :"$port" &>/dev/null; then
+    status="${GREEN}running${NC}"
+  else
+    status="${RED}stopped${NC}"
+  fi
+  printf "│ %-22s │ %4s │ %b │\n" "$name" "$port" "$status"
+done
+
+echo "└────────────────────────┴──────┴─────────┘"
+echo ""
+echo -e "Logs: ${CYAN}$LOG_DIR/${NC}"
+echo ""

--- a/start-services.sh
+++ b/start-services.sh
@@ -3,9 +3,9 @@
 # Start NeoApex services.
 #
 # Usage:
-#   ./start-services.sh          # Interactive mode (default)
-#   ./start-services.sh --yes    # Non-interactive: kill existing, start all
-#   ./start-services.sh -y       # Same as --yes
+#   ./start-services.sh          # Non-interactive (default): kill existing, start all
+#   ./start-services.sh -i       # Interactive mode: choose which to kill/start
+#   ./start-services.sh --interactive  # Same as -i
 #
 set -euo pipefail
 
@@ -14,13 +14,13 @@ cd "$SCRIPT_DIR"
 
 # ── Parse args ────────────────────────────────────────────────
 
-INTERACTIVE=true
+INTERACTIVE=false
 for arg in "$@"; do
   case "$arg" in
-    -y|--yes) INTERACTIVE=false ;;
+    -i|--interactive) INTERACTIVE=true ;;
     -h|--help)
-      echo "Usage: $0 [--yes|-y]"
-      echo "  --yes, -y   Non-interactive mode: kill existing services and start all"
+      echo "Usage: $0 [-i|--interactive]"
+      echo "  -i, --interactive   Interactive mode: choose which services to kill/start"
       exit 0
       ;;
     *) echo "Unknown option: $arg"; exit 1 ;;


### PR DESCRIPTION
## Summary

- **Single `services.json`** at repo root defines all service hostnames and ports — change once, all services pick it up
- **New port mapping** using `6xxx` range: LaunchPad (6000/6010), AdminDash (6100), Papermite (6200/6210), DataCore (6300)
- **CORS origins built dynamically** from frontend entries in services.json on all three backends
- **Environment variable overrides** for production deployment (`CORS_ALLOWED_ORIGINS`, `VITE_*` prefixed vars)
- **README** with full port mapping, env var tables per service, CORS config, and deployment guide

## Changes per service

| Service | What changed |
|---|---|
| DataCore | CORS reads from services.json, `CORS_ALLOWED_ORIGINS` env override |
| LaunchPad backend | Config reads services.json for DataCore URL, Papermite URL, CORS |
| Papermite backend | Config reads services.json for DataCore URL, CORS |
| LaunchPad frontend | `config.ts` with `VITE_*` overrides, vite port from config |
| Papermite frontend | `config.ts` with `VITE_*` overrides, vite port from config |
| AdminDash frontend | `config.ts` with `VITE_*` overrides, vite port from config |

## Test plan

- [x] 175 DataCore tests passing (CORS tests updated to new ports)
- [x] Zero hardcoded old ports remaining in project code
- [ ] Start all services on new ports and verify login
- [ ] Verify CORS works across all frontend→backend combinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)