### PR TITLE
fix(papermite): selection field [object Object] display + always-inline editor (#68)

### DIFF
--- a/docs/superpowers/plans/2026-05-15-papermite-selection-edit-display.md
+++ b/docs/superpowers/plans/2026-05-15-papermite-selection-edit-display.md
@@ -1,0 +1,749 @@
+# Papermite Selection Edit Display Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix Papermite issue #68 — selection-type fields in the Review page display `"[object Object]"` once clicked — and replace the click-to-edit input with an always-visible inline `<select>` (single-select) or checkbox group (multi-select) when options are defined. Establish a Vitest + React Testing Library harness in `papermite/frontend` and lock in the bug fix with component tests.
+
+**Architecture:** Single component change in `papermite/frontend/src/components/FieldRow.tsx`. A new `toEditString()` helper unifies display and fallback edit-mode serialization so neither path can produce `"[object Object]"`. When `fieldType === "selection"` and at least one option is defined, the Value cell renders the inline control directly (no edit-mode toggle). Single-select binds to a `<select>`; multi-select binds to a horizontal checkbox group. All other fields keep the existing click-to-edit text input. The `OptionsEditor` panel that adds/removes options is untouched. CSS additions land in `EntityCard.css` next to the existing `.field-row*` rules. The new Vitest setup lives in `papermite/frontend` only; it does not affect other services. Vitest 3+ pairs with the existing Vite 8.
+
+**Tech Stack:** React 19 + TypeScript 5.9 (`verbatimModuleSyntax: true`, strict mode) + Vite 8, Vitest 3 + `@testing-library/react` 16 + `@testing-library/jest-dom` 6 + `@testing-library/user-event` 14 + `happy-dom` 16.
+
+**Source artifacts:** `openspec/changes/papermite-selection-edit-display/{proposal.md, design.md, specs/papermite-field-row-editor/spec.md, tasks.md}`.
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|---|---|---|
+| Modify | `papermite/frontend/src/components/FieldRow.tsx` | Add `toEditString` helper, swap display + editValue init to use it, add inline selection control branch before the existing edit-mode ternary. |
+| Modify | `papermite/frontend/src/components/EntityCard.css` | Append `.field-row__multi-edit` and `.field-row__multi-edit-label` rules next to existing `.field-row__input`. |
+| Modify | `papermite/frontend/package.json` | Add `vitest`, `@testing-library/*`, `happy-dom` devDeps; add `test` and `test:run` scripts. |
+| Modify | `papermite/frontend/vite.config.ts` | Switch `defineConfig` import to `vitest/config`; add `test` block. |
+| Modify | `papermite/frontend/tsconfig.app.json` | Extend `compilerOptions.types` with vitest globals + jest-dom types. |
+| Create | `papermite/frontend/src/test/setup.ts` | Import `@testing-library/jest-dom/vitest` once for all tests. |
+| Create | `papermite/frontend/src/components/FieldRow.test.tsx` | Five component tests covering safe display, safe text-edit init, single-select inline, multi-select inline. |
+
+---
+
+## Task 1: Safe serialization helper in FieldRow.tsx
+
+**Files:**
+- Modify: `papermite/frontend/src/components/FieldRow.tsx:107-126`
+
+- [ ] **Step 1: Read current FieldRow.tsx**
+
+Run: `cat papermite/frontend/src/components/FieldRow.tsx | head -130`
+
+Confirm the file currently has at line 108: `const [editValue, setEditValue] = useState(String(value ?? ""));` and at lines 121-126:
+
+```tsx
+  const displayValue =
+    value === null || value === undefined || value === ""
+      ? "—"
+      : typeof value === "object"
+        ? JSON.stringify(value)
+        : String(value);
+```
+
+- [ ] **Step 2: Add `toEditString` helper at module scope**
+
+Use Edit to insert the helper **above the `OptionsEditor` function** (between line 18 and line 20 — i.e. immediately after the `Props` interface closing brace and the blank line that follows). Insert this exact block:
+
+```tsx
+function toEditString(v: unknown): string {
+  if (v === null || v === undefined || v === "") return "";
+  if (typeof v === "object") return JSON.stringify(v);
+  return String(v);
+}
+
+```
+
+The function must be at module scope (not inside any component). Keep the trailing blank line after the closing brace so spacing matches the rest of the file.
+
+- [ ] **Step 3: Replace `editValue` initialization**
+
+In `papermite/frontend/src/components/FieldRow.tsx`, replace the exact line:
+
+```tsx
+  const [editValue, setEditValue] = useState(String(value ?? ""));
+```
+
+with:
+
+```tsx
+  const [editValue, setEditValue] = useState(toEditString(value));
+```
+
+- [ ] **Step 4: Replace `displayValue` ternary**
+
+Replace the exact block (lines 121-126 in the original file):
+
+```tsx
+  const displayValue =
+    value === null || value === undefined || value === ""
+      ? "—"
+      : typeof value === "object"
+        ? JSON.stringify(value)
+        : String(value);
+```
+
+with:
+
+```tsx
+  const displayValue = toEditString(value) || "—";
+```
+
+- [ ] **Step 5: Type-check passes**
+
+Run: `cd papermite/frontend && npm run build`
+Expected: build succeeds with no TypeScript errors. (The Vite build runs `tsc -b` first.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add papermite/frontend/src/components/FieldRow.tsx
+git commit -m "fix(papermite): unify FieldRow display + edit serialization via toEditString helper
+
+Prevents '[object Object]' from leaking into the display or edit input
+when a selection field's value is an array or object. The two paths now
+share a single serialization helper that uses JSON.stringify for
+objects/arrays. Part of issue #68 fix."
+```
+
+---
+
+## Task 2: Inline always-visible selection controls
+
+**Files:**
+- Modify: `papermite/frontend/src/components/FieldRow.tsx:136-155`
+
+- [ ] **Step 1: Re-read the Value cell block**
+
+Open `papermite/frontend/src/components/FieldRow.tsx`. After Task 1, the Value cell is a single `<td className="field-row__value">` containing:
+
+```tsx
+        <td className="field-row__value">
+          {editing ? (
+            <input
+              className="input field-row__input"
+              value={editValue}
+              onChange={(e) => setEditValue(e.target.value)}
+              onBlur={handleSave}
+              onKeyDown={handleKeyDown}
+              autoFocus
+            />
+          ) : (
+            <span
+              className="field-row__display"
+              onClick={() => setEditing(true)}
+              title="Click to edit"
+            >
+              {displayValue}
+            </span>
+          )}
+        </td>
+```
+
+This is the block to wrap, not replace.
+
+- [ ] **Step 2: Insert the inline selection branch**
+
+Replace the exact block above with the following. The new `if (fieldType === "selection" && (options?.length ?? 0) > 0)` branch is checked FIRST; if it doesn't match, the existing click-to-edit ternary runs unchanged.
+
+```tsx
+        <td className="field-row__value">
+          {fieldType === "selection" && (options?.length ?? 0) > 0 ? (
+            multiple ? (
+              (() => {
+                const selected = Array.isArray(value)
+                  ? value.filter((s): s is string => typeof s === "string")
+                  : typeof value === "string" && value !== ""
+                    ? [value]
+                    : [];
+                return (
+                  <div className="field-row__multi-edit">
+                    {(options ?? []).map((opt) => (
+                      <label key={opt} className="field-row__multi-edit-label">
+                        <input
+                          type="checkbox"
+                          checked={selected.includes(opt)}
+                          onChange={(e) => {
+                            const next = e.target.checked
+                              ? [...selected, opt]
+                              : selected.filter((s) => s !== opt);
+                            onUpdate(fieldName, next);
+                          }}
+                        />
+                        {opt}
+                      </label>
+                    ))}
+                  </div>
+                );
+              })()
+            ) : (
+              (() => {
+                const currentValue =
+                  typeof value === "string"
+                    ? value
+                    : Array.isArray(value) && typeof value[0] === "string"
+                      ? value[0]
+                      : "";
+                return (
+                  <select
+                    className="input field-row__input"
+                    value={currentValue}
+                    onChange={(e) => onUpdate(fieldName, e.target.value)}
+                  >
+                    <option value="">— none —</option>
+                    {(options ?? []).map((opt) => (
+                      <option key={opt} value={opt}>
+                        {opt}
+                      </option>
+                    ))}
+                  </select>
+                );
+              })()
+            )
+          ) : editing ? (
+            <input
+              className="input field-row__input"
+              value={editValue}
+              onChange={(e) => setEditValue(e.target.value)}
+              onBlur={handleSave}
+              onKeyDown={handleKeyDown}
+              autoFocus
+            />
+          ) : (
+            <span
+              className="field-row__display"
+              onClick={() => setEditing(true)}
+              title="Click to edit"
+            >
+              {displayValue}
+            </span>
+          )}
+        </td>
+```
+
+Notes for the implementer:
+- `multiple` and `options` are already destructured from `Props` at the top of the component (lines 99-100 of the post-Task-1 file). No new prop destructuring needed.
+- The IIFE pattern `(() => { ... })()` is used so the `selected` / `currentValue` locals stay scoped inside JSX without lifting them out of the render. This is intentional — keep them inline.
+- `onUpdate` is already in scope and is the same callback the existing `handleSave` uses.
+
+- [ ] **Step 3: Lint passes**
+
+Run: `cd papermite/frontend && npm run lint`
+Expected: exits 0 with no errors. ESLint may warn about `react-hooks/exhaustive-deps` or unused vars — fix any genuine issues; do not silence rules. If `noUnusedLocals` (TS) flags anything, fix the cause not the symptom.
+
+- [ ] **Step 4: Type-check + build pass**
+
+Run: `cd papermite/frontend && npm run build`
+Expected: TypeScript project references build succeeds, Vite build produces `dist/`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add papermite/frontend/src/components/FieldRow.tsx
+git commit -m "feat(papermite): render inline always-visible selection controls in FieldRow
+
+When a selection field has at least one option defined, the Value cell
+renders a <select> (single-select) or checkbox group (multi-select)
+directly — no click-to-edit toggle. Bound state is derived defensively
+from value so legacy/corrupted shapes recover gracefully. Non-selection
+fields and selection fields with no options keep the existing
+click-to-edit text input.
+
+Fixes #68 user-visible behavior."
+```
+
+---
+
+## Task 3: CSS for the multi-select checkbox group
+
+**Files:**
+- Modify: `papermite/frontend/src/components/EntityCard.css:109-119`
+
+- [ ] **Step 1: Verify the insertion point**
+
+Run: `grep -n "field-row__input\|field-row__required" papermite/frontend/src/components/EntityCard.css`
+
+Expected output includes `.field-row__input` at line 109 and `.field-row__required` at line 116. We will insert two new rules **between** them.
+
+- [ ] **Step 2: Insert the new rules**
+
+In `papermite/frontend/src/components/EntityCard.css`, replace the exact block:
+
+```css
+.field-row__input {
+  padding: 4px 8px;
+  font-size: 14px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.field-row__required {
+```
+
+with:
+
+```css
+.field-row__input {
+  padding: 4px 8px;
+  font-size: 14px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.field-row__multi-edit {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.field-row__multi-edit-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.85rem;
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.field-row__required {
+```
+
+- [ ] **Step 3: Build passes**
+
+Run: `cd papermite/frontend && npm run build`
+Expected: build succeeds (CSS is bundled with no validation, but this catches any accidental syntax error breaking the import chain).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add papermite/frontend/src/components/EntityCard.css
+git commit -m "style(papermite): add inline multi-select checkbox group styles to FieldRow"
+```
+
+---
+
+## Task 4: Add Vitest + React Testing Library harness
+
+**Files:**
+- Modify: `papermite/frontend/package.json`
+- Modify: `papermite/frontend/vite.config.ts`
+- Modify: `papermite/frontend/tsconfig.app.json`
+- Create: `papermite/frontend/src/test/setup.ts`
+
+- [ ] **Step 1: Install dev dependencies**
+
+Run from the repo root:
+
+```bash
+cd papermite/frontend && npm install --save-dev \
+  vitest@^3.0.0 \
+  @testing-library/react@^16.0.0 \
+  @testing-library/jest-dom@^6.0.0 \
+  @testing-library/user-event@^14.0.0 \
+  happy-dom@^16.0.0
+```
+
+Expected: install succeeds. If npm resolves a peer-dep conflict on `react@19`, retry with `--legacy-peer-deps`. Do not downgrade React or testing-library; both support React 19.
+
+- [ ] **Step 2: Update vite.config.ts**
+
+Replace the entire contents of `papermite/frontend/vite.config.ts` (currently 9 lines) with:
+
+```ts
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+import services from '../../services.json'
+
+export default defineConfig({
+  plugins: [react()],
+  server: { port: services.services["papermite-frontend"].port, host: '127.0.0.1' },
+  test: {
+    environment: 'happy-dom',
+    setupFiles: ['./src/test/setup.ts'],
+    globals: true,
+  },
+})
+```
+
+Only two changes from the original: the `defineConfig` import comes from `vitest/config` instead of `vite`, and the `test` block is added. The dev-server config is unchanged.
+
+- [ ] **Step 3: Create the test setup file**
+
+Create `papermite/frontend/src/test/setup.ts` with:
+
+```ts
+import "@testing-library/jest-dom/vitest";
+```
+
+That single line is the entire file.
+
+- [ ] **Step 4: Update tsconfig.app.json**
+
+In `papermite/frontend/tsconfig.app.json`, replace:
+
+```json
+    "types": ["vite/client"],
+```
+
+with:
+
+```json
+    "types": ["vite/client", "vitest/globals", "@testing-library/jest-dom"],
+```
+
+- [ ] **Step 5: Add test scripts to package.json**
+
+In `papermite/frontend/package.json`, replace the existing `"scripts"` block:
+
+```json
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "lint": "eslint .",
+    "preview": "vite preview"
+  },
+```
+
+with:
+
+```json
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "lint": "eslint .",
+    "preview": "vite preview",
+    "test": "vitest",
+    "test:run": "vitest run"
+  },
+```
+
+- [ ] **Step 6: Write a smoke test**
+
+Create `papermite/frontend/src/test/smoke.test.ts` with:
+
+```ts
+import { describe, it, expect } from "vitest";
+
+describe("vitest harness", () => {
+  it("boots", () => {
+    expect(1 + 1).toBe(2);
+  });
+});
+```
+
+- [ ] **Step 7: Run the smoke test**
+
+Run: `cd papermite/frontend && npm run test:run`
+Expected: Vitest discovers `src/test/smoke.test.ts` and the single test passes. Output ends with something like `Test Files  1 passed (1) | Tests  1 passed (1)`. If `happy-dom` errors on import, verify `node_modules/happy-dom` is installed and that the `test.environment` value is the string `"happy-dom"`.
+
+- [ ] **Step 8: Lint passes**
+
+Run: `cd papermite/frontend && npm run lint`
+Expected: exits 0. If ESLint reports `'describe'/'it'/'expect' is not defined` for the smoke test, that means tests need explicit imports (which is what we already do — confirm the file imports them from `"vitest"`).
+
+- [ ] **Step 9: Build still passes**
+
+Run: `cd papermite/frontend && npm run build`
+Expected: `tsc -b && vite build` succeeds. The smoke test file is included in `tsc -b` because `tsconfig.app.json` has `"include": ["src"]`. If `tsc` errors on the missing types, double-check that the `types` array was updated in step 4.
+
+- [ ] **Step 10: Delete the smoke test**
+
+Run: `rm papermite/frontend/src/test/smoke.test.ts`
+
+We delete the smoke test now that it has proven the harness boots; the real tests in Task 5 will replace it. Keep `src/test/setup.ts` — it's the setup file referenced by `vite.config.ts`.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add papermite/frontend/package.json papermite/frontend/package-lock.json papermite/frontend/vite.config.ts papermite/frontend/tsconfig.app.json papermite/frontend/src/test/setup.ts
+git commit -m "chore(papermite): bootstrap Vitest + React Testing Library + happy-dom
+
+Adds the first test harness to papermite/frontend. Imports defineConfig
+from vitest/config (vite's defineConfig has no test typing). Adds
+test/test:run scripts and a single setup file pulling in jest-dom
+matchers. Smoke-tested then removed; real component tests follow."
+```
+
+---
+
+## Task 5: FieldRow component tests
+
+**Files:**
+- Create: `papermite/frontend/src/components/FieldRow.test.tsx`
+
+- [ ] **Step 1: Re-confirm FieldRow's props**
+
+Run: `sed -n '5,18p' papermite/frontend/src/components/FieldRow.tsx`
+
+Expected: shows the `Props` interface with `fieldName`, `value`, `source`, `required`, `fieldType`, `options?`, `multiple?`, `onUpdate`, `onRequiredToggle`, `onTypeChange`, `onOptionsChange`, `onDelete?`.
+
+`FieldRow` is the default export at the bottom of the file. It must be rendered inside a `<table><tbody>` because it returns `<tr>` rows. The tests below wrap renders accordingly.
+
+- [ ] **Step 2: Create FieldRow.test.tsx**
+
+Create `papermite/frontend/src/components/FieldRow.test.tsx` with the exact content below:
+
+```tsx
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import FieldRow from "./FieldRow";
+import type { FieldType } from "../types/models";
+
+interface FieldRowTestProps {
+  fieldName?: string;
+  value?: unknown;
+  source?: "base_model" | "custom_field";
+  required?: boolean;
+  fieldType?: FieldType;
+  options?: string[];
+  multiple?: boolean;
+  onUpdate?: (fieldName: string, value: unknown) => void;
+  onRequiredToggle?: (fieldName: string, required: boolean) => void;
+  onTypeChange?: (fieldName: string, fieldType: FieldType) => void;
+  onOptionsChange?: (
+    fieldName: string,
+    options: string[],
+    multiple: boolean
+  ) => void;
+  onDelete?: () => void;
+}
+
+function renderRow(overrides: FieldRowTestProps = {}) {
+  const onUpdate = overrides.onUpdate ?? vi.fn();
+  const onRequiredToggle = overrides.onRequiredToggle ?? vi.fn();
+  const onTypeChange = overrides.onTypeChange ?? vi.fn();
+  const onOptionsChange = overrides.onOptionsChange ?? vi.fn();
+
+  const utils = render(
+    <table>
+      <tbody>
+        <FieldRow
+          fieldName={overrides.fieldName ?? "grade_level"}
+          value={overrides.value}
+          source={overrides.source ?? "custom_field"}
+          required={overrides.required ?? false}
+          fieldType={overrides.fieldType ?? "str"}
+          options={overrides.options}
+          multiple={overrides.multiple}
+          onUpdate={onUpdate}
+          onRequiredToggle={onRequiredToggle}
+          onTypeChange={onTypeChange}
+          onOptionsChange={onOptionsChange}
+          onDelete={overrides.onDelete}
+        />
+      </tbody>
+    </table>
+  );
+
+  return { ...utils, onUpdate, onRequiredToggle, onTypeChange, onOptionsChange };
+}
+
+describe("FieldRow", () => {
+  it("renders an object value as JSON, never as [object Object]", () => {
+    renderRow({ value: { a: 1 }, fieldType: "str" });
+    expect(screen.getByText('{"a":1}')).toBeInTheDocument();
+    expect(screen.queryByText(/\[object Object\]/)).not.toBeInTheDocument();
+  });
+
+  it("initializes the text-edit input via JSON.stringify for array-of-objects", () => {
+    renderRow({ value: [{ x: 1 }], fieldType: "str" });
+    fireEvent.click(screen.getByText('[{"x":1}]'));
+    const input = screen.getByDisplayValue('[{"x":1}]') as HTMLInputElement;
+    expect(input).toBeInTheDocument();
+    expect(input.value).not.toBe("[object Object]");
+  });
+
+  it("renders a <select> inline for single-select with options (no click required)", () => {
+    const { onUpdate } = renderRow({
+      // base_model so the data-type column renders a locked <span>, not a <select>;
+      // this keeps the Value cell's <select> the only combobox in the row.
+      source: "base_model",
+      required: true,
+      value: "Active",
+      fieldType: "selection",
+      options: ["Active", "Inactive"],
+      multiple: false,
+    });
+
+    const select = screen.getByRole("combobox") as HTMLSelectElement;
+    expect(select).toBeInTheDocument();
+    expect(select.value).toBe("Active");
+    const optionValues = Array.from(select.options).map((o) => o.value);
+    expect(optionValues).toEqual(["", "Active", "Inactive"]);
+
+    fireEvent.change(select, { target: { value: "Inactive" } });
+    expect(onUpdate).toHaveBeenCalledWith("grade_level", "Inactive");
+  });
+
+  it("renders one checkbox per option inline for multi-select with options", () => {
+    const { onUpdate } = renderRow({
+      source: "base_model",
+      required: true,
+      fieldName: "days_of_week",
+      value: ["Mon"],
+      fieldType: "selection",
+      options: ["Mon", "Tue", "Wed"],
+      multiple: true,
+    });
+
+    const checkboxes = screen.getAllByRole("checkbox");
+    // The Required column also has a checkbox, so we filter by accessible name.
+    const optionBoxes = checkboxes.filter((cb) =>
+      ["Mon", "Tue", "Wed"].some((label) =>
+        cb.closest("label")?.textContent?.includes(label)
+      )
+    );
+    expect(optionBoxes).toHaveLength(3);
+    expect((optionBoxes[0] as HTMLInputElement).checked).toBe(true);
+    expect((optionBoxes[1] as HTMLInputElement).checked).toBe(false);
+    expect((optionBoxes[2] as HTMLInputElement).checked).toBe(false);
+
+    fireEvent.click(optionBoxes[1]);
+    expect(onUpdate).toHaveBeenCalledWith("days_of_week", ["Mon", "Tue"]);
+  });
+
+  it("falls back to text input when selection has no options yet", () => {
+    renderRow({
+      value: "seed",
+      fieldType: "selection",
+      options: [],
+    });
+
+    expect(screen.queryByRole("combobox")).toBeNull();
+    expect(screen.getByText("seed")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("seed"));
+    expect(screen.getByDisplayValue("seed")).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 3: Run the new tests**
+
+Run: `cd papermite/frontend && npm run test:run`
+Expected: Vitest discovers `src/components/FieldRow.test.tsx`, all 5 tests pass. Output ends with `Test Files  1 passed (1) | Tests  5 passed (5)`.
+
+If a test fails:
+- "Found multiple elements with role combobox" → there is more than one `<select>` rendered (e.g. the data-type selector). The single-select test renders with `source: "custom_field"` so the data-type `<select>` is also present. Switch `screen.getByRole("combobox")` to `screen.getAllByRole("combobox")` and pick the one whose `<option>` values match `options`.
+- "Element ... not found" for `[object Object]` queries → that's good, the regex `queryByText(/\[object Object\]/)` returning null is the assertion's expectation.
+
+Tests 3 and 4 render with `source: "base_model"` to keep the data-type column as a locked `<span>` so there's only one combobox in the row. If that's missed and you do hit a multiple-combobox failure, replace the test's `const select = screen.getByRole("combobox") as HTMLSelectElement;` with:
+
+```tsx
+    const selects = screen.getAllByRole("combobox") as HTMLSelectElement[];
+    const select = selects.find((s) =>
+      Array.from(s.options).some((o) => o.value === "Active")
+    )!;
+```
+
+and continue the test as written. Re-run.
+
+- [ ] **Step 4: Lint passes**
+
+Run: `cd papermite/frontend && npm run lint`
+Expected: exits 0. The test file uses explicit imports (`describe`, `it`, `expect`, `vi`, `fireEvent`, `render`, `screen`) so ESLint won't complain about undefined globals.
+
+- [ ] **Step 5: Build passes**
+
+Run: `cd papermite/frontend && npm run build`
+Expected: `tsc -b && vite build` succeeds. The test file is in `src/` so `tsc` will type-check it; the `vitest/globals` and `@testing-library/jest-dom` types from Task 4 satisfy any global references.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add papermite/frontend/src/components/FieldRow.test.tsx
+git commit -m "test(papermite): cover FieldRow safe serialization + inline selection controls
+
+Five component tests:
+- object value displays as JSON, never [object Object]
+- array-of-objects text-edit input initializes via JSON.stringify
+- single-select with options renders <select> inline, change calls onUpdate
+- multi-select with options renders checkbox group, toggle calls onUpdate with array
+- selection with empty options falls back to click-to-edit text input
+
+Regression coverage for issue #68."
+```
+
+---
+
+## Task 6: Manual verification
+
+**Files:** none (manual)
+
+- [ ] **Step 1: Start services**
+
+Run: `./start-services.sh`
+Expected: launchpad, papermite, admindash, and datacore start. Output shows each service's port (papermite frontend at 5700).
+
+- [ ] **Step 2: Verify lint, build, and tests are green**
+
+```bash
+cd papermite/frontend && npm run lint && npm run build && npm run test:run
+```
+
+Expected: all three exit 0, tests show `5 passed`.
+
+- [ ] **Step 3: Reproduce the original bug pre-condition**
+
+Open `http://localhost:5700` in a browser. Authenticate as the test tenant admin. From the Landing page choose **Upload New Document** and upload any sample document that has fields the AI extracts into list/dict shapes (e.g., a registration form with grade levels or days-of-week sections). On the Review page, locate a selection field whose extracted `value` is a list or dict.
+
+Expected: the Value cell shows a JSON-encoded string (e.g. `["1st","2nd"]` or `{"Mon":true}`) — NOT `"[object Object]"` or `"[object Object],[object Object]"`. The bug is no longer reproducible regardless of clicking.
+
+- [ ] **Step 4: Verify inline single-select dropdown**
+
+On the same Review page, find a selection field with `multiple: false` and at least one defined option (e.g. Student `status` or Student `gender`).
+
+Expected: the Value cell shows a dropdown (`<select>`) directly without any click required. Change selection — the row reflects the new value immediately. Refresh the page; the new value persists via IndexedDB.
+
+- [ ] **Step 5: Verify inline multi-select checkbox group**
+
+On the same Review page (or upload a doc that includes a Program), find a selection field with `multiple: true` (e.g. Program `grade_levels` or Program `days_of_week`).
+
+Expected: the Value cell shows a row of checkboxes, one per option, without any click required. Toggling multiple options updates the value as an array. Refresh — array persists.
+
+- [ ] **Step 6: Verify text-input fallback for non-selection fields**
+
+Find a non-selection field (e.g. Student `first_name`).
+
+Expected: existing behavior unchanged — click the value, a text input appears, edit, press Enter or blur to save.
+
+- [ ] **Step 7: Verify text-input fallback for selection-with-no-options**
+
+Add a custom field via the **+ Add field** form at the bottom of an entity, then change its data type to `selection` via the type dropdown.
+
+Expected: because no options are defined yet, the Value cell uses the click-to-edit text input (not the inline `<select>`).
+
+- [ ] **Step 8: Verify OptionsEditor panel still works (regression check)**
+
+Click the `[N opts]` button in the Data Type column on any selection field.
+
+Expected: the existing `OptionsEditor` panel opens below the row, with the `Allow multiple` toggle and add/remove option tags. Adding a new option and toggling `Allow multiple` both work. When `Allow multiple` is toggled, the Value cell flips between dropdown and checkbox group inline.
+
+- [ ] **Step 9: Final commit if any cleanups**
+
+Most likely there are no further changes. If anything was tweaked during manual testing:
+
+```bash
+git add papermite/frontend
+git commit -m "chore(papermite): minor cleanup from manual verification"
+```
+
+Otherwise skip this step.
+
+---
+
+## Spec coverage summary
+
+| Spec requirement | Plan tasks |
+|---|---|
+| `FieldRow display value safely serializes objects and arrays` (4 scenarios) | Task 1 (helper + display path), Task 5 test 1 |
+| `Text-input edit mode initialization mirrors display serialization` (2 scenarios) | Task 1 (editValue path), Task 5 test 2 |
+| `Selection field with options renders an inline always-visible control` (4 scenarios) | Task 2 (inline branch), Task 3 (CSS), Task 5 tests 3 & 4, Task 6 steps 4 & 5 |
+| `Inline selection control binds defensively to legacy values` (4 scenarios) | Task 2 (`selected`/`currentValue` guards), Task 6 step 3 |
+| `Selection field with no options falls back to text editor` (1 scenario) | Task 2 (untouched fallback branch), Task 5 test 5, Task 6 step 7 |
+
+All five requirements and 15 scenarios are covered.

