### PR TITLE
fix(admindash): bulk-add header, toolbar, and draft-cleanup polish

### DIFF
--- a/admindash/frontend/src/pages/BulkAddStudentsPage.css
+++ b/admindash/frontend/src/pages/BulkAddStudentsPage.css
@@ -4,17 +4,12 @@
   margin: 0 auto;
 }
 
-.bulk-add-page__header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 24px;
-}
-
-.bulk-add-page__header h1 {
-  font-size: 24px;
-  font-weight: 600;
-  margin: 0;
+.bulk-add-page h1 {
+  font-size: 28px;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: #1A202C;
+  margin-bottom: 1rem;
 }
 
 .bulk-add-page__btn-primary,
@@ -35,7 +30,7 @@
   border-color: #378ADD;
 }
 
-.bulk-add-page__btn-primary:hover {
+.bulk-add-page__btn-primary:hover:not(:disabled) {
   transform: translateY(-2px);
   box-shadow: 0 8px 32px rgba(55, 138, 221, 0.3);
 }
@@ -45,18 +40,13 @@
   cursor: not-allowed;
 }
 
-.bulk-add-page__btn-primary:disabled:hover {
-  transform: none;
-  box-shadow: none;
-}
-
 .bulk-add-page__btn-secondary {
   background: var(--bg-tertiary);
   color: var(--text-secondary);
   border-color: var(--border-primary);
 }
 
-.bulk-add-page__btn-secondary:hover {
+.bulk-add-page__btn-secondary:hover:not(:disabled) {
   background: var(--bg-secondary);
 }
 
@@ -65,16 +55,21 @@
   cursor: not-allowed;
 }
 
