### PR TITLE
docs(deployment): require tag rule on production environment in Step 12

### DIFF
--- a/docs/deployment/provisioning.md
+++ b/docs/deployment/provisioning.md
@@ -339,7 +339,11 @@ Configure:
 
 - **Required reviewers**: add yourself (and any teammate you trust)
 - **Wait timer**: 0 minutes
-- **Deployment branches**: restrict to `main`
+- **Deployment branches and tags**: select **Selected branches and tags** and add **both** of the following rules:
+  - **Branch** → `main` (allows manual `workflow_dispatch` runs from main, e.g. for rollbacks)
+  - **Tag** → `*-v*` (allows release-event runs whose ref is the module-prefixed tag — `datacore-v*`, `launchpad-v*`, `papermite-v*`, `admindash-v*`)
+
+  > ⚠️ A branch rule alone is **not** sufficient. The deploy workflow is triggered by `release` events whose `github.ref` is a tag like `refs/tags/datacore-v0.1.0`, not a branch. Without a matching tag rule, GitHub blocks the deploy with `Tag "<tag>" is not allowed to deploy to production due to environment protection rules.`
 
 Then add the environment secrets (Settings → Environments → production → Environment secrets → Add secret):
 


### PR DESCRIPTION
## Summary

Step 12 told you to set the GitHub \`production\` environment's deployment branches to \`main\` only. That blocks every release-event deploy because the workflow's \`github.ref\` is the tag (e.g. \`refs/tags/datacore-v0.1.0\`), not a branch.

Surfaced when cutting \`datacore-v0.1.0\`:

> Tag \"datacore-v0.1.0\" is not allowed to deploy to production due to environment protection rules.

Step 12 now instructs adding both rules:
- **Branch** \`main\` — allows \`workflow_dispatch\` / rollback runs
- **Tag** \`*-v*\` — allows release-event runs

## Test plan
- [ ] CI green
- [ ] After merge, re-run the failed datacore-v0.1.0 deploy and confirm it gets to the approval gate