--- a/openspec/changes/papermite-selection-edit-display/.openspec.yaml
+++ b/openspec/changes/papermite-selection-edit-display/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-15

--- a/openspec/changes/papermite-selection-edit-display/design.md
+++ b/openspec/changes/papermite-selection-edit-display/design.md
@@ -1,0 +1,106 @@
+## Context
+
+`papermite/frontend/src/components/FieldRow.tsx` is the per-field row in the Review page's `EntityCard`. It supports:
+
+1. Editing a field's sample value (click value → text input → blur/Enter saves).
+2. Changing the field's data type (custom fields only).
+3. For selection fields: opening an inline `OptionsEditor` to add/remove allowed options and toggle `multiple`.
+
+The current edit path uses a single text input regardless of `fieldType`. The bug is at line 108:
+
+```tsx
+const [editValue, setEditValue] = useState(String(value ?? ""));
+```
+
+`String(value)` on an array/object produces `"[object Object],[object Object]"`. Meanwhile, the read-only display path at lines 121-126 already handles objects with `JSON.stringify`, so the two are inconsistent.
+
+Selection-type field values flow in from `services/mapper.py` and can be:
+- `null` / missing
+- A single string (`"Active"`)
+- A list of strings (`["1st", "2nd"]`)
+- A list of dicts in pathological extractions (`[{...}, {...}]`) — this is the bug-triggering shape.
+
+`FieldMapping.options` is `string[] | undefined` and `multiple` is `boolean | undefined`. The Review page's value editor is meant to let the user fix a sample/example value, not bulk-edit data, so a richer control is acceptable.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Clicking a selection field with object/array `value` never shows `"[object Object]"` — neither in display nor in the edit input.
+- When a selection field has `options.length > 0`, the editor uses a control that constrains input to those options.
+- Multi-select fields (`multiple: true`) edit as an array of strings; single-select fields edit as a string.
+- Saving never produces a value whose shape contradicts the field's declared `multiple` flag.
+
+**Non-Goals:**
+- Changing the storage shape of `FieldMapping.value` (still `unknown`).
+- Touching AdminDash `DynamicForm` or Launchpad `FieldInput` (already covered by `selection-cardinality`).
+- Adding generalized form validation across all field types — only the selection branch gets specialized handling.
+- Building a full React Testing Library setup if one doesn't already exist; we'll keep tests lightweight and pragmatic (see Risks).
+
+## Decisions
+
+### Decision 1: Render selection controls always-inline in the Value cell (no click-to-edit toggle for selection-with-options)
+**What:** When `fieldType === "selection"` and `(options?.length ?? 0) > 0`, the Value cell renders the appropriate control directly — bypassing the existing display-span + edit-input toggle pattern. For all other cases (non-selection fields, or selection fields with no options), the existing click-to-edit text input is preserved.
+
+**Why:** Consistent with the `OptionsEditor` panel in the same component (also always-visible when its `[N opts]` button is toggled). Eliminates a transient edit state and the awkward "how do I exit multi-select edit mode" problem (no Done button needed, no click-outside handler). The control IS the display. Alternative considered: click-to-edit with a Done button — rejected because it adds a foreign affordance inside a table cell and complicates focus/state management.
+
+### Decision 2: Use `<select>` for single-select with options
+**What:** When `fieldType === "selection"`, `!multiple`, and `options.length > 0`, render `<select className="input field-row__input">` with `<option value="">— none —</option>` plus one `<option>` per allowed value. `onChange` calls `onUpdate(fieldName, e.target.value)` directly — no edit-mode entry/exit.
+
+**Why:** Single-cell dropdown matches the data-type `<select>` already in this component (line 161-169) for visual consistency. Reuses existing `.input` and `.field-row__input` styles, so no new CSS is needed for the single-select case. Radio buttons would be over-tall and crowd the table row.
+
+### Decision 3: Use inline checkboxes for multi-select with options
+**What:** When `fieldType === "selection"`, `multiple === true`, and `options.length > 0`, render a `<div className="field-row__multi-edit">` with one `<label><input type="checkbox"/>{opt}</label>` per option. Each `onChange` computes the next array (add or remove `opt`) and calls `onUpdate(fieldName, next)` directly — no edit-mode entry/exit, no Done button.
+
+**Why:** `<select multiple>` in a table cell is unwieldy. Inline checkboxes match the established Papermite tag/option visual pattern (see `options-editor__list`). With save-on-toggle and no edit mode, there's no need for a commit affordance.
+
+### Decision 4: Single `toEditString(v)` helper for display + fallback edit input
+**What:** Extract one helper used in both the display path (for non-selection fields, and selection fields without options) and the text-input fallback edit-init:
+
+```tsx
+const toEditString = (v: unknown): string =>
+  v === null || v === undefined || v === ""
+    ? ""
+    : typeof v === "object"
+      ? JSON.stringify(v)
+      : String(v);
+```
+
+Display path uses `toEditString(value) || "—"` (em-dash for empty); edit-init uses `toEditString(value)` directly. This eliminates the `String(value)` path entirely so no `"[object Object]"` can be produced anywhere in the component.
+
+**Why:** One helper, one place to test, no risk of the two serializers drifting again. The em-dash placeholder behavior is preserved by the `|| "—"` fallback for the display case only.
+
+### Decision 5: Sanitize legacy/garbage values when binding to the inline control
+**What:** Derive the control's bound state defensively from `value`:
+- Single-select dropdown's `currentValue`: `typeof value === "string" ? value : (Array.isArray(value) && typeof value[0] === "string" ? value[0] : "")` — array with string head → use head; anything else → empty.
+- Multi-select checkboxes' `selected` set: `Array.isArray(value) ? value.filter((s): s is string => typeof s === "string") : (typeof value === "string" ? [value] : [])` — array → keep only string entries; string → wrap; anything else → empty.
+
+**Why:** Drafts persisted to IndexedDB before this fix may contain `"[object Object]"` strings or raw object arrays. The control recovers gracefully (no error, no spurious selection) so the user can pick a valid option and overwrite. No migration step is needed.
+
+### Decision 6: Add Vitest 3 + React Testing Library + happy-dom; use `vitest/config` for the test block
+**What:** Bootstrap Vitest with React Testing Library and `happy-dom` in `papermite/frontend`. Important: `vite.config.ts` currently uses `defineConfig` imported from `vite`, which has no `test` typing. Two acceptable shapes:
+- **Recommended:** Switch the import in `vite.config.ts` to `import { defineConfig } from "vitest/config"` and add a `test` block.
+- Alternative: keep `vite.config.ts` as-is and create a separate `vitest.config.ts` that imports from `vitest/config`.
+
+Add `test`/`test:run` scripts, a `src/test/setup.ts` that imports `@testing-library/jest-dom/vitest`, and update `tsconfig.app.json`'s `compilerOptions.types` from `["vite/client"]` to `["vite/client", "vitest/globals", "@testing-library/jest-dom"]`.
+
+Note: `tsconfig.app.json` has `verbatimModuleSyntax: true`, so test files MUST use `import type {...}` for type-only imports (e.g., `import type { FieldType } from "../types/models"`). Existing files in `src/` already follow this pattern.
+
+Tests cover four focused cases for `FieldRow`:
+1. Object value displays as JSON, never `"[object Object]"`.
+2. Non-selection field with array-of-objects value entering edit mode initializes the text input via `JSON.stringify`, never `String(value)`.
+3. Selection field with `multiple: false` + options renders a `<select>` inline (not click-to-edit) and `onUpdate` is called with the chosen string on change.
+4. Selection field with `multiple: true` + options renders one checkbox per option inline; toggling `"Tue"` on a field whose current value is `["Mon"]` invokes `onUpdate(fieldName, ["Mon", "Tue"])`.
+
+**Why:** User opted in over the deferred-harness alternative; locks in regression coverage and establishes the test pattern for future papermite frontend work. `happy-dom` over `jsdom` for faster startup; trivial to swap if quirks appear. Pinning to Vitest 3+ ensures compatibility with Vite 8 already in `package.json`.
+
+## Risks / Trade-offs
+
+- **Risk:** Adding Vitest as the first test harness in `papermite/frontend` introduces new dev deps, a config decision, and tsconfig changes. → Mitigation: scoped to `papermite/frontend` only; no impact on other services. Use Vitest 3+ for Vite 8 compatibility.
+- **Risk:** Always-inline controls add visual weight to every Review-page row with a selection field. → Mitigation: dropdown reuses existing `.input` / `.field-row__input` styles so visual footprint matches the data-type select; checkbox group wraps via flex like `OptionsEditor` already does.
+- **Trade-off:** Removing click-to-edit for selection-with-options means the cell is interactive on mount (no "click first" affordance). → Mitigation: this is consistent with the data-type `<select>` in the same row, which is also always-interactive; user mental model is preserved.
+- **Risk:** Multi-select editor doesn't expose a "clear all" affordance. → Mitigation: deferred; user can uncheck each option, and the row's `value` becomes `[]` which serializes back cleanly.
+- **Risk:** Drafts persisted to IndexedDB before this fix may contain corrupted `"[object Object]"` strings. → Mitigation: Decision 5's defensive binding leaves no selection in that state; user picks a real option and the next save overwrites the bad value.
+
+## Open Questions
+
+- (Resolved) Add Vitest harness to `papermite/frontend` as part of this change — see Decision 6.