+.bulk-add-page__toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.bulk-add-page__toolbar-spacer {
+  flex: 1;
+}
+
 .bulk-add-page--error .bulk-add-page__no-model {
-  background: var(--color-bg-subtle, #f9fafb);
+  background: var(--bg-secondary);
   border-radius: 8px;
   padding: 32px;
   text-align: center;
-  color: var(--color-text-muted, #6b7280);
-}
-
-.bulk-add-page__toolbar {
-  display: flex; gap: 8px;
-  margin-bottom: 12px;
-  justify-content: flex-end;
+  color: var(--text-secondary);
 }

--- a/admindash/frontend/src/pages/BulkAddStudentsPage.tsx
+++ b/admindash/frontend/src/pages/BulkAddStudentsPage.tsx
@@ -78,11 +78,23 @@ export default function BulkAddStudentsPage({ tenant }: BulkAddStudentsPageProps
     return () => { cancelled = true; };
   }, [tenant, getModel]);
 
-  // Task 8.1: Debounced persistence to IndexedDB once review phase begins.
+  // Task 8.1 + Bug fix: Persist to IndexedDB during review/submitting/post_submit.
+  // When ALL rows are 'created' (a fully-successful batch), instead of saving,
+  // actively delete any existing draft so the resume prompt does not surface
+  // a finished batch on next page load.
   useEffect(() => {
-    // Skip persistence before review phase.
     if (phase !== 'review' && phase !== 'submitting' && phase !== 'post_submit') return;
     if (mode == null) return;
+
+    const allCreated =
+      phase === 'post_submit' &&
+      rows.length > 0 &&
+      rows.every((r) => r.status === 'created');
+
+    if (allCreated) {
+      void deleteDraft(buildDraftId(tenant, batchId));
+      return;
+    }
 
     const handle = window.setTimeout(() => {
       if (createdAtRef.current == null) {
@@ -289,47 +301,7 @@ export default function BulkAddStudentsPage({ tenant }: BulkAddStudentsPageProps
 
   return (
     <div className="bulk-add-page">
-      <header className="bulk-add-page__header">
-        <h1>{t('bulkAdd.title')}</h1>
-        {(phase === 'mode_select' || phase === 'uploading') && (
-          <button
-            className="bulk-add-page__btn-secondary"
-            onClick={() => navigate('/students')}
-          >
-            {t('common.cancel')}
-          </button>
-        )}
-        {phase === 'extracting' && (
-          <button
-            className="bulk-add-page__btn-secondary"
-            onClick={() => {
-              // In-flight extracts are allowed to settle; we just navigate away.
-              // No IndexedDB draft has been created yet (review phase boundary).
-              navigate('/students');
-            }}
-          >
-            {t('common.cancel')}
-          </button>
-        )}
-        {(phase === 'review' || phase === 'post_submit') && (
-          <button
-            className="bulk-add-page__btn-secondary"
-            onClick={() => {
-              if (window.confirm(t('bulkAdd.discardConfirm'))) {
-                void deleteDraft(buildDraftId(tenant, batchId));
-                navigate('/students');
-              }
-            }}
-          >
-            {t('bulkAdd.discardBatch')}
-          </button>
-        )}
-        {phase === 'submitting' && (
-          <button className="bulk-add-page__btn-secondary" disabled>
-            {t('bulkAdd.submittingDisabled')}
-          </button>
-        )}
-      </header>
+      <h1>{t('bulkAdd.title')}</h1>
 
       {resumeDrafts && (
         <ResumeBatchPrompt
@@ -385,8 +357,8 @@ export default function BulkAddStudentsPage({ tenant }: BulkAddStudentsPageProps
         />
       )}
 
-      {phase === 'review' && (
-        <div className="bulk-add-page__toolbar">
+      <div className="bulk-add-page__toolbar">
+        {phase === 'review' && (
           <button
             className="bulk-add-page__btn-primary"
             disabled={rows.length === 0}
@@ -395,8 +367,37 @@ export default function BulkAddStudentsPage({ tenant }: BulkAddStudentsPageProps
           >
             {t('bulkAdd.toolbar.createAll').replace('{n}', String(rows.length))}
           </button>
-        </div>
-      )}
+        )}
+
+        <div className="bulk-add-page__toolbar-spacer" />
+
+        {(phase === 'mode_select' || phase === 'uploading' || phase === 'extracting') && (
+          <button
+            className="bulk-add-page__btn-secondary"
+            onClick={() => navigate('/students')}
+          >
+            {t('common.cancel')}
+          </button>
+        )}
+        {(phase === 'review' || phase === 'post_submit') && (
+          <button
+            className="bulk-add-page__btn-secondary"
+            onClick={() => {
+              if (window.confirm(t('bulkAdd.discardConfirm'))) {
+                void deleteDraft(buildDraftId(tenant, batchId));
+                navigate('/students');
+              }
+            }}
+          >
+            {t('bulkAdd.discardBatch')}
+          </button>
+        )}
+        {phase === 'submitting' && (
+          <button className="bulk-add-page__btn-secondary" disabled>
+            {t('bulkAdd.submittingDisabled')}
+          </button>
+        )}
+      </div>
 
       {(phase === 'extracting' || phase === 'review') && rows.length > 0 && (
         <BulkReviewTable

--- a/admindash/frontend/src/pages/StudentsPage.css
+++ b/admindash/frontend/src/pages/StudentsPage.css
@@ -280,7 +280,8 @@
   font-family: var(--font-sans);
   font-size: 0.85rem;
   font-weight: 500;
-  padding: 0.45rem 0.85rem;
+  /* Compensate for 1px border so total box-height matches primary's borderless box. */
+  padding: calc(0.45rem - 1px) calc(0.85rem - 1px);
   border-radius: var(--radius-sm);
   background: transparent;
   color: #378ADD;


### PR DESCRIPTION
## Summary
Three more bug fixes from manual testing of `admindash-v0.2.1`.

- **Batch draft persisted after all-success completion.** The persistence effect now actively `deleteDraft`s when every row reaches `'created'` status, instead of re-saving on every state change. Eliminates the race with `handleDone` and stops the resume prompt from surfacing finished batches on next page load.
- **Cancel/Discard button positioning.** Removed the unique top-right page-header bar (no other admindash page uses one) and moved the action into the same `.bulk-add-page__toolbar` that holds "Create All" — mirroring the `.students-toolbar` pattern. Page title is now a plain `<h1>` matching the rest of admindash.
- **Entry button height match.** "Bulk add" secondary button on `StudentsPage` now compensates the 1px border into its padding so its box-height matches the adjacent primary "Add Student" exactly.

## Test plan
- [ ] Submit a batch where all rows succeed; click Done; reload `/students/bulk-add` — no resume prompt should appear.
- [ ] Submit a batch with some failures; navigate away (without clicking Done); reload — resume prompt SHOULD appear with just the failed-rows state.
- [ ] Visual check: the bulk-add page title now sits flush at top-left like every other page; toolbar action sits below the title.
- [ ] Visual check: `Add Student` and `Bulk add` on `StudentsPage` are the same height side by side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)