### PR TITLE
feat(admindash): show actual extraction model in upload widget

### DIFF
--- a/admindash/backend/app/api/extract.py
+++ b/admindash/backend/app/api/extract.py
@@ -57,3 +57,22 @@ async def extract_student(
         status_code=upstream_resp.status_code,
         media_type=upstream_resp.headers.get("content-type"),
     )
+
+
+@router.get("/config/models")
+def get_available_models(user=Depends(require_authenticated_user)):
+    """Proxy papermite's /api/config/models so admindash can read the default."""
+    try:
+        resp = httpx.get(
+            f"{settings.papermite_backend_url}/api/config/models",
+            headers={"Authorization": user["_token"]},
+            timeout=10.0,
+        )
+    except httpx.RequestError:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Papermite is unreachable",
+        )
+    if resp.status_code != 200:
+        raise HTTPException(status_code=resp.status_code, detail=resp.text)
+    return resp.json()

--- a/admindash/backend/tests/test_extract.py
+++ b/admindash/backend/tests/test_extract.py
@@ -38,3 +38,46 @@ def test_unauthenticated_extract_returns_401(client):
         files={"file": ("x.pdf", b"x", "application/pdf")},
     )
     assert resp.status_code == 401
+
+
+@respx.mock
+def test_config_models_is_proxied(client):
+    respx.get("http://localhost:5800/auth/me").mock(
+        return_value=httpx.Response(200, json={"id": "u1", "tenant_id": "t1"})
+    )
+    payload = {
+        "default": "anthropic:claude-haiku-4-5-20251001",
+        "models": [
+            {"id": "anthropic:claude-haiku-4-5-20251001", "label": "Claude Haiku 4.5"},
+        ],
+    }
+    route = respx.get("http://localhost:5710/api/config/models").mock(
+        return_value=httpx.Response(200, json=payload)
+    )
+
+    resp = client.get(
+        "/api/config/models",
+        headers={"Authorization": "Bearer good"},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == payload
+    assert route.called
+    forwarded = route.calls[0].request
+    assert forwarded.headers["authorization"] == "Bearer good"
+
+
+@respx.mock
+def test_config_models_papermite_unreachable_returns_502(client):
+    respx.get("http://localhost:5800/auth/me").mock(
+        return_value=httpx.Response(200, json={"id": "u1", "tenant_id": "t1"})
+    )
+    respx.get("http://localhost:5710/api/config/models").mock(
+        side_effect=httpx.ConnectError("connection refused")
+    )
+
+    resp = client.get(
+        "/api/config/models",
+        headers={"Authorization": "Bearer good"},
+    )
+    assert resp.status_code == 502
+    assert resp.json()["detail"] == "Papermite is unreachable"

--- a/admindash/frontend/src/api/client.ts
+++ b/admindash/frontend/src/api/client.ts
@@ -108,6 +108,19 @@ export async function extractStudentFromDocument(
   return resp.json();
 }
 
+export interface AvailableModelsResponse {
+  default: string;
+  models: { id: string; label?: string }[];
+}
+
+export async function fetchAvailableModels(): Promise<AvailableModelsResponse> {
+  const resp = await fetch(`${API_BASE}/api/config/models`, {
+    headers: authHeaders(),
+  });
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+  return resp.json();
+}
+
 export async function fetchNextEntityId(
   tenantId: string,
   entityType: string,

--- a/admindash/frontend/src/components/DocumentUpload.tsx
+++ b/admindash/frontend/src/components/DocumentUpload.tsx
@@ -1,5 +1,6 @@
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { useTranslation } from '../hooks/useTranslation.ts';
+import { fetchAvailableModels } from '../api/client.ts';
 import './DocumentUpload.css';
 
 const ACCEPTED_FORMATS = ['.pdf', '.docx', '.txt'];
@@ -20,7 +21,23 @@ export default function DocumentUpload({ onExtracted, onUpload }: DocumentUpload
   const [uploading, setUploading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [fileName, setFileName] = useState<string | null>(null);
+  const [defaultModel, setDefaultModel] = useState<string | null>(null);
+  const [modelLoadFailed, setModelLoadFailed] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchAvailableModels()
+      .then((data) => {
+        if (!cancelled) setDefaultModel(data.default);
+      })
+      .catch(() => {
+        if (!cancelled) setModelLoadFailed(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const validateFile = (file: File): boolean => {
     const ext = '.' + file.name.split('.').pop()?.toLowerCase();
@@ -89,7 +106,13 @@ export default function DocumentUpload({ onExtracted, onUpload }: DocumentUpload
         )}
       </div>
       {error && <div className="document-upload-error">{error}</div>}
-      <p className="document-upload-model">Extraction model: claude-haiku-4-5</p>
+      {defaultModel ? (
+        <p className="document-upload-model">Extraction model: {defaultModel}</p>
+      ) : modelLoadFailed ? (
+        <p className="document-upload-model">Extraction model: (unknown)</p>
+      ) : (
+        <p className="document-upload-model">Extraction model: loading…</p>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Replaces the hardcoded \`Extraction model: claude-haiku-4-5\` label in admindash's document-upload widget with a dynamic value fetched from papermite at request time. The hardcoded label was actively misleading after \`PAPERMITE_DEFAULT_MODEL\` was set to \`anthropic:claude-sonnet-4-6\` on papermite-api — production extractions run on Sonnet but the UI still claimed Haiku.

## Changes

- New admindash backend proxy: \`GET /api/config/models\` forwards to papermite's existing \`/api/config/models\` and returns \`{"default": "<model_id>", "models": [...]}\`.
- New \`fetchAvailableModels()\` helper in \`api/client.ts\` matching the existing fetch pattern.
- \`DocumentUpload\` component fetches on mount, displays \`Extraction model: <default>\` once loaded; shows \`loading…\` while in flight and \`(unknown)\` on error.

The label updates automatically whenever the operator flips \`PAPERMITE_DEFAULT_MODEL\` — no admindash redeploy needed.

## Test plan

- [x] 41 admindash backend tests pass (39 baseline + 2 new for the proxy)
- [x] admindash-frontend builds clean (313 KB)
- [x] No new lint errors
- [ ] Post-deploy: open admin.floatify.com → Add Student → Upload Document → label reads \`Extraction model: anthropic:claude-sonnet-4-6\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)