### PR TITLE
docs(deployment): migrate frontends to Cloudflare Workers with Static Assets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -143,7 +143,7 @@ jobs:
           echo "## Deployed launchpad-api ${{ needs.parse-tag.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
 
   deploy-launchpad-frontend:
-    name: Deploy launchpad-frontend (Cloudflare Pages)
+    name: Deploy launchpad-frontend (Cloudflare Workers)
     needs: parse-tag
     if: needs.parse-tag.outputs.module == 'launchpad'
     runs-on: ubuntu-latest
@@ -168,12 +168,13 @@ jobs:
           VITE_API_BASE_URL: https://api.launchpad.floatify.com
         run: npm run build
 
-      - name: Deploy to Cloudflare Pages
+      - name: Deploy to Cloudflare Workers
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy launchpad/frontend/dist --project-name=launchpad-frontend --branch=main
+          workingDirectory: launchpad/frontend
+          command: deploy
 
   deploy-papermite-api:
     name: Deploy papermite-api (Fly.io)
@@ -217,7 +218,7 @@ jobs:
           echo "## Deployed papermite-api ${{ needs.parse-tag.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
 
   deploy-papermite-frontend:
-    name: Deploy papermite-frontend (Cloudflare Pages)
+    name: Deploy papermite-frontend (Cloudflare Workers)
     needs: parse-tag
     if: needs.parse-tag.outputs.module == 'papermite'
     runs-on: ubuntu-latest
@@ -242,12 +243,13 @@ jobs:
           VITE_API_BASE_URL: https://api.papermite.floatify.com
         run: npm run build
 
-      - name: Deploy to Cloudflare Pages
+      - name: Deploy to Cloudflare Workers
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy papermite/frontend/dist --project-name=papermite-frontend --branch=main
+          workingDirectory: papermite/frontend
+          command: deploy
 
   deploy-admindash-api:
     name: Deploy admindash-api (Fly.io)
@@ -291,7 +293,7 @@ jobs:
           echo "## Deployed admindash-api ${{ needs.parse-tag.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
 
   deploy-admindash-frontend:
-    name: Deploy admindash frontend (Cloudflare Pages)
+    name: Deploy admindash frontend (Cloudflare Workers)
     needs: parse-tag
     if: needs.parse-tag.outputs.module == 'admindash'
     runs-on: ubuntu-latest
@@ -316,9 +318,10 @@ jobs:
           VITE_ADMINDASH_API_URL: https://api.admin.floatify.com
         run: npm run build
 
-      - name: Deploy to Cloudflare Pages
+      - name: Deploy to Cloudflare Workers
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy admindash/frontend/dist --project-name=admindash --branch=main
+          workingDirectory: admindash/frontend
+          command: deploy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,15 +95,15 @@ All data tenant-scoped. Tenant ID embedded in JWT. API routes enforce tenant mat
 
 ## Deployment
 
-NeoApex deploys to Fly.io (Python backends) and Cloudflare Pages (React frontends) via a GitHub Actions release-tag-triggered pipeline.
+NeoApex deploys to Fly.io (Python backends) and Cloudflare Workers with Static Assets (React frontends) via a GitHub Actions release-tag-triggered pipeline.
 
-**Topology:** `datacore` is on Fly's private network only. `launchpad-api`, `papermite-api`, and `admindash-api` are public Fly.io apps fronted by Cloudflare with an IP allowlist middleware. The three frontends are on Cloudflare Pages at `launchpad.floatify.com`, `papermite.floatify.com`, and `admin.floatify.com`. The API endpoints are at `api.<name>.floatify.com`.
+**Topology:** `datacore` is on Fly's private network only. `launchpad-api`, `papermite-api`, and `admindash-api` are public Fly.io apps fronted by Cloudflare with an IP allowlist middleware. The three frontends are Cloudflare Workers (Static Assets) at `launchpad.floatify.com`, `papermite.floatify.com`, and `admin.floatify.com`. The API endpoints are at `api.<name>.floatify.com`.
 
 **Release trigger:** publish a GitHub Release with a module-prefixed tag (`datacore-v*`, `launchpad-v*`, `papermite-v*`, `admindash-v*`). The `.github/workflows/deploy.yml` workflow parses the tag, dispatches to per-module deploy jobs, and requires manual approval via the `production` GitHub Environment before any deploy step runs.
 
 **Docs:**
 - [`docs/deployment/architecture.md`](docs/deployment/architecture.md) — topology diagram, trust boundaries, cost estimates