--- a/openspec/changes/papermite-selection-edit-display/proposal.md
+++ b/openspec/changes/papermite-selection-edit-display/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+In Papermite's Review page, clicking a selection-type field's value to edit reveals a corrupted string like `"[object Object],[object Object]"` whenever the underlying value is an array or object (issue #68). The bug exists because `FieldRow.tsx` initializes `editValue` with `String(value ?? "")` while the read-only display path uses `JSON.stringify` for objects — the two serializers disagree, and the edit path silently round-trips garbage back into the model definition draft if the user saves.
+
+Beyond the serialization mismatch, the underlying UX is wrong for selection fields: even with valid string options, the editor is a free-text input. Users can type arbitrary text that violates the declared option set, defeating the purpose of having `options`/`multiple` on the field.
+
+## What Changes
+
+- Fix the immediate display bug: `editValue` initialization SHALL use the same serializer as the read-only display so object/array values do not collapse into `"[object Object]"` on first click.
+- Render a selection-aware control **inline and always-visible** in the Value cell when a `selection`-type field has at least one option defined — no click-to-edit toggle for selection fields with options:
+  - `multiple: false` → `<select>` dropdown bound to the option list, with an empty/placeholder choice for the unset state. Choosing an option saves immediately.
+  - `multiple: true` → inline checkbox group, one per option, persisting an array of selected option strings. Each toggle saves immediately.
+- Preserve the existing click-to-edit text input **only** when the field is `selection`-type but has no options defined yet (so users can still seed values from a fresh extraction before opening the options editor), or for any non-selection field.
+- Add/remove options remains handled by the existing `OptionsEditor` panel (toggled by the `[N opts]` button in the Data Type column); this change does not touch that flow.
+- Sanitize legacy values when binding to the inline control:
+  - Array of strings → bind to multi-select state (`multiple: true`) or first element (`multiple: false`).
+  - Array of objects / generic object → leave no option pre-selected and let the user choose afresh, but never coerce to `"[object Object]"`.
+- Out of scope: AdminDash `DynamicForm` and Launchpad `FieldInput` — they already render radio/checkbox controls via the `selection-cardinality` capability and are not affected by this bug.
+
+## Capabilities
+
+### New Capabilities
+- `papermite-field-row-editor`: Defines how Papermite's Review-page FieldRow renders and edits values per field type, focusing on selection-aware editing and safe serialization of object/array values.
+
+### Modified Capabilities
+<!-- selection-cardinality covers AdminDash/Launchpad rendering and the model-level multiple property. Papermite's editor was deliberately out of that scope, so we are NOT modifying that capability — we are adding a sibling. -->
+
+## Impact
+
+- Code: `papermite/frontend/src/components/FieldRow.tsx` (edit-value initialization + new selection editor branches), `papermite/frontend/src/components/FieldRow.css` (or `EntityCard.css`) for the new dropdown/checkbox group styles.
+- Tests: New unit tests for FieldRow selection edit behavior — likely the first React component tests in the papermite frontend, so we will add Vitest + React Testing Library setup if not already present.
+- No backend changes. No changes to `FieldMapping` schema, mapper, or LanceDB storage. No changes to other frontends.
+- No breaking changes to persisted model definitions; the fix is purely render/editor behavior.

--- a/openspec/changes/papermite-selection-edit-display/specs/papermite-field-row-editor/spec.md
+++ b/openspec/changes/papermite-selection-edit-display/specs/papermite-field-row-editor/spec.md
@@ -1,0 +1,84 @@
+## ADDED Requirements
+
+### Requirement: FieldRow display value safely serializes objects and arrays
+The Papermite Review-page `FieldRow` component SHALL display a field's `value` without producing the string `"[object Object]"`. For `null`, `undefined`, or empty-string values, the row SHALL render an em-dash placeholder. For values whose `typeof` is `"object"` (including arrays and plain objects), the row SHALL render `JSON.stringify(value)`. For all other values, the row SHALL render `String(value)`. The same serialization helper SHALL be used for both display text and any text-input edit-mode initialization, so the two paths cannot drift.
+
+#### Scenario: Object value renders as JSON
+- **WHEN** a FieldRow receives a value of `{ a: 1 }`
+- **THEN** the display SHALL show `{"a":1}` and SHALL NOT show `"[object Object]"`
+
+#### Scenario: Array-of-objects value renders as JSON
+- **WHEN** a FieldRow receives a value of `[{ x: 1 }, { y: 2 }]`
+- **THEN** the display SHALL show `[{"x":1},{"y":2}]` and SHALL NOT show `"[object Object],[object Object]"`
+
+#### Scenario: Null value renders as placeholder
+- **WHEN** a FieldRow receives a value of `null`, `undefined`, or `""`
+- **THEN** the display SHALL show the em-dash placeholder `"—"`
+
+#### Scenario: Primitive value renders as string
+- **WHEN** a FieldRow receives a value of `"Active"` or `42` or `true`
+- **THEN** the display SHALL show `"Active"` or `"42"` or `"true"` respectively
+
+### Requirement: Text-input edit mode initialization mirrors display serialization
+For non-selection fields and selection fields with no options defined, the FieldRow SHALL preserve its existing click-to-edit text-input behavior. When entering text-edit mode, the input's initial value SHALL be produced by the same serialization helper used for display. The input value SHALL NEVER be initialized via `String(value)` on a non-null object or array.
+
+#### Scenario: Object value in text-edit input
+- **WHEN** a non-selection field with value `{ a: 1 }` enters edit mode
+- **THEN** the text input SHALL be initialized to `{"a":1}`
+- **AND** SHALL NOT be initialized to `"[object Object]"`
+
+#### Scenario: Array-of-strings value in text-edit input
+- **WHEN** a non-selection field with value `["Monday","Tuesday"]` enters edit mode
+- **THEN** the text input SHALL be initialized to `'["Monday","Tuesday"]'`
+
+### Requirement: Selection field with options renders an inline always-visible control
+When a FieldRow has `fieldType === "selection"` and `options.length > 0`, the Value cell SHALL render an inline always-visible control sized to the cell — bypassing the click-to-edit pattern used by text fields. The control SHALL be a `<select>` dropdown for `multiple: false` (or absent) and a checkbox group for `multiple: true`. No "Done" button or edit-mode toggle SHALL be required to interact with the control.
+
+#### Scenario: Single-select with options always renders a dropdown
+- **WHEN** a selection field with `multiple: false` and `options: ["Active","Inactive"]` is rendered
+- **THEN** the Value cell SHALL contain a `<select>` element with one `<option>` per allowed value plus an empty placeholder option
+- **AND** no click-to-edit transition SHALL be required
+
+#### Scenario: Multi-select with options always renders a checkbox group
+- **WHEN** a selection field with `multiple: true` and `options: ["Mon","Tue","Wed"]` is rendered
+- **THEN** the Value cell SHALL contain three checkboxes, one per option, each with its option label
+- **AND** no click-to-edit transition SHALL be required
+
+#### Scenario: Choosing a dropdown option saves immediately
+- **WHEN** the user selects an option from the inline dropdown
+- **THEN** the field's value SHALL be updated to that option string
+- **AND** no additional confirmation action SHALL be required
+
+#### Scenario: Toggling a checkbox updates the value array
+- **WHEN** the user checks the `"Tue"` checkbox on a field whose current value is `["Mon"]`
+- **THEN** the field's value SHALL become an array containing both `"Mon"` and `"Tue"` (any order)
+- **AND** no additional confirmation action SHALL be required
+
+### Requirement: Inline selection control binds defensively to legacy values
+The inline selection control SHALL bind its current state defensively from the field's `value`, recovering gracefully when `value` does not match the declared cardinality. The control SHALL NEVER raise an error or display `"[object Object]"` for malformed values.
+
+#### Scenario: Single-select dropdown ignores legacy array value
+- **WHEN** a single-select field has a current value of `["Active"]` (legacy array)
+- **THEN** the dropdown SHALL preselect `"Active"` (the first string element)
+
+#### Scenario: Single-select dropdown shows no selection for object value
+- **WHEN** a single-select field has a current value of `{ x: 1 }` or `[{ x: 1 }]`
+- **THEN** the dropdown SHALL show no option selected (the empty placeholder)
+- **AND** SHALL NOT raise an error
+
+#### Scenario: Multi-select checkboxes wrap a string legacy value
+- **WHEN** a multi-select field has a current value of `"Mon"` (legacy string)
+- **THEN** the editor SHALL render with the `"Mon"` checkbox pre-checked and other options unchecked
+
+#### Scenario: Multi-select checkboxes ignore non-string array entries
+- **WHEN** a multi-select field has a current value of `[{ x: 1 }, "Mon"]`
+- **THEN** only the `"Mon"` checkbox SHALL be pre-checked
+- **AND** the editor SHALL NOT raise an error
+
+### Requirement: Selection field with no options falls back to text editor
+When a FieldRow has `fieldType === "selection"` but `options` is empty or undefined, the Value cell SHALL preserve the existing click-to-edit text-input behavior, so users can seed values before defining the option list via the `OptionsEditor` panel.
+
+#### Scenario: No options yet — text input fallback
+- **WHEN** a selection field has `options: []` and the user clicks the Value cell
+- **THEN** the editor SHALL be the same text input used for non-selection fields
+- **AND** the input value SHALL be initialized via the safe serialization helper

--- a/openspec/changes/papermite-selection-edit-display/tasks.md
+++ b/openspec/changes/papermite-selection-edit-display/tasks.md
@@ -1,0 +1,49 @@
+## 1. Safe serialization helper
+
+- [ ] 1.1 In `papermite/frontend/src/components/FieldRow.tsx`, add a module-scope helper `toEditString(v: unknown): string` returning `""` for null/undefined/empty-string, `JSON.stringify(v)` for objects/arrays (`typeof v === "object" && v !== null`), and `String(v)` otherwise.
+- [ ] 1.2 Replace the inline `displayValue` ternary (lines 121-126) with `const displayValue = toEditString(value) || "—"`.
+- [ ] 1.3 Replace `useState(String(value ?? ""))` (line 108) with `useState(toEditString(value))`.
+- [ ] 1.4 Confirm `cd papermite/frontend && npm run build` passes.
+
+## 2. Inline selection controls (always-visible, no edit-mode toggle)
+
+- [ ] 2.1 In `FieldRow.tsx`, inside the Value `<td>` (currently the `editing ? <input> : <span>` ternary), add a top-level conditional BEFORE the existing ternary: if `fieldType === "selection"` and `(options?.length ?? 0) > 0`, render the inline selection control; otherwise fall through to the existing click-to-edit logic.
+- [ ] 2.2 Implement the single-select branch (`!multiple`): compute `currentValue = typeof value === "string" ? value : (Array.isArray(value) && typeof value[0] === "string" ? value[0] : "")`. Render `<select className="input field-row__input" value={currentValue} onChange={(e) => onUpdate(fieldName, e.target.value)}>` with `<option value="">— none —</option>` followed by `(options ?? []).map(opt => <option key={opt} value={opt}>{opt}</option>)`.
+- [ ] 2.3 Implement the multi-select branch (`multiple === true`): compute `selected = Array.isArray(value) ? value.filter((s): s is string => typeof s === "string") : (typeof value === "string" ? [value] : [])`. Render `<div className="field-row__multi-edit">{(options ?? []).map(opt => <label key={opt} className="field-row__multi-edit-label"><input type="checkbox" checked={selected.includes(opt)} onChange={(e) => { const next = e.target.checked ? [...selected, opt] : selected.filter(s => s !== opt); onUpdate(fieldName, next); }} />{opt}</label>)}</div>`.
+- [ ] 2.4 Verify the existing `editing` state and click-to-edit code remain untouched for the fallback path (non-selection fields, or selection fields with `options.length === 0`).
+- [ ] 2.5 `cd papermite/frontend && npm run lint && npm run build` — both pass.
+
+## 3. Styles for multi-select inline control
+
+- [ ] 3.1 In `papermite/frontend/src/components/EntityCard.css` (which already houses all `.field-row*` styles, confirmed by grep), append rules near the existing `.field-row__input` block: `.field-row__multi-edit { display: flex; flex-wrap: wrap; gap: 0.4rem; }` and `.field-row__multi-edit-label { display: inline-flex; align-items: center; gap: 0.25rem; font-size: 0.85rem; color: var(--text-primary); cursor: pointer; }`.
+- [ ] 3.2 Confirm the dropdown reuses existing `.input` / `.field-row__input` styling without further CSS additions.
+
+## 4. Vitest + React Testing Library harness
+
+- [ ] 4.1 Add dev dependencies to `papermite/frontend/package.json`: `vitest@^3.0.0`, `@testing-library/react@^16.0.0`, `@testing-library/jest-dom@^6.0.0`, `@testing-library/user-event@^14.0.0`, `happy-dom@^16.0.0` (pin majors only). Run `npm install` to update the lockfile.
+- [ ] 4.2 Update `papermite/frontend/vite.config.ts`: change `import { defineConfig } from "vite"` to `import { defineConfig } from "vitest/config"`, and add a `test` block: `test: { environment: "happy-dom", setupFiles: ["./src/test/setup.ts"], globals: true }`. (Alternative: keep `vite.config.ts` as-is and create a separate `vitest.config.ts` importing from `vitest/config` — choose whichever the codebase reviewer prefers during implementation.)
+- [ ] 4.3 Create `papermite/frontend/src/test/setup.ts` with `import "@testing-library/jest-dom/vitest";`.
+- [ ] 4.4 Update `papermite/frontend/tsconfig.app.json`: change `"types": ["vite/client"]` to `"types": ["vite/client", "vitest/globals", "@testing-library/jest-dom"]`.
+- [ ] 4.5 Add scripts to `papermite/frontend/package.json`: `"test": "vitest"` and `"test:run": "vitest run"`.
+- [ ] 4.6 Smoke-test: create `papermite/frontend/src/test/smoke.test.ts` with a one-line `it("boots", () => { expect(1 + 1).toBe(2); });`. Run `npm run test:run` — passes.
+- [ ] 4.7 Verify ESLint still passes (`npm run lint`); if it complains about test files, add a matching ignore or override in the ESLint config. Delete the smoke test once the harness is confirmed working.
+
+## 5. FieldRow component tests
+
+- [ ] 5.1 Create `papermite/frontend/src/components/FieldRow.test.tsx`. Add a `renderRow(propsOverride?: Partial<FieldRowProps>)` helper inside the file that supplies all required props with sensible defaults and merges overrides. Use `import type { FieldType } from "../types/models"` for type-only imports (the project has `verbatimModuleSyntax: true`).
+- [ ] 5.2 Test: object value renders as JSON in display. Render with `value={{ a: 1 }}`, `fieldType="str"`. Assert the rendered text includes `{"a":1}` and does NOT include `[object Object]`.
+- [ ] 5.3 Test: non-selection field with array-of-objects entering text-edit mode. Render with `value={[{ x: 1 }]}`, `fieldType="str"`. Click the value span. Assert the input's `value` attribute is `[{"x":1}]`, not `[object Object]`.
+- [ ] 5.4 Test: selection field with `multiple: false` + options renders a `<select>` inline (no click required). Render with `value="Active"`, `fieldType="selection"`, `options=["Active","Inactive"]`, `multiple=false`. Assert a `<select>` is present, with options for `""`, `"Active"`, `"Inactive"`. Fire `change` to `"Inactive"`. Assert `onUpdate` was called with `("fieldName", "Inactive")`.
+- [ ] 5.5 Test: selection field with `multiple: true` + options renders three checkboxes inline. Render with `value=["Mon"]`, `fieldType="selection"`, `options=["Mon","Tue","Wed"]`, `multiple=true`. Assert three checkboxes present; `"Mon"` is checked, others unchecked. Click the `"Tue"` checkbox. Assert `onUpdate` was called with `("fieldName", ["Mon","Tue"])`.
+- [ ] 5.6 Run `cd papermite/frontend && npm run test:run` — all five tests pass.
+
+## 6. Verification
+
+- [ ] 6.1 `cd papermite/frontend && npm run lint` passes.
+- [ ] 6.2 `cd papermite/frontend && npm run build` passes (TypeScript project references + Vite build).
+- [ ] 6.3 `cd papermite/frontend && npm run test:run` passes.
+- [ ] 6.4 Run `./start-services.sh`. Open Papermite at `http://localhost:5700`, upload a sample doc, navigate to the Review page. On a selection field whose extracted value is an array of objects or dicts, confirm the cell shows readable text (JSON) and NOT `"[object Object]"`.
+- [ ] 6.5 On a single-select selection field with options defined, confirm the dropdown is always visible inline. Change selection — verify the row state updates and persists via IndexedDB across a page reload.
+- [ ] 6.6 On a multi-select selection field with options defined, confirm the checkbox group is always visible inline. Toggle multiple options — verify the value persists as an array and survives a page reload.
+- [ ] 6.7 On a non-selection field (e.g., `str` type) or a selection field with empty options, confirm the original click-to-edit text input still works (regression check).
+- [ ] 6.8 On any selection field, confirm the `[N opts]` button still opens the existing `OptionsEditor` panel and that adding/removing options + toggling `Allow multiple` still works (regression check for the unrelated flow).

--- a/papermite/frontend/package-lock.json
+++ b/papermite/frontend/package-lock.json
@@ -16,6 +16,9 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^24.12.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -24,14 +27,23 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
+        "happy-dom": "^16.8.1",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.56.1",
-        "vite": "^8.0.0"
+        "vite": "^8.0.0",
+        "vitest": "^3.2.4"
       }
     },
     "../../ui-tokens": {
       "name": "@neoapex/ui-tokens",
       "version": "0.1.0"
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -225,6 +237,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -305,6 +327,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -869,6 +1333,446 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -879,6 +1783,32 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1245,6 +2175,94 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1285,6 +2303,17 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -1307,6 +2336,26 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -1373,6 +2422,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1404,6 +2463,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1419,6 +2495,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/color-convert": {
@@ -1483,6 +2569,13 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -1508,12 +2601,32 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -1525,12 +2638,69 @@
         "node": ">=8"
       }
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.313",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.313.tgz",
       "integrity": "sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -1729,6 +2899,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -1737,6 +2917,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -1880,6 +3070,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/happy-dom": {
+      "version": "16.8.1",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-16.8.1.tgz",
+      "integrity": "sha512-n0QrmT9lD81rbpKsyhnlz3DgnMZlaOkJPpgi746doA+HvaMC79bdWkwjrNnGJRvDrWTI8iOcJiVTJ5CdT/AZRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "webidl-conversions": "^7.0.0",
+        "whatwg-mimetype": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -1948,6 +3152,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-extglob": {
@@ -2355,6 +3569,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -2363,6 +3584,37 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -2501,6 +3753,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2560,6 +3829,36 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2590,6 +3889,14 @@
       "peerDependencies": {
         "react": "^19.2.4"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-router": {
       "version": "7.13.1",
@@ -2627,6 +3934,20 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/resolve-from": {
@@ -2680,6 +4001,51 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -2725,6 +4091,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2733,6 +4106,33 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -2748,6 +4148,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -2760,6 +4180,20 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
@@ -2776,6 +4210,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/ts-api-utils": {
@@ -2977,6 +4441,299 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/vite": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
+      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
+      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -2991,6 +4748,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/papermite/frontend/package.json
+++ b/papermite/frontend/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest",
+    "test:run": "vitest run"
   },
   "dependencies": {
     "@neoapex/ui-tokens": "file:../../ui-tokens",
@@ -18,6 +20,9 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^24.12.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
@@ -26,8 +31,10 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
+    "happy-dom": "^16.8.1",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.56.1",
-    "vite": "^8.0.0"
+    "vite": "^8.0.0",
+    "vitest": "^3.2.4"
   }
 }

