### PR TITLE
fix(deploy): pin wrangler v4 so Workers Static Assets deploy succeeds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -176,6 +176,7 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: launchpad/frontend
           command: deploy
+          wranglerVersion: '4'
 
   deploy-papermite-api:
     name: Deploy papermite-api (Fly.io)
@@ -251,6 +252,7 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: papermite/frontend
           command: deploy
+          wranglerVersion: '4'
 
   deploy-admindash-api:
     name: Deploy admindash-api (Fly.io)
@@ -326,3 +328,4 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: admindash/frontend
           command: deploy
+          wranglerVersion: '4'

--- a/docs/deployment/provisioning.md
+++ b/docs/deployment/provisioning.md
@@ -339,7 +339,11 @@ Configure:
 
 - **Required reviewers**: add yourself (and any teammate you trust)
 - **Wait timer**: 0 minutes
-- **Deployment branches**: restrict to `main`
+- **Deployment branches and tags**: select **Selected branches and tags** and add **both** of the following rules:
+  - **Branch** → `main` (allows manual `workflow_dispatch` runs from main, e.g. for rollbacks)
+  - **Tag** → `*-v*` (allows release-event runs whose ref is the module-prefixed tag — `datacore-v*`, `launchpad-v*`, `papermite-v*`, `admindash-v*`)
+
+  > ⚠️ A branch rule alone is **not** sufficient. The deploy workflow is triggered by `release` events whose `github.ref` is a tag like `refs/tags/datacore-v0.1.0`, not a branch. Without a matching tag rule, GitHub blocks the deploy with `Tag "<tag>" is not allowed to deploy to production due to environment protection rules.`
 
 Then add the environment secrets (Settings → Environments → production → Environment secrets → Add secret):
 


### PR DESCRIPTION
## Summary

\`cloudflare/wrangler-action@v3\` defaults to wrangler 3.90.0, which predates support for the \`assets\` field in \`wrangler.jsonc\`. Without that support wrangler treats our config as a classic Worker and demands a \`main\` script entry-point, failing with:

\`\`\`
✘ ERROR  Missing entry-point: The entry-point should be specified via the command line
\`\`\`

Pinning \`wranglerVersion: '4'\` on the action installs wrangler 4.x which fully supports Workers with Static Assets.

Applied to all three frontend deploy jobs (launchpad, papermite, admindash).

## Test plan
- [ ] CI green
- [ ] After merge, re-run launchpad-v0.1.0 deploy and confirm \`deploy-launchpad-frontend\` succeeds end-to-end