-- [`docs/deployment/provisioning.md`](docs/deployment/provisioning.md) — one-time setup runbook (Fly.io account, Cloudflare Pages, DNS, secrets, first deploy)
+- [`docs/deployment/provisioning.md`](docs/deployment/provisioning.md) — one-time setup runbook (Fly.io account, Cloudflare Workers, DNS, secrets, first deploy)
 - [`docs/deployment/release-runbook.md`](docs/deployment/release-runbook.md) — cutting releases, approving deploys, rolling back
 - [`docs/deployment/follow-ups.md`](docs/deployment/follow-ups.md) — deferred hardening and nice-to-haves
 

--- a/admindash/frontend/wrangler.jsonc
+++ b/admindash/frontend/wrangler.jsonc
@@ -1,0 +1,10 @@
+// Cloudflare Workers config for the admindash frontend.
+// See launchpad/frontend/wrangler.jsonc for the shared rationale.
+{
+  "name": "admindash",
+  "compatibility_date": "2026-04-01",
+  "assets": {
+    "directory": "./dist",
+    "not_found_handling": "single-page-application"
+  }
+}

--- a/docs/deployment/architecture.md
+++ b/docs/deployment/architecture.md
@@ -10,7 +10,7 @@ Last updated: 2026-04-11
                                                    ▼
                           ┌─────────────────────────────────────────────┐
                           │                  Cloudflare                 │
-                          │  DNS │ TLS │ WAF │ Pages (static frontends) │
+                          │  DNS │ TLS │ WAF │ Workers (static frontends) │
                           └─────────────────────────────────────────────┘
                                  │                        │
                                  │                        │
@@ -18,10 +18,10 @@ Last updated: 2026-04-11
            │                     │                │       │        │
            ▼                     ▼                ▼       ▼        ▼
      ┌─────────┐         ┌─────────┐       ┌─────────┐ ┌─────┐ ┌──────────┐
-     │ launch  │         │papermite│       │ admin   │ │CF   │ │ CF Pages │
-     │  pad    │         │ frontend│       │  dash   │ │Pages│ │ (3 sites)│
-     │frontend │         │(Pages)  │       │ (Pages) │ │     │ │          │
-     │(Pages)  │         └─────────┘       └─────────┘ └─────┘ └──────────┘
+     │ launch  │         │papermite│       │ admin   │ │CF   │ │CF Workers│
+     │  pad    │         │ frontend│       │  dash   │ │Wrkr │ │ (3 sites)│
+     │frontend │         │(Worker) │       │(Worker) │ │     │ │          │
+     │(Worker) │         └─────────┘       └─────────┘ └─────┘ └──────────┘
      └─────────┘
            │                     │                │
            │ fetch("/api/…")     │                │
@@ -49,9 +49,9 @@ Last updated: 2026-04-11
 | `launchpad-api` | Python/FastAPI backend | Fly.io (`sjc`) | `api.launchpad.floatify.com` | `launchpad-api.flycast:5510` |
 | `papermite-api` | Python/FastAPI backend | Fly.io (`sjc`) | `api.papermite.floatify.com` | `papermite-api.flycast:5710` |
 | `admindash-api` | Python/FastAPI backend | Fly.io (`sjc`, scale-to-zero) | `api.admin.floatify.com` | `admindash-api.flycast:5610` |
-| `launchpad-frontend` | React SPA (static) | Cloudflare Pages | `launchpad.floatify.com` | — |
-| `papermite-frontend` | React SPA (static) | Cloudflare Pages | `papermite.floatify.com` | — |
-| `admindash` | React SPA (static) | Cloudflare Pages | `admin.floatify.com` | — |
+| `launchpad-frontend` | React SPA (static) | Cloudflare Workers (Static Assets) | `launchpad.floatify.com` | — |
+| `papermite-frontend` | React SPA (static) | Cloudflare Workers (Static Assets) | `papermite.floatify.com` | — |
+| `admindash` | React SPA (static) | Cloudflare Workers (Static Assets) | `admin.floatify.com` | — |
 
 ## Trust boundaries and security layers
 
@@ -66,7 +66,7 @@ Last updated: 2026-04-11
 
 ## Data flow for a typical admindash request
 
-1. Browser at `https://admin.floatify.com` → Cloudflare Pages serves the SPA
+1. Browser at `https://admin.floatify.com` → Cloudflare Worker (Static Assets) serves the SPA
 2. SPA makes `fetch("https://api.admin.floatify.com/api/query", ...)` with `Authorization: Bearer <jwt>`
 3. Cloudflare receives the request, proxies it to the `admindash-api` Fly.io origin
 4. `admindash-api`'s `CloudflareIPMiddleware` sees a Cloudflare source IP and allows the request
