### PR TITLE
fix(admindash): align bulk-add actions bar with upload column

### DIFF
--- a/admindash/frontend/src/pages/BulkAddStudentsPage.css
+++ b/admindash/frontend/src/pages/BulkAddStudentsPage.css
@@ -66,7 +66,11 @@
   display: flex;
   justify-content: flex-end;
   gap: 0.75rem;
-  margin-top: 2rem;
+  /* Match the 800px max-width used by the mode selector and dropzones so the
+     button's right-edge aligns with the upload column above it, instead of
+     floating to the page container's right edge. */
+  max-width: 800px;
+  margin-top: 4rem;
   padding-top: 1rem;
   border-top: 1px solid var(--border-subtle);
 }


### PR DESCRIPTION
## Summary
The Cancel/Discard action bar was right-aligning to the 1400px page container, but the mode-selector cards and dropzones above it use `max-width: 800px`. On short phases (mode_select, uploading, mapping) the Cancel button visually floated far to the right of the upload column.

- Constrain `.bulk-add-page__actions` to `max-width: 800px` so its right edge aligns with the upload column above.
- Increase `margin-top` from 2rem to 4rem so it sits visibly lower on the page.

## Test plan
- [ ] Visit `/students/bulk-add` — Cancel button's right edge aligns vertically with the right edge of the mode-selector cards.
- [ ] Pick CSV mode — Cancel button's right edge aligns with the dropzone's right edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)