--- a/papermite/frontend/src/components/EntityCard.css
+++ b/papermite/frontend/src/components/EntityCard.css
@@ -113,6 +113,21 @@
   box-sizing: border-box;
 }
 
+.field-row__multi-edit {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.field-row__multi-edit-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.85rem;
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
 .field-row__required {
   width: 64px;
 }

--- a/papermite/frontend/src/components/FieldRow.test.tsx
+++ b/papermite/frontend/src/components/FieldRow.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import FieldRow from "./FieldRow";
+import type { FieldType } from "../types/models";
+
+interface FieldRowTestProps {
+  fieldName?: string;
+  value?: unknown;
+  source?: "base_model" | "custom_field";
+  required?: boolean;
+  fieldType?: FieldType;
+  options?: string[];
+  multiple?: boolean;
+  onUpdate?: (fieldName: string, value: unknown) => void;
+  onRequiredToggle?: (fieldName: string, required: boolean) => void;
+  onTypeChange?: (fieldName: string, fieldType: FieldType) => void;
+  onOptionsChange?: (
+    fieldName: string,
+    options: string[],
+    multiple: boolean
+  ) => void;
+  onDelete?: () => void;
+}
+
+function renderRow(overrides: FieldRowTestProps = {}) {
+  const onUpdate = overrides.onUpdate ?? vi.fn();
+  const onRequiredToggle = overrides.onRequiredToggle ?? vi.fn();
+  const onTypeChange = overrides.onTypeChange ?? vi.fn();
+  const onOptionsChange = overrides.onOptionsChange ?? vi.fn();
+
+  const utils = render(
+    <table>
+      <tbody>
+        <FieldRow
+          fieldName={overrides.fieldName ?? "grade_level"}
+          value={overrides.value}
+          source={overrides.source ?? "custom_field"}
+          required={overrides.required ?? false}
+          fieldType={overrides.fieldType ?? "str"}
+          options={overrides.options}
+          multiple={overrides.multiple}
+          onUpdate={onUpdate}
+          onRequiredToggle={onRequiredToggle}
+          onTypeChange={onTypeChange}
+          onOptionsChange={onOptionsChange}
+          onDelete={overrides.onDelete}
+        />
+      </tbody>
+    </table>
+  );
+
+  return { ...utils, onUpdate, onRequiredToggle, onTypeChange, onOptionsChange };
+}
+
+describe("FieldRow", () => {
+  it("renders an object value as JSON, never as [object Object]", () => {
+    renderRow({ value: { a: 1 }, fieldType: "str" });
+    expect(screen.getByText('{"a":1}')).toBeInTheDocument();
+    expect(screen.queryByText(/\[object Object\]/)).not.toBeInTheDocument();
+  });
+
+  it("initializes the text-edit input via JSON.stringify for array-of-objects", () => {
+    renderRow({ value: [{ x: 1 }], fieldType: "str" });
+    fireEvent.click(screen.getByText('[{"x":1}]'));
+    const input = screen.getByDisplayValue('[{"x":1}]') as HTMLInputElement;
+    expect(input).toBeInTheDocument();
+    expect(input.value).not.toBe("[object Object]");
+  });
+
+  it("renders a <select> inline for single-select with options (no click required)", () => {
+    const { onUpdate } = renderRow({
+      // base_model so the data-type column renders a locked <span>, not a <select>;
+      // this keeps the Value cell's <select> the only combobox in the row.
+      source: "base_model",
+      required: true,
+      value: "Active",
+      fieldType: "selection",
+      options: ["Active", "Inactive"],
+      multiple: false,
+    });
+
+    const select = screen.getByRole("combobox") as HTMLSelectElement;
+    expect(select).toBeInTheDocument();
+    expect(select.value).toBe("Active");
+    const optionValues = Array.from(select.options).map((o) => o.value);
+    expect(optionValues).toEqual(["", "Active", "Inactive"]);
+
+    fireEvent.change(select, { target: { value: "Inactive" } });
+    expect(onUpdate).toHaveBeenCalledWith("grade_level", "Inactive");
+  });
+
+  it("renders one checkbox per option inline for multi-select with options", () => {
+    const { onUpdate } = renderRow({
+      source: "base_model",
+      required: true,
+      fieldName: "days_of_week",
+      value: ["Mon"],
+      fieldType: "selection",
+      options: ["Mon", "Tue", "Wed"],
+      multiple: true,
+    });
+
+    const checkboxes = screen.getAllByRole("checkbox");
+    // The Required column also has a checkbox, so we filter by accessible name.
+    const optionBoxes = checkboxes.filter((cb) =>
+      ["Mon", "Tue", "Wed"].some((label) =>
+        cb.closest("label")?.textContent?.includes(label)
+      )
+    );
+    expect(optionBoxes).toHaveLength(3);
+    expect((optionBoxes[0] as HTMLInputElement).checked).toBe(true);
+    expect((optionBoxes[1] as HTMLInputElement).checked).toBe(false);
+    expect((optionBoxes[2] as HTMLInputElement).checked).toBe(false);
+
+    fireEvent.click(optionBoxes[1]);
+    expect(onUpdate).toHaveBeenCalledWith("days_of_week", ["Mon", "Tue"]);
+  });
+
+  it("falls back to text input when selection has no options yet", () => {
+    renderRow({
+      source: "base_model",
+      value: "seed",
+      fieldType: "selection",
+      options: [],
+    });
+
+    expect(screen.queryByRole("combobox")).toBeNull();
+    expect(screen.getByText("seed")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("seed"));
+    expect(screen.getByDisplayValue("seed")).toBeInTheDocument();
+  });
+});

--- a/papermite/frontend/src/components/FieldRow.tsx
+++ b/papermite/frontend/src/components/FieldRow.tsx
@@ -135,7 +135,59 @@ export default function FieldRow({
           <code>{fieldName}</code>
         </td>
         <td className="field-row__value">
-          {editing ? (
+          {fieldType === "selection" && (options?.length ?? 0) > 0 ? (
+            multiple ? (
+              (() => {
+                const selected = Array.isArray(value)
+                  ? value.filter((s): s is string => typeof s === "string")
+                  : typeof value === "string" && value !== ""
+                    ? [value]
+                    : [];
+                return (
+                  <div className="field-row__multi-edit">
+                    {(options ?? []).map((opt) => (
+                      <label key={opt} className="field-row__multi-edit-label">
+                        <input
+                          type="checkbox"
+                          checked={selected.includes(opt)}
+                          onChange={(e) => {
+                            const next = e.target.checked
+                              ? [...selected, opt]
+                              : selected.filter((s) => s !== opt);
+                            onUpdate(fieldName, next);
+                          }}
+                        />
+                        {opt}
+                      </label>
+                    ))}
+                  </div>
+                );
+              })()
+            ) : (
+              (() => {
+                const currentValue =
+                  typeof value === "string"
+                    ? value
+                    : Array.isArray(value) && typeof value[0] === "string"
+                      ? value[0]
+                      : "";
+                return (
+                  <select
+                    className="input field-row__input"
+                    value={currentValue}
+                    onChange={(e) => onUpdate(fieldName, e.target.value)}
+                  >
+                    <option value="">— none —</option>
+                    {(options ?? []).map((opt) => (
+                      <option key={opt} value={opt}>
+                        {opt}
+                      </option>
+                    ))}
+                  </select>
+                );
+              })()
+            )
+          ) : editing ? (
             <input
               className="input field-row__input"
               value={editValue}

--- a/papermite/frontend/src/components/FieldRow.tsx
+++ b/papermite/frontend/src/components/FieldRow.tsx
@@ -17,6 +17,12 @@ interface Props {
   onDelete?: () => void;
 }
 
+function toEditString(v: unknown): string {
+  if (v === null || v === undefined || v === "") return "";
+  if (typeof v === "object") return JSON.stringify(v);
+  return String(v);
+}
+
 function OptionsEditor({
   options,
   multiple,
@@ -105,7 +111,7 @@ export default function FieldRow({
   onDelete,
 }: Props) {
   const [editing, setEditing] = useState(false);
-  const [editValue, setEditValue] = useState(String(value ?? ""));
+  const [editValue, setEditValue] = useState(toEditString(value));
   const [showOptions, setShowOptions] = useState(false);
 
   const handleSave = () => {
@@ -118,12 +124,7 @@ export default function FieldRow({
     if (e.key === "Escape") setEditing(false);
   };
 
-  const displayValue =
-    value === null || value === undefined || value === ""
-      ? "—"
-      : typeof value === "object"
-        ? JSON.stringify(value)
-        : String(value);
+  const displayValue = toEditString(value) || "—";
 
   const isBase = source === "base_model";
 

--- a/papermite/frontend/src/test/setup.ts
+++ b/papermite/frontend/src/test/setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";

--- a/papermite/frontend/tsconfig.app.json
+++ b/papermite/frontend/tsconfig.app.json
@@ -5,7 +5,7 @@
     "useDefineForClassFields": true,
     "lib": ["ES2023", "DOM", "DOM.Iterable"],
     "module": "ESNext",
-    "types": ["vite/client"],
+    "types": ["vite/client", "vitest/globals", "@testing-library/jest-dom"],
     "skipLibCheck": true,
 
     /* Bundler mode */

--- a/papermite/frontend/vitest.config.ts
+++ b/papermite/frontend/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'happy-dom',
+    setupFiles: ['./src/test/setup.ts'],
+    globals: true,
+  },
+})


### PR DESCRIPTION
## Summary

Fixes #68. The papermite Review-page selection field displayed `"[object Object]"` once clicked because `editValue` was initialized via `String(value)` while the read-only display path used `JSON.stringify`. The two serializers now share a single `toEditString` helper.

Beyond the bug fix, the Value cell now renders selection-aware controls inline (no click-to-edit toggle) when a selection field has options defined:
- `multiple: false` → `<select>` dropdown
- `multiple: true` → horizontal checkbox group

Non-selection fields and selection fields without options keep the existing click-to-edit text input. Add/remove options remains handled by the existing `[N opts]` → `OptionsEditor` panel (untouched).

Also bootstraps the first test harness in `papermite/frontend`: Vitest 3 + React Testing Library 16 + happy-dom 16 + jest-dom, with five component tests covering all five spec requirements.

## Test Plan

- [x] `cd papermite/frontend && npm run test:run` — 5/5 pass
- [x] `cd papermite/frontend && npm run build` — clean TS check + Vite build
- [x] Lint clean for changed files (`FieldRow.tsx`, `FieldRow.test.tsx`, `vitest.config.ts`, `src/test/setup.ts`)
- [ ] Manual: upload a doc, open Review page, confirm selection fields no longer show `[object Object]`
- [ ] Manual: single-select renders inline dropdown; change persists across reload
- [ ] Manual: multi-select renders inline checkbox group; toggles persist as array across reload
- [ ] Manual: non-selection fields still use click-to-edit text input
- [ ] Manual: `[N opts]` panel still opens and Add/Remove options still works

## Notes

- 7 pre-existing lint errors remain in `App.tsx`, `FinalizedPage.tsx`, `ReviewPage.tsx`. They're unrelated to #68 and out of scope for this PR.
- Vitest 3 has a type-incompat with Vite 8 when `defineConfig` is imported from `vitest/config` into the existing `vite.config.ts`. Workaround: kept `vite.config.ts` pristine and put the test block in a separate `vitest.config.ts` (Vitest reads it preferentially for `npm run test:run`).
- Final code-reviewer recommended merge-as-is with minor follow-up notes (rename `toEditString`, extract IIFEs to sub-components, add a11y attributes, add `null/undefined/""` display tests). I'll file these as a follow-up issue separately if you want.

OpenSpec change: `openspec/changes/papermite-selection-edit-display/`
Implementation plan: `docs/superpowers/plans/2026-05-15-papermite-selection-edit-display.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)