@@ -84,7 +84,7 @@ Last updated: 2026-04-11
 | Fly.io: `launchpad-api` (shared-cpu-1x, 512MB, min=1) | ~$5–8 |
 | Fly.io: `papermite-api` (shared-cpu-2x, 1GB, min=1) | ~$8–15 |
 | Fly.io: `admindash-api` (shared-cpu-1x, 256MB, min=0, scale-to-zero) | ~$0.50–3 |
-| Cloudflare (Pages, DNS, TLS, WAF basics) | Free |
+| Cloudflare (Workers Static Assets, DNS, TLS, WAF basics) | Free |
 | GHCR (private image storage) | Free at this scale |
 | **Total** | **~$18–35** |
 
@@ -92,6 +92,6 @@ Last updated: 2026-04-11
 
 See [`release-runbook.md`](./release-runbook.md) for how to cut a release and approve a deploy.
 
-See [`provisioning.md`](./provisioning.md) for first-time setup of Fly.io apps, Cloudflare Pages projects, DNS records, and GitHub Environment/secrets.
+See [`provisioning.md`](./provisioning.md) for first-time setup of Fly.io apps, Cloudflare Worker projects, DNS records, and GitHub Environment/secrets.
 
 See [`follow-ups.md`](./follow-ups.md) for deferred hardening work.

--- a/docs/deployment/follow-ups.md
+++ b/docs/deployment/follow-ups.md
@@ -24,7 +24,7 @@ Deferred hardening and nice-to-haves. These are intentionally out of scope for t
 
 - **Multi-region Fly.io topology** — currently single-region (`sjc`). If uptime requirements tighten, replicate the backends to a second region. DataCore would need a different strategy (LanceDB replication is not trivial).
 
-- **Staging environment** — a second Fly.io org + Cloudflare Pages branch deployments would give us a place to test deploys before hitting production. Currently deploys go straight to prod after approval.
+- **Staging environment** — a second Fly.io org + Cloudflare Worker preview deployments (non-production branches) would give us a place to test deploys before hitting production. Currently deploys go straight to prod after approval.
 
 - **GHCR image cleanup** — the registry grows unbounded as releases accumulate. A scheduled cleanup workflow should prune images older than N days, keeping the last K releases per module.
 

--- a/docs/deployment/provisioning.md
+++ b/docs/deployment/provisioning.md
@@ -149,41 +149,49 @@ flyctl ssh console --app launchpad-api -C "curl -s http://datacore.flycast:5800/
 
 Expected: `{"status":"ok"}`.
 
-## Step 7: Create Cloudflare Pages projects
+## Step 7: Create Cloudflare Workers projects (Static Assets)
 
-In the Cloudflare dashboard → **Workers & Pages** → **Create application** → **Pages** → **Connect to Git**:
+Cloudflare's unified UI now creates new git-connected static sites as **Workers with Static Assets** (the successor to classic Pages — the URL path shows `workers/services/view/...`, not `workers-and-pages/view/...`). Each frontend has a `wrangler.jsonc` committed at `<svc>/frontend/wrangler.jsonc` that declares the project name, compatibility date, and SPA fallback.
 
-Create three projects:
+In the Cloudflare dashboard → **Workers & Pages** → **Create** → **Import an existing Git repository**:
+
+Create three projects. Field names reflect the current (2026) UI:
 
 1. **launchpad-frontend**
    - Repo: `kennyhlee/neo-apex`
+   - Project name: `launchpad-frontend` (must match `name` in `launchpad/frontend/wrangler.jsonc`)
    - Production branch: `main`
    - Build command: `npm run build`
-   - Build output directory: `dist`
-   - Root directory: `launchpad/frontend`
-   - Production environment variables:
+   - Deploy command: `npx wrangler deploy`
+   - Advanced → Path: `launchpad/frontend`
+   - Advanced → API token / token name: leave blank (the `CLOUDFLARE_API_TOKEN` variable set below supplies auth)
+   - Variables:
+     - `CLOUDFLARE_API_TOKEN` = token from Step 11 (needs `Account → Cloudflare Pages → Edit`, `User → User Details → Read`, `Account → Account Settings → Read`)
+     - `CLOUDFLARE_ACCOUNT_ID` = your Cloudflare account ID
      - `VITE_API_BASE_URL` = `https://api.launchpad.floatify.com`
-     - (add any other VITE_* values the app needs)
+     - (add any other `VITE_*` values the app needs)
 
 2. **papermite-frontend**
