### PR TITLE
fix(admindash): bulk-add Cancel/Discard at bottom-right

### DIFF
--- a/admindash/frontend/src/pages/BulkAddStudentsPage.css
+++ b/admindash/frontend/src/pages/BulkAddStudentsPage.css
@@ -62,8 +62,13 @@
   margin-bottom: 1rem;
 }
 
-.bulk-add-page__toolbar-spacer {
-  flex: 1;
+.bulk-add-page__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  margin-top: 2rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border-subtle);
 }
 
 .bulk-add-page--error .bulk-add-page__no-model {

--- a/admindash/frontend/src/pages/BulkAddStudentsPage.tsx
+++ b/admindash/frontend/src/pages/BulkAddStudentsPage.tsx
@@ -357,8 +357,8 @@ export default function BulkAddStudentsPage({ tenant }: BulkAddStudentsPageProps
         />
       )}
 
-      <div className="bulk-add-page__toolbar">
-        {phase === 'review' && (
+      {phase === 'review' && (
+        <div className="bulk-add-page__toolbar">
           <button
             className="bulk-add-page__btn-primary"
             disabled={rows.length === 0}
@@ -367,37 +367,8 @@ export default function BulkAddStudentsPage({ tenant }: BulkAddStudentsPageProps
           >
             {t('bulkAdd.toolbar.createAll').replace('{n}', String(rows.length))}
           </button>
-        )}
-
-        <div className="bulk-add-page__toolbar-spacer" />
-
-        {(phase === 'mode_select' || phase === 'uploading' || phase === 'extracting') && (
-          <button
-            className="bulk-add-page__btn-secondary"
-            onClick={() => navigate('/students')}
-          >
-            {t('common.cancel')}
-          </button>
-        )}
-        {(phase === 'review' || phase === 'post_submit') && (
-          <button
-            className="bulk-add-page__btn-secondary"
-            onClick={() => {
-              if (window.confirm(t('bulkAdd.discardConfirm'))) {
-                void deleteDraft(buildDraftId(tenant, batchId));
-                navigate('/students');
-              }
-            }}
-          >
-            {t('bulkAdd.discardBatch')}
-          </button>
-        )}
-        {phase === 'submitting' && (
-          <button className="bulk-add-page__btn-secondary" disabled>
-            {t('bulkAdd.submittingDisabled')}
-          </button>
-        )}
-      </div>
+        </div>
+      )}
 
       {(phase === 'extracting' || phase === 'review') && rows.length > 0 && (
         <BulkReviewTable
@@ -525,6 +496,37 @@ export default function BulkAddStudentsPage({ tenant }: BulkAddStudentsPageProps
           }}
         />
       )}
+
+      <div className="bulk-add-page__actions">
+        {(phase === 'mode_select' || phase === 'uploading' || phase === 'extracting') && (
+          <button
+            type="button"
+            className="bulk-add-page__btn-secondary"
+            onClick={() => navigate('/students')}
+          >
+            {t('common.cancel')}
+          </button>
+        )}
+        {(phase === 'review' || phase === 'post_submit') && (
+          <button
+            type="button"
+            className="bulk-add-page__btn-secondary"
+            onClick={() => {
+              if (window.confirm(t('bulkAdd.discardConfirm'))) {
+                void deleteDraft(buildDraftId(tenant, batchId));
+                navigate('/students');
+              }
+            }}
+          >
+            {t('bulkAdd.discardBatch')}
+          </button>
+        )}
+        {phase === 'submitting' && (
+          <button type="button" className="bulk-add-page__btn-secondary" disabled>
+            {t('bulkAdd.submittingDisabled')}
+          </button>
+        )}
+      </div>
 
     </div>
   );


### PR DESCRIPTION
## Summary
Moves the Cancel/Discard action from the top toolbar (added in v0.2.2) to a bottom-right action bar matching the `.dynamic-form-actions` convention used by `AddStudentModal` and other forms in admindash.

- Top toolbar now contains only the **Create All** primary action (review phase only).
- New `.bulk-add-page__actions` bar at the bottom of the page renders in every phase with the right label: **Cancel** (mode_select / uploading / extracting), **Discard batch** (review / post_submit), or a disabled **Submitting…** (submitting).

## Test plan
- [ ] Visual: `/students/bulk-add` shows the Cancel/Discard button anchored at the bottom-right of the page in every phase.
- [ ] Functional: Clicking Cancel during ephemeral phases navigates to `/students` immediately. Clicking Discard during review/post_submit prompts to confirm, deletes the IndexedDB draft, and navigates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)