### PR TITLE
fix(admindash): bulk-add student_id auto-assign and button styling

### DIFF
--- a/admindash/frontend/src/components/ResumeBatchPrompt.css
+++ b/admindash/frontend/src/components/ResumeBatchPrompt.css
@@ -14,23 +14,60 @@
   margin-top: 16px;
   display: flex; gap: 8px; justify-content: flex-end;
 }
-.resume-prompt__actions button {
-  padding: 6px 12px; border-radius: 4px; cursor: pointer;
-  border: 1px solid var(--color-border, #d1d5db); background: white;
+
+.resume-prompt__btn {
+  font-family: var(--font-sans);
+  font-size: 0.85rem;
+  font-weight: 500;
+  padding: 0.45rem 0.85rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: all 0.2s;
 }
-.resume-prompt__resume {
-  background: var(--color-primary, #2563eb); color: white;
-  border-color: var(--color-primary, #2563eb);
+
+.resume-prompt__btn--small {
+  font-size: 0.75rem;
+  padding: 0.3rem 0.6rem;
 }
+
+.resume-prompt__btn--primary {
+  background: #378ADD;
+  color: var(--text-inverse);
+  border-color: #378ADD;
+}
+
+.resume-prompt__btn--primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 16px rgba(55, 138, 221, 0.25);
+}
+
+.resume-prompt__btn--secondary {
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  border-color: var(--border-primary);
+}
+
+.resume-prompt__btn--secondary:hover {
+  background: var(--bg-secondary);
+}
+
+.resume-prompt__btn--danger {
+  background: transparent;
+  color: var(--text-secondary);
+  border-color: var(--border-primary);
+}
+
+.resume-prompt__btn--danger:hover {
+  background: rgba(229, 62, 62, 0.08);
+  color: #c53030;
+  border-color: #c53030;
+}
+
 .resume-prompt__others { margin-top: 16px; }
 .resume-prompt__others summary { cursor: pointer; font-size: 14px; }
 .resume-prompt__others ul { list-style: none; padding: 0; margin: 8px 0; }
 .resume-prompt__others li {
   display: flex; gap: 8px; align-items: center; padding: 4px 0;
   font-size: 13px;
-}
-.resume-prompt__discard-all {
-  margin-top: 8px; padding: 4px 8px; cursor: pointer;
-  background: transparent; color: var(--color-error, #b91c1c);
-  border: 1px solid var(--color-error, #b91c1c); border-radius: 4px;
 }

--- a/admindash/frontend/src/components/ResumeBatchPrompt.tsx
+++ b/admindash/frontend/src/components/ResumeBatchPrompt.tsx
@@ -30,10 +30,23 @@ export default function ResumeBatchPrompt({
             {' '}— {new Date(primary.updatedAt).toLocaleString()}
           </p>
           <div className="resume-prompt__actions">
-            <button onClick={onCancel}>{t('common.cancel')}</button>
-            <button onClick={() => onDiscardOne(primary)}>{t('bulkAdd.resume.discardThis')}</button>
             <button
-              className="resume-prompt__resume"
+              type="button"
+              className="resume-prompt__btn resume-prompt__btn--secondary"
+              onClick={onCancel}
+            >
+              {t('common.cancel')}
+            </button>
+            <button
+              type="button"
+              className="resume-prompt__btn resume-prompt__btn--danger"
+              onClick={() => onDiscardOne(primary)}
+            >
+              {t('bulkAdd.resume.discardThis')}
+            </button>
+            <button
+              type="button"
+              className="resume-prompt__btn resume-prompt__btn--primary"
               onClick={() => onResume(primary)}
             >
               {t('bulkAdd.resume.resume')}
@@ -48,12 +61,28 @@ export default function ResumeBatchPrompt({
               {others.map((d) => (
                 <li key={d.id}>
                   <span>{d.rows.length} rows · {new Date(d.updatedAt).toLocaleString()}</span>
-                  <button onClick={() => onResume(d)}>{t('bulkAdd.resume.resume')}</button>
-                  <button onClick={() => onDiscardOne(d)}>{t('bulkAdd.resume.discardThis')}</button>
+                  <button
+                    type="button"
+                    className="resume-prompt__btn resume-prompt__btn--primary resume-prompt__btn--small"
+                    onClick={() => onResume(d)}
+                  >
+                    {t('bulkAdd.resume.resume')}
+                  </button>
+                  <button
+                    type="button"
+                    className="resume-prompt__btn resume-prompt__btn--danger resume-prompt__btn--small"
+                    onClick={() => onDiscardOne(d)}
+                  >
+                    {t('bulkAdd.resume.discardThis')}
+                  </button>
                 </li>
               ))}
             </ul>
-            <button onClick={onDiscardAll} className="resume-prompt__discard-all">
+            <button
+              type="button"
+              className="resume-prompt__btn resume-prompt__btn--danger"
+              onClick={onDiscardAll}
+            >
               {t('bulkAdd.resume.discardAll')}
             </button>
           </details>

--- a/admindash/frontend/src/pages/BulkAddStudentsPage.css
+++ b/admindash/frontend/src/pages/BulkAddStudentsPage.css
@@ -19,23 +19,50 @@
 
 .bulk-add-page__btn-primary,
 .bulk-add-page__btn-secondary {
-  padding: 8px 16px;
-  border-radius: 6px;
-  font-size: 14px;
+  font-family: var(--font-sans);
+  font-size: 0.85rem;
   font-weight: 500;
+  padding: 0.45rem 0.85rem;
+  border-radius: var(--radius-sm);
   cursor: pointer;
-  border: 1px solid var(--color-border, #d1d5db);
+  border: 1px solid transparent;
+  transition: all 0.2s;
 }
 
 .bulk-add-page__btn-primary {
-  background: var(--color-primary, #2563eb);
-  color: white;
-  border-color: var(--color-primary, #2563eb);
+  background: #378ADD;
+  color: var(--text-inverse);
+  border-color: #378ADD;
+}
+
+.bulk-add-page__btn-primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 32px rgba(55, 138, 221, 0.3);
+}
+
+.bulk-add-page__btn-primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.bulk-add-page__btn-primary:disabled:hover {
+  transform: none;
+  box-shadow: none;
 }
 
 .bulk-add-page__btn-secondary {
-  background: var(--color-bg, white);
-  color: var(--color-text, #111827);
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  border-color: var(--border-primary);
+}
+
+.bulk-add-page__btn-secondary:hover {
+  background: var(--bg-secondary);
+}
+
+.bulk-add-page__btn-secondary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 .bulk-add-page--error .bulk-add-page__no-model {
@@ -50,7 +77,4 @@
   display: flex; gap: 8px;
   margin-bottom: 12px;
   justify-content: flex-end;
-}
-.bulk-add-page__btn-primary:disabled {
-  opacity: 0.5; cursor: not-allowed;
 }

--- a/admindash/frontend/src/pages/BulkAddStudentsPage.tsx
+++ b/admindash/frontend/src/pages/BulkAddStudentsPage.tsx
@@ -204,7 +204,15 @@ export default function BulkAddStudentsPage({ tenant }: BulkAddStudentsPageProps
         const baseData: Record<string, unknown> = {};
         const customFields: Record<string, unknown> = {};
         for (const [k, v] of Object.entries(r.values)) {
-          if (k === 'student_id' && (v == null || String(v).trim() === '')) continue;
+          if (k === 'student_id') {
+            // Documents mode: always strip — backend auto-assigns the next ID.
+            // The LLM may extract a junk value (e.g., a reference number from the
+            // application form) into student_id which would otherwise be used as
+            // the literal value. Matches AddStudentModal.tsx:89's behavior.
+            if (mode === 'documents') continue;
+            // CSV mode: respect explicit student_id from the CSV; skip empty.
+            if (v == null || String(v).trim() === '') continue;
+          }
           if (baseFieldNames.has(k)) baseData[k] = v;
           else if (customFieldNames.has(k)) customFields[k] = v;
         }

--- a/admindash/frontend/src/pages/StudentsPage.css
+++ b/admindash/frontend/src/pages/StudentsPage.css
@@ -277,17 +277,20 @@
 }
 
 .students-toolbar-secondary {
-  margin-left: 8px;
-  padding: 8px 16px;
-  border-radius: 6px;
-  font-size: 14px;
+  font-family: var(--font-sans);
+  font-size: 0.85rem;
   font-weight: 500;
-  cursor: pointer;
+  padding: 0.45rem 0.85rem;
+  border-radius: var(--radius-sm);
   background: transparent;
-  color: var(--color-primary, #2563eb);
-  border: 1px solid var(--color-primary, #2563eb);
+  color: #378ADD;
+  border: 1px solid #378ADD;
+  cursor: pointer;
+  transition: all 0.2s;
 }
 
 .students-toolbar-secondary:hover {
-  background: var(--color-primary-subtle, #eff6ff);
+  background: rgba(55, 138, 221, 0.08);
+  transform: translateY(-2px);
+  box-shadow: 0 8px 32px rgba(55, 138, 221, 0.15);
 }


### PR DESCRIPTION
## Summary
- Three bug fixes from manual testing of `admindash-v0.2.0`.
- **`student_id` missing from batch-added records:** documents-mode now always strips `student_id` from the create payload so the backend auto-assigns the next sequential ID, matching `AddStudentModal.tsx:89`. The LLM was extracting junk values (reference numbers, "N/A", etc.) into `student_id`, which the backend then used as the literal value instead of auto-assigning. CSV mode still respects an explicit `student_id` column per spec.
- **Inconsistent button styling on entry + page header:** bulk-add buttons now share the existing `students-toolbar-primary` aesthetic — design tokens (`var(--font-sans)`, `var(--radius-sm)`), Floatify primary blue (`#378ADD`), consistent padding and hover transforms.
- **Resume dialog buttons:** all three primary actions now share a `.resume-prompt__btn` base class with primary / secondary / danger modifiers, replacing the prior mix of classed and unclassed bare buttons.

## Known follow-up

`PostSubmitSummary` (Retry Failed / Done) buttons may have the same hand-rolled style. Not in this PR's scope; flag after retest if visible.

## Test plan
- [ ] Documents-mode batch — confirm new student records have auto-assigned `student_id`.
- [ ] CSV-mode with explicit `student_id` column — confirm value is preserved.
- [ ] Visual confirmation that bulk-add entry button + page header buttons match the existing primary button.
- [ ] Visual confirmation that resume dialog buttons all have consistent styling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)