-   - Same settings, root directory: `papermite/frontend`
+   - Same settings, Path: `papermite/frontend`
    - `VITE_API_BASE_URL` = `https://api.papermite.floatify.com`
 
 3. **admindash**
-   - Root directory: `admindash/frontend`
+   - Path: `admindash/frontend`
    - `VITE_ADMINDASH_API_URL` = `https://api.admin.floatify.com`
 
-Let each project do its first build from `main`. Verify each is reachable at its temporary `*.pages.dev` URL.
+Trigger the first deploy from `main`. Verify each is reachable at its temporary `*.workers.dev` URL.
 
-## Step 8: Add custom domains to each Cloudflare Pages project
+> **Why Workers and not Pages?** Cloudflare is consolidating static-site hosting onto Workers with Static Assets. Existing Pages projects keep working, but the "new Pages project" flow now actually creates a Worker. `wrangler.jsonc` in the repo makes the setup reproducible and unblocks CI-driven deploys (Step 13).
 
-In each Pages project → **Custom domains** → **Set up a custom domain**:
+## Step 8: Add custom domains to each Worker project
+
+In each project → **Settings** → **Domains & Routes** → **Add Custom Domain**:
 
 - `launchpad-frontend` → `launchpad.floatify.com`
 - `papermite-frontend` → `papermite.floatify.com`
 - `admindash` → `admin.floatify.com`
 
-Cloudflare will automatically create the CNAME records and provision TLS certificates.
+Cloudflare auto-creates the DNS records and provisions TLS certificates.
 
 ## Step 9: Add Cloudflare DNS records for the Fly.io backends
 
@@ -235,14 +243,22 @@ flyctl tokens create deploy --app admindash-api --name github-actions-admindash-
 In Cloudflare dashboard → **My Profile** → **API Tokens** → **Create Token** → **Custom token**:
 
 - Name: `neo-apex-deploy`
-- Permissions:
+- Permissions (all three are required for `wrangler deploy` on Workers with Static Assets):
   - `Account` → `Cloudflare Pages` → `Edit`
-- Account Resources: include the specific account
+  - `User` → `User Details` → `Read`
+  - `Account` → `Account Settings` → `Read`
+- Account Resources: `Include` → your specific account
 - Zone Resources: none needed
 - Click **Continue to summary** → **Create Token**
 - Copy the token — you will never see it again
 
-Also copy your Cloudflare **Account ID** from the Pages dashboard (right side).
+Also copy your Cloudflare **Account ID** from the Workers & Pages dashboard (right sidebar).
+
+The same token feeds three callers, so generate once and reuse:
+
+1. Each Cloudflare Worker project's `CLOUDFLARE_API_TOKEN` variable (Step 7 — already set if you did Step 11 first).
+2. The GitHub Environment secret `CLOUDFLARE_API_TOKEN` (Step 12).
+3. Your local `flyctl`/`wrangler` shell if you ever deploy by hand (optional).
 
 ## Step 12: Create the GitHub `production` environment with required reviewer
 

--- a/docs/deployment/release-runbook.md
+++ b/docs/deployment/release-runbook.md
@@ -36,7 +36,7 @@ The release event triggers the Deploy workflow (`.github/workflows/deploy.yml`),
 2. Enters the `production` GitHub Environment — waiting for reviewer approval
 3. Builds the Docker image (for backends) and pushes to GHCR
 4. Runs `flyctl deploy` against the target Fly.io app
-5. For modules with a frontend, builds and deploys to Cloudflare Pages in parallel
+5. For modules with a frontend, builds and deploys to Cloudflare Workers (Static Assets) in parallel
 
 ## Approving a deploy
 
@@ -70,9 +70,9 @@ flyctl deploy --image ghcr.io/kennyhlee/datacore:datacore-v1.1.9 --config dataco
 
 This requires `flyctl` authenticated with a token that has deploy rights. Bypasses the GitHub Environment approval — use only in emergencies.
 
-### Option 3: Rollback a frontend via Cloudflare Pages dashboard
+### Option 3: Rollback a frontend via Cloudflare dashboard
 
-Cloudflare dashboard → `launchpad-frontend` (or whichever) → **Deployments** → find the previous deployment → **Rollback to this deployment**.
+Cloudflare dashboard → **Workers & Pages** → `launchpad-frontend` (or whichever) → **Deployments** → find the previous deployment → **Rollback to this deployment**.
 
 ## Reading logs
 
@@ -87,9 +87,9 @@ flyctl logs --app admindash-api
 
 Add `--region sjc` if you have multi-region. Add `-i` for interactive follow.
 
-### Cloudflare Pages frontends
+### Cloudflare Workers frontends
 
-Cloudflare dashboard → each Pages project → **Deployments** → click a deployment → **Build output** tab.
+Cloudflare dashboard → **Workers & Pages** → each Worker project → **Deployments** → click a deployment → **Build output** tab. Runtime logs are in the **Logs** tab.
 
 ### GitHub Actions
 

--- a/launchpad/frontend/wrangler.jsonc
+++ b/launchpad/frontend/wrangler.jsonc
@@ -1,0 +1,18 @@
+// Cloudflare Workers config for the launchpad frontend.
+//
+// Deployed as a Worker with Static Assets (Cloudflare's successor to
+// classic Pages). The built Vite bundle in ./dist is served from
+// Cloudflare's edge. `not_found_handling = "single-page-application"`
+// returns index.html for unknown paths so React Router handles routing.
+//
+// Build-time env vars (e.g. VITE_API_BASE_URL) are configured in the
+// Cloudflare dashboard, not here — they affect the bundle produced by
+// `npm run build`, which is the Deploy command's upstream step.
+{
+  "name": "launchpad-frontend",
+  "compatibility_date": "2026-04-01",
+  "assets": {
+    "directory": "./dist",
+    "not_found_handling": "single-page-application"
+  }
+}

--- a/papermite/frontend/src/App.tsx
+++ b/papermite/frontend/src/App.tsx
@@ -123,7 +123,6 @@ function AppShell({ user, onLogout }: { user: TestUser; onLogout: () => void }) 
 export default function App() {
   const [user, setUser] = useState<TestUser | null>(null);
   const [authChecked, setAuthChecked] = useState(false);
-  const [backendError, setBackendError] = useState(false);
 
   useEffect(() => {
     // Check for exchange code from launchpad
@@ -164,7 +163,6 @@ export default function App() {
   const handleLogin = (token: string, loggedInUser: TestUser) => {
     storeToken(token);
     setUser(loggedInUser);
-    setBackendError(false);
   };
 
   const handleLogout = () => {

--- a/papermite/frontend/src/pages/FinalizedPage.tsx
+++ b/papermite/frontend/src/pages/FinalizedPage.tsx
@@ -3,7 +3,6 @@ import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import type {
   ExtractionResult,
   FinalizePreviewResponse,
-  FinalizeCommitResponse,
   ModelDefinition,
   TestUser,
 } from "../types/models";
@@ -246,7 +245,7 @@ export default function FinalizedPage({ user }: Props) {
           tenant_id: user.tenant_id,
           version: isUnchanged ? existingVersion : existingVersion + 1,
           entity_count: draft.entities.length,
-          model_definition: modelDef as ModelDefinition,
+          model_definition: modelDef as unknown as ModelDefinition,
           source_filename: isUnchanged ? (existingMeta.source_filename || draft.filename) : draft.filename,
           created_by: isUnchanged ? existingMeta.created_by : user.name,
           created_at: isUnchanged ? existingMeta.created_at : undefined,

--- a/papermite/frontend/wrangler.jsonc
+++ b/papermite/frontend/wrangler.jsonc
@@ -1,0 +1,10 @@
+// Cloudflare Workers config for the papermite frontend.
+// See launchpad/frontend/wrangler.jsonc for the shared rationale.
+{
+  "name": "papermite-frontend",
+  "compatibility_date": "2026-04-01",
+  "assets": {
+    "directory": "./dist",
+    "not_found_handling": "single-page-application"
+  }
+}


### PR DESCRIPTION
## Summary

- Phase 2 provisioning revealed that Cloudflare now creates new git-connected static sites as **Workers with Static Assets**, not classic Pages. `wrangler pages deploy` fails with "project not found"; `wrangler deploy` works.
- Adds \`wrangler.jsonc\` for each of the three frontends (launchpad, papermite, admindash) with \`not_found_handling = \"single-page-application\"\` so React Router keeps working.
- Updates the GitHub Actions deploy workflow to \`wrangler deploy\` with \`workingDirectory\`.
- Updates provisioning.md Step 7 (new UI field names + new flow), Step 11 (three token permissions required, not one), plus architecture.md, release-runbook.md, follow-ups.md, and top-level CLAUDE.md terminology.

## Test plan

- [x] launchpad-frontend first deploy succeeded from Cloudflare's build pipeline with this config
- [ ] papermite-frontend deploy (Step 7 remaining work)
- [ ] admindash deploy (Step 7 remaining work)
- [ ] GitHub Actions release tag (Step 13 — will be exercised when \`launchpad-v0.1.0\` is cut)

🤖 Generated with [Claude Code](https://claude.com/claude-code)