### PR TITLE
feat(papermite): editable custom-field attribute names (closes #67)

### DIFF
--- a/docs/superpowers/plans/2026-05-16-papermite-editable-attribute-names.md
+++ b/docs/superpowers/plans/2026-05-16-papermite-editable-attribute-names.md
@@ -1,0 +1,791 @@
+# Papermite Editable Attribute Names Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resolve [Papermite issue #67](https://github.com/kennyhlee/neo-apex/issues/67) — let users rename LLM-detected attribute (field) names on the Papermite review screen. The rename is scoped to **custom_field** rows; base-model field names remain locked, matching the existing lock pattern for base-field types and required flags.
+
+**Architecture:** Pure frontend gap-fill in three files (`FieldRow.tsx`, `EntityCard.tsx`, `EntityCard.css`) plus one backend regression test. `FieldRow` gains an inline edit toggle on the name cell — identical UX to the existing value-cell toggle — but only renders the editable control when `source === "custom_field"`. The rename callback flows up to `EntityCard.handleFieldNameChange`, which validates non-emptiness and per-entity uniqueness (across **both** base and custom sources) and updates the three in-memory locations the existing `handleFieldDelete` already maintains: `entity.field_mappings`, `entity.entity`, and `entity.entity.custom_fields`. The handler returns `{ ok: true } | { ok: false, error: string }` rather than throwing, so the row can render the error inline without try/catch in event handlers. The backend already accepts whatever `field_name` value the client sends — `_build_model_definition` reads it verbatim — so no backend code changes; only a regression test that pins this behavior in place.
+
+**Tech Stack:** React 19 + TypeScript 5.9 (`verbatimModuleSyntax: true`, strict mode) + Vite 8 on the frontend; FastAPI + pydantic + httpx on the backend; pytest with `unittest.mock.patch` and `fastapi.testclient.TestClient` for tests; `uv` as the Python package manager.
+
+**Source artifacts:** `openspec/changes/papermite-editable-attribute-names/{proposal.md, design.md, specs/papermite-attribute-rename/spec.md, tasks.md}`.
+
+**Port reference (root `CLAUDE.md` + `services.json` are authoritative):** Papermite backend runs on **5710** for local dev, frontend on **5700**. The `papermite/CLAUDE.md` file mentions port 8000 and a `/finalize/preview` endpoint — both are stale, ignore them.
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|---|---|---|
+| Modify | `papermite/frontend/src/components/FieldRow.tsx` | Add `onFieldNameChange` prop, name-edit state (`editingName`, `editName`, `nameError`), and a custom-field-only branch in the name `<td>` that toggles between a display `<span>` and `<input>`. Base-field rows keep the existing `<code>`. |
+| Modify | `papermite/frontend/src/components/EntityCard.tsx` | Add `handleFieldNameChange` (validation + 3-way state sync), pass it as `onFieldNameChange` to `<FieldRow />`. |
+| Modify | `papermite/frontend/src/components/EntityCard.css` | Add `.field-row__name-display` (hover/cursor affordance) and `.field-row__name-error` (inline red message). Leave the existing `.field-row__name code` selector untouched. |
+| Create | `papermite/backend/tests/test_finalize_api.py` | Regression test: POST a `FinalizeRequest` with a renamed custom field, mock `httpx.put`, assert the captured payload carries the new name in `custom_fields` and no trace of the old name. |
+
+No other files require changes. `ReviewPage.tsx`'s existing `hasChanges()` already compares `om.field_name !== cm.field_name` (line 19), so dirty tracking is ready. Backend `finalize.py` and the `FieldMapping` Pydantic model accept arbitrary string `field_name` values today.
+
+---
+
+## Task 1: Add the `onFieldNameChange` prop and name-edit state to `FieldRow`
+
+**Files:**
+- Modify: `papermite/frontend/src/components/FieldRow.tsx`
+
+- [ ] **Step 1: Read the current `Props` interface and component signature**
+
+Run: `sed -n '1,30p' papermite/frontend/src/components/FieldRow.tsx`
+
+Confirm the file starts:
+```tsx
+import { useState } from "react";
+import { FIELD_TYPES } from "../types/models";
+import type { FieldType } from "../types/models";
+
+interface Props {
+  fieldName: string;
+  value: unknown;
+  source: "base_model" | "custom_field";
+  required: boolean;
+  fieldType: FieldType;
+  options?: string[];
+  multiple?: boolean;
+  onUpdate: (fieldName: string, value: unknown) => void;
+  onRequiredToggle: (fieldName: string, required: boolean) => void;
+  onTypeChange: (fieldName: string, fieldType: FieldType) => void;
+  onOptionsChange: (fieldName: string, options: string[], multiple: boolean) => void;
+  onDelete?: () => void;
+}
+```
+
+If the file has drifted, re-read it fully and adapt the line anchors in subsequent steps accordingly — but the symbol names below are stable.
+
+- [ ] **Step 2: Add `useEffect` to the React import**
+
+Replace the exact line at the top of the file:
+
+```tsx
+import { useState } from "react";
+```
+
+with:
+
+```tsx
+import { useEffect, useState } from "react";
+```
+
+`useEffect` is used by the auto-clear timer for `nameError` in Step 6.
+
+- [ ] **Step 3: Add `onFieldNameChange` to the `Props` interface**
+
+Inside the `Props` interface, immediately after the `onOptionsChange` line and before `onDelete?: () => void;`, insert:
+
+```tsx
+  onFieldNameChange?: (
+    oldName: string,
+    newName: string
+  ) => { ok: true } | { ok: false; error: string };
+```
+
+The full `Props` block should now read:
+
+```tsx
+interface Props {
+  fieldName: string;
+  value: unknown;
+  source: "base_model" | "custom_field";
+  required: boolean;
+  fieldType: FieldType;
+  options?: string[];
+  multiple?: boolean;
+  onUpdate: (fieldName: string, value: unknown) => void;
+  onRequiredToggle: (fieldName: string, required: boolean) => void;
+  onTypeChange: (fieldName: string, fieldType: FieldType) => void;
+  onOptionsChange: (fieldName: string, options: string[], multiple: boolean) => void;
+  onFieldNameChange?: (
+    oldName: string,
+    newName: string
+  ) => { ok: true } | { ok: false; error: string };
+  onDelete?: () => void;
+}
+```
+
+- [ ] **Step 4: Destructure `onFieldNameChange` in the component signature**
+
+Find the `export default function FieldRow({ ... }: Props)` destructuring block (around line 99-112). Add `onFieldNameChange,` immediately after `onOptionsChange,` and before `onDelete,`. The block should read:
+
+```tsx
+export default function FieldRow({
+  fieldName,
+  value,
+  source,
+  required,
+  fieldType,
+  options,
+  multiple,
+  onUpdate,
+  onRequiredToggle,
+  onTypeChange,
+  onOptionsChange,
+  onFieldNameChange,
+  onDelete,
+}: Props) {
+```
+
+- [ ] **Step 5: Add name-edit state inside the component**
+
+Find the three existing `useState` calls inside the component body (around lines 113-115):
+
+```tsx
+  const [editing, setEditing] = useState(false);
+  const [editValue, setEditValue] = useState(toEditString(value));
+  const [showOptions, setShowOptions] = useState(false);
+```
+
+Insert three new state declarations immediately after the `setShowOptions` line:
+
+```tsx
+  const [editingName, setEditingName] = useState(false);
+  const [editName, setEditName] = useState(fieldName);
+  const [nameError, setNameError] = useState<string | null>(null);
+```
+
+- [ ] **Step 6: Add the `nameError` auto-clear effect**
+
+Immediately after the new state declarations from Step 5 (so still above `handleSave`), insert:
+
+```tsx
+  useEffect(() => {
+    if (nameError === null) return;
+    const t = setTimeout(() => setNameError(null), 3000);
+    return () => clearTimeout(t);
+  }, [nameError]);
+```
+
+- [ ] **Step 7: Add `handleNameSave` and `handleNameKeyDown` handlers**
+
+Immediately after the existing `handleKeyDown` function (which lives directly after `handleSave`, around lines 122-125), insert:
+
+```tsx
+  const handleNameSave = () => {
+    const trimmed = editName.trim();
+    if (trimmed === fieldName) {
+      setEditingName(false);
+      setEditName(fieldName);
+      return;
+    }
+    if (!onFieldNameChange) {
+      setEditingName(false);
+      setEditName(fieldName);
+      return;
+    }
+    const result = onFieldNameChange(fieldName, trimmed);
+    if (result.ok) {
+      setEditingName(false);
+    } else {
+      setNameError(result.error);
+      setEditingName(false);
+      setEditName(fieldName);
+    }
+  };
+
+  const handleNameKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleNameSave();
+    }
+    if (e.key === "Escape") {
+      setEditingName(false);
+      setEditName(fieldName);
+    }
+  };
+```
+
+Note: on success, we deliberately do NOT reset `editName` to `fieldName`, because the `FieldRow` will remount immediately (its `key={mapping.field_name}` prop in the parent changes), and a fresh component will initialize `editName` to the new `fieldName` from props. On rejection or no-op we reset locally so the next click into edit mode starts clean.
+
+- [ ] **Step 8: Save and run the typecheck**
+
+Run: `cd papermite/frontend && npm run build`
+
+Expected: TypeScript compiles successfully and Vite produces a build. If it fails with errors referencing the new symbols, fix the introduced typos before continuing. (We haven't wired the new state into the JSX yet, so React's unused-variable warning may surface — that is fine, Task 2 wires it up.)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add papermite/frontend/src/components/FieldRow.tsx
+git commit -m "feat(papermite): scaffold name-edit state on FieldRow (no UI yet)"
+```
+
+---
+
+## Task 2: Render the editable name cell for custom fields
+
+**Files:**
+- Modify: `papermite/frontend/src/components/FieldRow.tsx` (the name `<td>` only)
+
+- [ ] **Step 1: Locate the current name cell**
+
+Run: `sed -n '130,140p' papermite/frontend/src/components/FieldRow.tsx`
+
+Confirm you see:
+
+```tsx
+  return (
+    <>
+      <tr className="field-row">
+        <td className="field-row__name">
+          <code>{fieldName}</code>
+        </td>
+```
+
+- [ ] **Step 2: Replace the name `<td>` with the conditional renderer**
+
+Replace this exact block:
+
+```tsx
+        <td className="field-row__name">
+          <code>{fieldName}</code>
+        </td>
+```
+
+with:
+
+```tsx
+        <td className="field-row__name">
+          {isBase ? (
+            <code>{fieldName}</code>
+          ) : editingName ? (
+            <input
+              className="input field-row__input"
+              value={editName}
+              onChange={(e) => setEditName(e.target.value)}
+              onBlur={handleNameSave}
+              onKeyDown={handleNameKeyDown}
+              autoFocus
+            />
+          ) : (
+            <span
+              className="field-row__name-display"
+              onClick={() => {
+                setEditName(fieldName);
+                setEditingName(true);
+              }}
+              title="Click to edit"
+            >
+              {fieldName}
+            </span>
+          )}
+          {nameError && (
+            <div className="field-row__name-error" role="alert">
+              {nameError}
+            </div>
+          )}
+        </td>
+```
+
+Note: `isBase` is already defined a few lines below (line 129 in the original: `const isBase = source === "base_model";`). The JSX references it before its declaration in source order, which works because `const` declarations are hoisted to the top of their scope when used inside JSX inside the same function body. (If TypeScript complains about temporal dead zone, move `const isBase = source === "base_model";` to just before the `return (` — see Step 4.)
+
+- [ ] **Step 3: Hoist `isBase` declaration above `return` for safety**
+
+Find the line (originally line 129, may have shifted slightly):
+
+```tsx
+  const isBase = source === "base_model";
+```
+
+Confirm it sits between `const displayValue = ...` and `return (`. If it has somehow drifted below `return`, move it back above `return (`. This keeps the JSX reference in the name cell working with no temporal dead zone risk.
+
+- [ ] **Step 4: Run typecheck**
+
+Run: `cd papermite/frontend && npm run build`
+
+Expected: clean build, no TypeScript errors.
+
+If you see an error like `Cannot find name 'editName'` or similar, you missed a step in Task 1 — go back and complete it before proceeding.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add papermite/frontend/src/components/FieldRow.tsx
+git commit -m "feat(papermite): render editable name cell for custom fields"
+```
+
+---
+
+## Task 3: Wire `handleFieldNameChange` in `EntityCard`
+
+**Files:**
+- Modify: `papermite/frontend/src/components/EntityCard.tsx`
+
+- [ ] **Step 1: Read the current handlers**
+
+Run: `sed -n '60,90p' papermite/frontend/src/components/EntityCard.tsx`
+
+Confirm you see `handleOptionsChange`, `handleFieldDelete`, and `handleAddField` defined. The delete handler cleans up `entity.entity[fieldName]` AND `entity.entity.custom_fields[fieldName]` — your new handler mirrors that cleanup pattern for renames.
+
+- [ ] **Step 2: Add `handleFieldNameChange` immediately after `handleOptionsChange`**
+
+Find the closing `};` of `handleOptionsChange` (around line 66 in the current file). Immediately after it (before the blank line that precedes `handleFieldDelete`), insert:
+
+```tsx
+  const handleFieldNameChange = (
+    oldName: string,
+    newName: string
+  ): { ok: true } | { ok: false; error: string } => {
+    const trimmed = newName.trim();
+    if (trimmed.length === 0) {
+      return { ok: false, error: "Name cannot be empty" };
+    }
+    if (trimmed === oldName) {
+      return { ok: true };
+    }
+    const collision = entity.field_mappings.some(
+      (m) => m.field_name !== oldName && m.field_name === trimmed
+    );
+    if (collision) {
+      return {
+        ok: false,
+        error: `"${trimmed}" is already used by another field`,
+      };
+    }
+
+    const newMappings = entity.field_mappings.map((m) =>
+      m.field_name === oldName ? { ...m, field_name: trimmed } : m
+    );
+
+    const newEntity: Record<string, unknown> = { ...entity.entity };
+    if (Object.prototype.hasOwnProperty.call(newEntity, oldName)) {
+      newEntity[trimmed] = newEntity[oldName];
+      delete newEntity[oldName];
+    }
+
+    const cf = newEntity.custom_fields;
+    if (
+      cf &&
+      typeof cf === "object" &&
+      Object.prototype.hasOwnProperty.call(cf, oldName)
+    ) {
+      const cfClone = { ...(cf as Record<string, unknown>) };
+      cfClone[trimmed] = cfClone[oldName];
+      delete cfClone[oldName];
+      newEntity.custom_fields = cfClone;
+    }
+
+    onUpdate(index, {
+      ...entity,
+      entity: newEntity,
+      field_mappings: newMappings,
+    });
+    return { ok: true };
+  };
+```
+
+- [ ] **Step 3: Pass `onFieldNameChange` to `FieldRow`**
+
+Find the `<FieldRow ... />` element (around lines 137-155). Immediately after `onOptionsChange={handleOptionsChange}` and before the `onDelete={...}` line, insert:
+
+```tsx
+                onFieldNameChange={
+                  mapping.source === "custom_field"
+                    ? handleFieldNameChange
+                    : undefined
+                }
+```
+
+The full FieldRow invocation should now read:
+
+```tsx
+              <FieldRow
+                key={mapping.field_name}
+                fieldName={mapping.field_name}
+                value={mapping.value}
+                source={mapping.source}
+                required={mapping.required}
+                fieldType={mapping.field_type}
+                options={mapping.options}
+                multiple={mapping.multiple}
+                onUpdate={handleFieldUpdate}
+                onRequiredToggle={handleRequiredToggle}
+                onTypeChange={handleTypeChange}
+                onOptionsChange={handleOptionsChange}
+                onFieldNameChange={
+                  mapping.source === "custom_field"
+                    ? handleFieldNameChange
+                    : undefined
+                }
+                onDelete={
+                  mapping.source === "custom_field"
+                    ? () => handleFieldDelete(mapping.field_name)
+                    : undefined
+                }
+              />
+```
+
+Even though `FieldRow` itself already gates on `isBase` (Task 2 Step 2), passing `undefined` for base rows is belt-and-suspenders — if the props ever diverge the gate still holds.
+
+- [ ] **Step 4: Run typecheck**
+
+Run: `cd papermite/frontend && npm run build`
+
+Expected: clean build.
+
+- [ ] **Step 5: Run the linter**
+
+Run: `cd papermite/frontend && npm run lint`
+
+Expected: no new errors or warnings introduced by `FieldRow.tsx` or `EntityCard.tsx`. Pre-existing lint output (if any) in unrelated files is OK.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add papermite/frontend/src/components/EntityCard.tsx
+git commit -m "feat(papermite): rename handler validates and syncs three state locations"
+```
+
+---
+
+## Task 4: Styling — affordance and inline error
+
+**Files:**
+- Modify: `papermite/frontend/src/components/EntityCard.css`
+
+- [ ] **Step 1: Locate the existing name-cell rule**
+
+Run: `sed -n '81,90p' papermite/frontend/src/components/EntityCard.css`
+
+Confirm you see:
+
+```css
+.field-row__name code {
+  font-family: var(--font-sans);
+  font-size: 13px;
+  color: var(--text-secondary);
+  background: none;
+  padding: 0;
+}
+```
+
+This rule MUST remain unchanged so base-field rendering stays visually inert.
+
+- [ ] **Step 2: Append new rules after `.field-row__name code`**
+
+Use Edit to insert the following block immediately after the closing `}` of `.field-row__name code` and the blank line that follows it, and before `.field-row__value {`:
+
+```css
+.field-row__name-display {
+  font-family: var(--font-sans);
+  font-size: 13px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  padding: 4px 0;
+  border-bottom: 1px dashed transparent;
+  transition: border-color 0.2s;
+  display: inline-block;
+}
+
+.field-row__name-display:hover {
+  border-bottom-color: var(--text-tertiary);
+}
+
+.field-row__name-error {
+  margin-top: 4px;
+  font-family: var(--font-sans);
+  font-size: 12px;
+  color: var(--accent-danger, #d4537e);
+  line-height: 1.3;
+}
+```
+
+Rationale for the colors and spacing:
+- `font-family`/`font-size`/`color` on `.field-row__name-display` match the existing `.field-row__name code` so swapping between display and the existing static base render is visually consistent.
+- The hover underline mirrors `.field-row__display:hover` (the value cell pattern at line 105-107 of the same file) so the affordance feels familiar.
+- `--accent-danger` falls back to `#d4537e` (the existing FAMILY entity color, which is already in the magenta/red range) if the CSS variable isn't defined.
+
+- [ ] **Step 3: Verify no other selectors regressed**
+
+Run: `cd papermite/frontend && npm run build`
+
+Expected: clean build (CSS is processed by Vite without explicit type-checking, but the build will surface any malformed CSS).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add papermite/frontend/src/components/EntityCard.css
+git commit -m "style(papermite): hover affordance for name cell and inline error style"
+```
+
+---
+
+## Task 5: Backend regression test for rename pass-through
+
+**Files:**
+- Create: `papermite/backend/tests/test_finalize_api.py`
+
+- [ ] **Step 1: Read the existing test conventions**
+
+Run: `sed -n '1,40p' papermite/backend/tests/test_extract_api.py`
+
+Confirm: `from app.main import app`, `from app.models.registry import UserRecord`, the `mock_auth` fixture pattern, and use of `TestClient(app)`. Replicate this style.
+
+Also confirm `papermite/backend/tests/conftest.py` autouses `_bypass_cloudflare_middleware` (sets `TRUST_ALL_IPS=1`) — so your test doesn't need to do that.
+
+- [ ] **Step 2: Write the failing test**
+
+Create the file `papermite/backend/tests/test_finalize_api.py` with this exact content:
+
+```python
+"""Regression tests for POST /api/tenants/{tenant_id}/finalize/commit.
+
+Pins the contract that custom-field renames flow from the request payload
+straight into the model definition sent to DataCore.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.models.registry import UserRecord
+
+client = TestClient(app)
+
+FAKE_USER = UserRecord(
+    user_id="u1",
+    name="Test Admin",
+    email="admin@test.com",
+    password_hash="",
+    tenant_id="t1",
+    tenant_name="Test Tenant",
+    role="admin",
+    created_at="",
+)
+
+
+@pytest.fixture(autouse=True)
+def mock_auth():
+    """Bypass auth for all tests using FastAPI dependency override."""
+    from app.api.auth import require_admin
+
+    app.dependency_overrides[require_admin] = lambda: FAKE_USER
+    yield
+    app.dependency_overrides.pop(require_admin, None)
+
+
+def _payload_with_renamed_custom_field() -> dict:
+    """A finalize payload with one custom field renamed away from any LLM default."""
+    return {
+        "extraction": {
+            "extraction_id": "e1",
+            "tenant_id": "t1",
+            "filename": "app.pdf",
+            "entities": [
+                {
+                    "entity_type": "student",
+                    "entity": {
+                        "first_name": "Sam",
+                        "date_of_birth": "2010-01-01",
+                        "custom_fields": {"date_of_birth": "2010-01-01"},
+                    },
+                    "field_mappings": [
+                        {
+                            "field_name": "first_name",
+                            "value": "Sam",
+                            "source": "base_model",
+                            "required": True,
+                            "field_type": "str",
+                        },
+                        {
+                            "field_name": "date_of_birth",
+                            "value": "2010-01-01",
+                            "source": "custom_field",
+                            "required": False,
+                            "field_type": "date",
+                        },
+                    ],
+                }
+            ],
+            "status": "pending_review",
+        }
+    }
+
+
+def _datacore_response_payload(model_definition: dict) -> dict:
+    """Shape that `finalize_commit` expects back from DataCore."""
+    return {
+        "status": "ok",
+        "version": 1,
+        "model_definition": model_definition,
+        "source_filename": "app.pdf",
+        "created_by": "Test Admin",
+        "created_at": "2026-05-16T00:00:00Z",
+    }
+
+
+def test_renamed_custom_field_is_passed_through_to_datacore():
+    """Frontend rename must reach DataCore's model_definition payload verbatim."""
+    captured: dict = {}
+
+    def fake_put(url, *, json, timeout):  # noqa: ARG001 - signature matches httpx.put
+        captured["url"] = url
+        captured["json"] = json
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = _datacore_response_payload(
+            json["model_definition"]
+        )
+        return mock_resp
+
+    with patch("app.api.finalize.httpx.put", side_effect=fake_put):
+        resp = client.post(
+            "/api/tenants/t1/finalize/commit",
+            json=_payload_with_renamed_custom_field(),
+        )
+
+    assert resp.status_code == 200, resp.text
+
+    # The renamed custom field reached DataCore under its new name.
+    sent_model = captured["json"]["model_definition"]
+    assert "student" in sent_model, sent_model
+    student = sent_model["student"]
+
+    custom_names = [f["name"] for f in student["custom_fields"]]
+    base_names = [f["name"] for f in student["base_fields"]]
+
+    assert "date_of_birth" in custom_names, custom_names
+    # Critically: no trace of the LLM-default name anywhere.
+    assert "dob" not in custom_names, custom_names
+    assert "dob" not in base_names, base_names
+
+    # And the renamed field's other properties were preserved.
+    renamed = next(f for f in student["custom_fields"] if f["name"] == "date_of_birth")
+    assert renamed["type"] == "date"
+    assert renamed["required"] is False
+
+
+def test_finalize_rejects_tenant_mismatch():
+    """Sanity: the existing tenant guard still works with the test setup."""
+    bad = _payload_with_renamed_custom_field()
+    bad["extraction"]["tenant_id"] = "other_tenant"
+    resp = client.post("/api/tenants/t1/finalize/commit", json=bad)
+    assert resp.status_code == 400, resp.text
+```
+
+- [ ] **Step 3: Run the test and confirm it passes**
+
+Run: `cd papermite/backend && uv run python -m pytest tests/test_finalize_api.py -v`
+
+Expected output (both tests pass):
+
+```
+tests/test_finalize_api.py::test_renamed_custom_field_is_passed_through_to_datacore PASSED
+tests/test_finalize_api.py::test_finalize_rejects_tenant_mismatch PASSED
+```
+
+If `test_renamed_custom_field_is_passed_through_to_datacore` fails because the assertion can't find `student["custom_fields"]`, re-read `_build_model_definition` in `papermite/backend/app/api/finalize.py` — your payload's `entity_type` must lowercase to `"student"`, which matches the lookup `entity_type.lower()` on line 38. The fixture above already uses `"student"`, so this should pass on first run.
+
+If it fails because `httpx.put` is called with positional arguments instead of keyword `json=`, change `fake_put`'s signature to `def fake_put(url, *args, **kwargs):` and read `kwargs["json"]`. The current `finalize.py:96-104` uses `json=...` as a keyword, so the keyword form should work.
+
+- [ ] **Step 4: Run the full backend test suite to confirm no regressions**
+
+Run: `cd papermite/backend && uv run python -m pytest tests/ -v`
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add papermite/backend/tests/test_finalize_api.py
+git commit -m "test(papermite): pin custom-field rename pass-through to DataCore"
+```
+
+---
+
+## Task 6: Manual verification
+
+**Files:** none.
+
+This task is intentionally execution-only. Do NOT skip — there is no Vitest harness on Papermite yet (only a single bug-fix added one for FieldRow), so the most reliable verification of the new UX is to click through it.
+
+- [ ] **Step 1: Start the services**
+
+From the repo root:
+
+```bash
+./start-services.sh
+```
+
+If the script asks any questions, choose to start papermite frontend + backend + datacore. Wait until you see all three reporting healthy (papermite-frontend on 5700, papermite-backend on 5710, datacore on 5800).
+
+- [ ] **Step 2: Reach the review screen with at least one custom field**
+
+In a browser:
+1. Open `http://localhost:5700/`.
+2. If a model already exists for your test tenant, click "Edit Model" to land on the review screen with the existing model loaded. Otherwise click "Upload New Document" and upload any sample PDF the LLM will produce custom fields from (any of the sample docs in `~/Development/NeoApex/sampledoc/`, or any application form).
+
+You should now be on `/review/<id>` with one or more `EntityCard` panels.
+
+- [ ] **Step 3: Verify custom-field rename works (happy path)**
+
+- Locate a row with the `custom` badge (the source column shows `custom`).
+- Hover the field name in the leftmost column — the cursor should change to a pointer and a dashed underline should appear.
+- Click it. An input should appear, prefilled with the current name and focused.
+- Type a new name, press **Enter**. The row should re-render showing the new name, no error message should appear.
+
+Pass criteria: name visibly changes, no console errors in the browser devtools, no error message under the cell.
+
+- [ ] **Step 4: Verify base-field name is NOT editable**
+
+- Locate a row with the `base` badge.
+- Hover the field name. The cursor should NOT change to pointer; no underline appears.
+- Click it. Nothing should happen — no input, no focus indicator beyond default.
+
+Pass criteria: base-field name remains static.
+
+- [ ] **Step 5: Verify duplicate-name collision (custom vs custom)**
+
+- Click a custom field name. Enter the name of another custom field in the same entity card. Press Enter.
+- The input should disappear, the name should revert to the original, and a small red error message should appear under the cell saying something like `"<name>" is already used by another field`.
+- Wait ~3 seconds. The error should auto-clear.
+
+- [ ] **Step 6: Verify duplicate-name collision (custom vs base)**
+
+- Click a custom field name. Enter a base-field name from the same entity (e.g. on a Student card, `first_name`). Press Enter.
+- The input should revert and the same inline error pattern should appear.
+
+- [ ] **Step 7: Verify empty / whitespace rejection**
+
+- Click a custom field name. Clear the input completely. Press Enter.
+- The input should revert and an inline error reading `Name cannot be empty` should appear.
+- Repeat with only spaces in the input. Same behavior.
+
+- [ ] **Step 8: Verify Escape cancels**
+
+- Click a custom field name. Type something different. Press **Escape**.
+- The input should disappear and the original name should display. No error.
+
+- [ ] **Step 9: Verify finalize round-trips the rename**
+
+- Make a single rename that you'll recognize later (e.g. rename a custom field to `manual_test_renamed`).
+- Click **Finalize Model →**. On the next page, click **Confirm & Save** (or whatever the confirm button is labeled — see `FinalizePage.tsx`).
+- Return to the landing page. Click **Edit Model**.
+- On the review screen, confirm the renamed field appears under `manual_test_renamed` and is still renameable. Optionally rename it again to confirm.
+
+- [ ] **Step 10: Stop the services and commit nothing**
+
+Manual verification produces no code changes. If anything failed, return to the failing task above, fix the implementation, re-run the relevant build/lint/test steps, then re-run only the failing manual step.
+
+---
+
+## Self-Review Notes
+
+The plan above covers every requirement in `openspec/changes/papermite-editable-attribute-names/specs/papermite-attribute-rename/spec.md`:
+
+- **"Custom-field name cells SHALL be inline-editable; base-field name cells SHALL NOT"** → Task 1 (props/state), Task 2 (`isBase` gate in JSX), Task 6 Steps 3-4 (manual verification of both branches).
+- **"Validated for non-emptiness and per-entity uniqueness against ALL mappings"** → Task 3 Step 2 (validation logic checks `field_mappings.some(...)` regardless of `source`), Task 6 Steps 5-7 (manual verification of all three rejection paths).
+- **"Successful rename SHALL update field_mappings, entity.entity, and entity.entity.custom_fields in lockstep"** → Task 3 Step 2 (the three `newMappings` / `newEntity[trimmed] = ...` / `cfClone[trimmed] = ...` blocks).
+- **"Renames SHALL propagate through finalize to the saved model definition"** → Task 5 (backend regression test asserts exact payload to DataCore), Task 6 Step 9 (manual round-trip).
+- **"Reopening a saved model SHALL allow further custom-field renames"** → Task 6 Step 9 (`Edit Model` → confirm renamed field is still renameable).
+
+The handler contract `{ ok: true } | { ok: false, error: string }` is consistent across Task 1 (Props type), Task 1 Step 7 (`handleNameSave` consumes it), and Task 3 Step 2 (`handleFieldNameChange` returns it).
+
+No placeholders. No "TBD". All file paths absolute-from-repo-root. All bash commands exact.

--- a/openspec/changes/papermite-editable-attribute-names/.openspec.yaml
+++ b/openspec/changes/papermite-editable-attribute-names/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-16

--- a/openspec/changes/papermite-editable-attribute-names/design.md
+++ b/openspec/changes/papermite-editable-attribute-names/design.md
@@ -1,0 +1,110 @@
+## Context
+
+Papermite's review screen (`ReviewPage` → `EntityCard` → `FieldRow`) is the last place a user can shape a model definition before it's committed to DataCore. The data type used throughout this flow is `ExtractionResult`, whose `entities[].field_mappings[]` are `FieldMapping` objects with a `field_name: string` property and a `source: "base_model" | "custom_field"` discriminator.
+
+Today, on the review screen:
+
+- **Custom fields** are fully editable except for their *name* — value, type, required, options, multiple, and delete all work; the name is rendered as static `<code>{fieldName}</code>`.
+- **Base fields** are intentionally more constrained: type is locked (`field-row__type-locked` at `FieldRow.tsx:212`), required is locked (`disabled={isBase}` at line 245), no delete button (line 254). Only the value is editable. Names are locked, consistent with that pattern.
+
+State shape and dataflow notes that shaped the design below:
+
+- `FieldRow.tsx` exposes callbacks `onUpdate`, `onRequiredToggle`, `onTypeChange`, `onOptionsChange`, `onDelete` — no `onFieldNameChange`.
+- `EntityCard.tsx` mirrors each field mapping into **three places**: `entity.field_mappings` (the list FieldRow renders from), `entity.entity[fieldName]` (the value bag), and for custom fields `entity.entity.custom_fields[fieldName]` (the custom-bag). `handleFieldDelete` (lines 68–85) cleans up all three; `handleFieldUpdate` writes the new value into `entity.entity[fieldName]` (line 28); `handleAddField` populates all three (lines 87–100). A rename must keep this discipline.
+- `EntityCard.tsx:138` uses `<FieldRow key={mapping.field_name} />`. Changing `field_name` forces React to unmount/remount the row. Since commit happens on Enter or blur (not while typing), the user has already finished editing when the remount occurs — the lost input focus doesn't surface as a UX problem.
+- `ReviewPage.hasChanges()` (lines 16–25) already compares `om.field_name !== cm.field_name` position-by-position — dirty tracking is ready.
+- `backend/app/api/finalize.py::_build_model_definition` (lines 31–77) reads `mapping.field_name` straight into the persisted model definition with no server-side validation. `FieldMapping` Pydantic model (`backend/app/models/extraction.py:20–27`) declares `field_name: str` with no validator.
+- The persisted model definition is built **only** from `field_mappings`, not from `entity.entity` — so a stale key in `entity.entity` after rename wouldn't corrupt what reaches DataCore. We still rename it because (a) consistency with the delete handler, (b) avoids subtle bugs in any future code that reads from `entity.entity`.
+
+So this change is a frontend gap-fill scoped to custom fields: add the input on the custom-field name cell, lift the state, validate uniqueness, keep the three state locations in sync, and confirm the backend keeps working.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A user can click a **custom-field** name on the review screen, type a new name, and press Enter (or blur) to commit the rename — same interaction the value cell already uses.
+- The frontend prevents committing empty names, or names that collide with any other field in the same entity (base or custom), with a brief inline message and an automatic revert.
+- Renaming keeps `field_mappings`, `entity.entity`, and `entity.entity.custom_fields` mutually consistent (the same three locations that `handleFieldDelete` touches today).
+- Existing dirty-tracking, finalize, and DataCore versioned-write paths continue to work unchanged.
+
+**Non-Goals:**
+- Renaming **base-field** names. Base fields keep the same lock pattern they already have for type, required, and delete. Their names come from the underlying domain Pydantic class field keys; allowing them to diverge would weaken the convention that `model_definition[entity]["base_fields"][n]["name"]` corresponds to `EntityClass.model_fields`. Issue #67's "attribute name detected by LLM" maps cleanly to custom fields.
+- Cross-entity uniqueness. Two different entities may legitimately share a field name (e.g., `name` on both `student` and `parent`); this matches today's spec model.
+- Renaming the `entity_type` itself.
+- A separate "rename" mode (modal, menu item). The inline pattern is established and works for the analogous Value edit; introducing a second pattern just for names would be inconsistent.
+- Server-side name validation beyond what the Pydantic model already enforces (`str`). The model definition consumer in DataCore is the authority on what names it accepts; we are not introducing parallel validation here.
+- A migration for previously-saved model definitions. Existing names remain as-is; users can edit any custom-field names next time they open the model.
+
+## Decisions
+
+### Decision 1: Inline click-to-edit, mirroring the value cell
+
+Use the same `editing: boolean` + controlled `<input>` pattern that `FieldRow` already uses for the value cell. On click, swap the displayed name for an `<input autoFocus />`; commit on Enter or blur; revert on Escape.
+
+**Alternatives considered:**
+- *Always-visible input* (like the type `<select>`). Rejected — names are long, wrapping them as inputs would visually dominate the table.
+- *Pencil icon → modal*. Rejected — heavier than necessary and inconsistent with the value-cell pattern users already know.
+- *Double-click to edit*. Rejected — discoverability is worse and there's no precedent for it in this UI.
+
+### Decision 2: Validate uniqueness within an entity (against ALL mappings), on commit
+
+When the user commits a rename, check every other mapping in `entity.field_mappings` — both base and custom — for the same trimmed name. If found, reject. Empty/whitespace-only names are rejected the same way. The error message appears inline below the cell for ~3 seconds, then auto-clears.
+
+Uniqueness must span both source types: a custom field renamed to collide with a base name would silently lose its data to whichever mapping the backend writes second, because `_build_model_definition` splits by source into separate `base_fields`/`custom_fields` arrays but downstream consumers reading the merged form would see two `name` fields.
+
+**Alternatives considered:**
+- *Validate against custom fields only*. Rejected — a custom field colliding with a base field name is exactly the dangerous case.
+- *Live validation as the user types*. Rejected — distracting, and transient duplicates are normal mid-typing.
+- *Server-side rejection only*. Rejected — the user wouldn't see the error until "Finalize", which is too late.
+- *Auto-suffix duplicates* (e.g., `name_2`). Rejected — silently changing the user's input is surprising.
+
+### Decision 3: Rename in place — preserve mapping order and identity, sync all three state locations
+
+In `handleFieldNameChange(oldName, newName)`:
+
+1. Find the mapping in `field_mappings` by `oldName`, replace `field_name`, write the array back with the same index.
+2. Rename the key in `entity.entity`: copy the value under `newName`, delete the `oldName` key.
+3. Rename the key in `entity.entity.custom_fields` (which always exists for renameable rows since base fields aren't renameable, but defensively guard for the property's existence).
+
+The downstream `_build_model_definition` is order-preserving and reads only `field_mappings`, so the resulting model definition is stable apart from the name. Step (2) and (3) keep the in-memory shape consistent with `handleFieldDelete`'s cleanup pattern and avoid stale keys.
+
+**Alternatives considered:**
+- *Remove + append with new name in `field_mappings`*. Rejected — silently reorders fields and would shift the displayed table.
+- *Skip steps (2) and (3) because the backend doesn't read them*. Rejected — same reason `handleFieldDelete` cleans them up: future code that reads `entity.entity` would see stale keys.
+
+### Decision 4: Rename handler returns a discriminated result, doesn't throw
+
+`onFieldNameChange` returns `{ ok: true } | { ok: false, error: string }` rather than throwing. The FieldRow can then set `nameError` and revert without try/catch in an event handler (where thrown errors are awkward — React doesn't catch them and the surrounding code has to wrap every synchronous handler).
+
+**Alternatives considered:**
+- *Throw on validation failure*. Rejected — pushes try/catch into every call site and conflates "user typed a duplicate" with "something genuinely broke".
+- *Validate inside FieldRow*. Rejected — FieldRow doesn't know about sibling mappings; the parent owns that information.
+
+### Decision 5: Only custom-field name cells render the editable input
+
+In `FieldRow.tsx`, gate the name-cell input on `source === "custom_field"`. Base-field rows keep the existing `<code>{fieldName}</code>` rendering with no click handler, no hover affordance, and no `title`. This mirrors how base-field types are already rendered as `<span className="field-row__type-locked">{fieldType}</span>` instead of a `<select>`.
+
+**Alternatives considered:**
+- *Allow base-field renames too*. Rejected — see Non-Goals. The backend doesn't enforce that base-field names equal the underlying class field keys, so it would technically work, but it breaks an implicit contract.
+- *Show a disabled-looking input on base rows*. Rejected — the existing pattern uses a different element (`<code>`/`<span>`), not a styled-disabled input. Consistency with the existing lock pattern wins.
+
+### Decision 6: No backend code changes; add a regression test instead
+
+The backend already consumes whatever `field_name` the frontend sends. To prevent a future change from accidentally locking it down (e.g., adding a Pydantic validator), add a backend test that posts a `FinalizeRequest` with a renamed custom field, mocks `httpx.put` to DataCore, and asserts the captured payload's `model_definition[entity]["custom_fields"]` contains the new name and not the old.
+
+The test mocks `httpx.put` directly (matching the pattern in `test_extract_api.py`), since that's the symbol `finalize_commit` calls.
+
+**Alternatives considered:**
+- *Add an explicit rename API endpoint*. Rejected — the rename is part of the same edit session that produces the finalize payload.
+
+## Risks / Trade-offs
+
+- **Risk:** A user renames a field to a name that DataCore's model-definition validator rejects (e.g., a reserved keyword). → **Mitigation:** The `POST /finalize/commit` call surfaces the DataCore HTTP error to the user via the existing error-handling path on `ReviewPage`; no UX change needed for this rare case. We don't pre-validate against DataCore rules here because that would couple Papermite to DataCore's internal name policy.
+- **Risk:** Stale drafts in IndexedDB might still have old names if the user reloads mid-edit. → **Mitigation:** Renames go through the existing draft-save pipeline — `handleFieldNameChange` lifts state through `onEntityUpdate`, which `ReviewPage.handleEntityUpdate` (lines 58–65) immediately writes into IndexedDB. No special handling needed.
+- **Risk:** Changing `field_name` invalidates the `<FieldRow key={mapping.field_name}>` React key (`EntityCard.tsx:138`), causing remount. → **Mitigation:** Commit happens on Enter or blur, so the user's focus is already leaving the input when the remount fires. Edge case: `showOptions` internal state on the row would reset, but custom selection fields would have to be mid-options-edit AND mid-rename simultaneously — vanishingly rare, not worth fixing here.
+- **Risk:** A user renames a custom field to a base-field name (e.g., `first_name`), and the backend's `_build_model_definition` puts the two in separate arrays (`base_fields` vs `custom_fields`) — downstream consumers reading the merged form would see two `name` fields. → **Mitigation:** Decision 2's cross-source uniqueness check rejects this client-side before finalize.
+- **Trade-off:** Per-entity uniqueness instead of global uniqueness. A duplicate across entities is allowed even though it could be confusing in a finalized form. Acceptable because (a) it matches the current spec model, and (b) form rendering qualifies fields by entity anyway.
+- **Trade-off:** Inline error shown for ~3 seconds is informal compared to a persistent toast. Accepted because the user has immediate feedback (the input reverted) and the cell is right where their attention is.
+
+## Migration Plan
+
+No data migration. Ship the frontend changes; existing model definitions are unaffected. Existing custom-field names in saved models become editable next time the user opens the model via LandingPage → Edit. Rollback is a revert of the frontend files since the backend is unchanged.

--- a/openspec/changes/papermite-editable-attribute-names/proposal.md
+++ b/openspec/changes/papermite-editable-attribute-names/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+After Papermite's LLM processes an uploaded document, the detected attribute names (field names) appear in the review UI as read-only text. Users can edit values, types, required flags, and selection options — but not the name itself. Since these names become the actual field labels in the final model definition that drives end-user forms, locking them forces users to either accept whatever wording the LLM produced or discard the field entirely and recreate it. Resolves [#67](https://github.com/kennyhlee/neo-apex/issues/67).
+
+## What Changes
+
+- Make the field name cell on **custom-field rows** in the review screen editable, using the same click-to-edit inline pattern already established for the value cell. Base-model field names remain locked, matching how base-field *types* are already locked (`field-row__type-locked`).
+- Add an `onFieldNameChange` callback path from `FieldRow` up through `EntityCard` so renames update the in-memory `ExtractionResult` consistently: rename the entry inside `field_mappings`, the key inside `entity.entity`, and the key inside `entity.entity.custom_fields` — preserving order and all other properties (mirrors how `handleFieldDelete` cleans up all three).
+- Validate field names client-side: non-empty (after trim), unique within the entity (compared against **all** sibling mappings, base + custom, to prevent a custom field colliding with a base name). Reject the edit (revert and surface a brief inline error) on conflict.
+- The rename handler returns a discriminated result (`{ ok: true } | { ok: false, error: string }`) rather than throwing, so the `FieldRow` can render the error inline without needing try/catch in event handlers.
+- Backend `_build_model_definition` and the `FieldMapping` Pydantic model already pass `field_name` through verbatim, so no backend code changes are needed — only a regression test confirming custom-field renames reach the persisted model definition.
+
+## Capabilities
+
+### New Capabilities
+
+- `papermite-attribute-rename`: Inline rename of extracted attribute (field) names in the Papermite review screen, with uniqueness validation and propagation through finalize.
+
+### Modified Capabilities
+
+<!-- None — no existing Papermite specs in openspec/specs/. -->
+
+## Impact
+
+- **Frontend** (`papermite/frontend/`):
+  - `src/components/FieldRow.tsx` — for custom-field rows, replace the static `<code>{fieldName}</code>` with an editable input/display toggle; add the `onFieldNameChange` prop. Base-field rows continue to render `<code>{fieldName}</code>` with no click handler.
+  - `src/components/EntityCard.tsx` — add `handleFieldNameChange` that enforces non-emptiness + uniqueness, renames the matching entry in `entity.field_mappings`, and also renames the corresponding keys in `entity.entity` and `entity.entity.custom_fields` so all three stay consistent (matching the existing pattern in `handleFieldDelete`).
+  - `src/components/EntityCard.css` — hover/focus affordance + `title="Click to edit"` for the editable name cell so users discover it, plus a small inline error style.
+- **Backend** (`papermite/backend/`): no code changes. Add a regression test that posts a `FinalizeRequest` with a custom field renamed from the LLM-default and asserts the model definition sent to DataCore contains the new name in `custom_fields` and not the old one. Mock `httpx.put` (matches the existing pattern in `test_extract_api.py`).
+- **API contracts**: unchanged. `FieldMapping.field_name` is already a free-form `str`.
+- **Data**: no schema migration. Each commit produces a new model definition version via the existing DataCore versioned write.

--- a/openspec/changes/papermite-editable-attribute-names/specs/papermite-attribute-rename/spec.md
+++ b/openspec/changes/papermite-editable-attribute-names/specs/papermite-attribute-rename/spec.md
@@ -1,0 +1,165 @@
+## ADDED Requirements
+
+### Requirement: Custom-field name cells SHALL be inline-editable; base-field name cells SHALL NOT
+
+On the Papermite review screen, every row whose mapping has `source: "custom_field"` SHALL render its field name in a control that toggles between a display element and a text input. The interaction SHALL match the existing inline edit pattern for the field value cell: clicking the displayed name swaps it for an `<input>` that is auto-focused and pre-filled with the current name. The display element SHALL carry `title="Click to edit"` as an affordance hint, mirroring the value cell.
+
+Rows whose mapping has `source: "base_model"` SHALL continue to render the field name as static `<code>{fieldName}</code>` with no click handler, no hover affordance, and no `title`. Clicking a base-field name SHALL have no effect. This mirrors the existing lock pattern on base-field type (`<span className="field-row__type-locked">`) and base-field required toggle (`disabled={isBase}`).
+
+#### Scenario: Clicking a custom-field name enters edit mode
+
+- **GIVEN** a field row whose mapping has `source: "custom_field"`
+- **WHEN** the user clicks on the displayed name
+- **THEN** the name cell SHALL switch to an `<input>` element
+- **AND** the input SHALL be auto-focused with the cursor positioned for editing
+- **AND** the input value SHALL equal the current field name
+
+#### Scenario: Clicking a base-field name does nothing
+
+- **GIVEN** a field row whose mapping has `source: "base_model"`
+- **WHEN** the user clicks on the displayed name
+- **THEN** the name cell SHALL remain a static `<code>` element
+- **AND** no input SHALL appear
+- **AND** the `ExtractionResult` SHALL NOT be modified
+
+#### Scenario: Pressing Enter commits the rename
+
+- **GIVEN** a custom-field name cell is in edit mode with a non-empty, unique trimmed value
+- **WHEN** the user presses Enter
+- **THEN** the input SHALL exit edit mode and revert to the display element showing the new name
+- **AND** the in-memory `ExtractionResult` SHALL be updated as defined in the propagation requirement below
+
+#### Scenario: Blurring the input commits the rename
+
+- **GIVEN** a custom-field name cell is in edit mode with a non-empty, unique trimmed value
+- **WHEN** the input loses focus (blur)
+- **THEN** the rename SHALL be committed using the same logic as pressing Enter
+
+#### Scenario: Pressing Escape cancels the rename
+
+- **GIVEN** a custom-field name cell is in edit mode
+- **WHEN** the user presses Escape
+- **THEN** the input SHALL exit edit mode and revert to the original name
+- **AND** the `ExtractionResult` SHALL NOT be modified
+
+### Requirement: Renames SHALL be validated for non-emptiness and per-entity uniqueness against ALL mappings
+
+When a rename is committed, the new name (after trimming leading and trailing whitespace) MUST satisfy:
+
+1. Length greater than zero.
+2. Differ from the `field_name` of every other `FieldMapping` in the same entity — comparing against **both** `source: "base_model"` and `source: "custom_field"` mappings (case-sensitive).
+
+If validation fails, the rename SHALL be rejected: the input SHALL revert to the original name, the in-memory `ExtractionResult` SHALL NOT be modified, and a brief inline error message SHALL appear adjacent to the cell and auto-clear after approximately 3 seconds.
+
+The handler the parent passes to `FieldRow` SHALL return a discriminated result of the shape `{ ok: true } | { ok: false, error: string }`; it SHALL NOT throw.
+
+#### Scenario: Empty name is rejected
+
+- **GIVEN** a custom-field name cell is in edit mode
+- **WHEN** the user clears the input and commits (Enter or blur)
+- **THEN** the input SHALL revert to the original name
+- **AND** the `ExtractionResult` SHALL NOT be modified
+- **AND** an inline error indicating the name cannot be empty SHALL appear briefly
+
+#### Scenario: Whitespace-only name is rejected
+
+- **GIVEN** a custom-field name cell is in edit mode
+- **WHEN** the user enters only whitespace characters and commits
+- **THEN** the rename SHALL be rejected with the same behavior as an empty name
+
+#### Scenario: Duplicate name colliding with another custom field is rejected
+
+- **GIVEN** an entity has two custom-field mappings named `nickname` and `pronouns`
+- **AND** the user is editing the `pronouns` cell
+- **WHEN** the user enters `nickname` and commits
+- **THEN** the input SHALL revert to `pronouns`
+- **AND** the `ExtractionResult` SHALL NOT be modified
+- **AND** an inline error indicating the name is already used SHALL appear briefly
+
+#### Scenario: Duplicate name colliding with a base field is rejected
+
+- **GIVEN** an entity has a base-field mapping named `first_name` and a custom-field mapping named `nickname`
+- **AND** the user is editing the `nickname` cell
+- **WHEN** the user enters `first_name` and commits
+- **THEN** the input SHALL revert to `nickname`
+- **AND** the `ExtractionResult` SHALL NOT be modified
+- **AND** an inline error SHALL appear briefly
+
+#### Scenario: Duplicate name across different entities is allowed
+
+- **GIVEN** entity `student` has a custom field `note` and entity `family` has a custom field `comment`
+- **WHEN** the user renames `family.comment` to `note`
+- **THEN** the rename SHALL succeed
+- **AND** both entities SHALL have a `note` field afterward
+
+#### Scenario: Committing the unchanged name is a no-op
+
+- **GIVEN** a custom-field name cell is in edit mode showing the current name
+- **WHEN** the user commits without changing the value
+- **THEN** the input SHALL exit edit mode
+- **AND** no error SHALL be shown
+- **AND** the `ExtractionResult` SHALL NOT be modified
+
+### Requirement: A successful rename SHALL update field_mappings, entity.entity, and entity.entity.custom_fields in lockstep
+
+When a rename is committed and passes validation, the `EntityResult` returned to `ReviewPage` SHALL reflect all three of the following changes, applied to a single new object (no partial application):
+
+1. In `entity.field_mappings`, the matching mapping's `field_name` is replaced with the new (trimmed) name at the same array index. All other properties of the mapping (`value`, `source`, `required`, `field_type`, `options`, `multiple`) SHALL be unchanged.
+2. In `entity.entity`, the key under the old name is removed and a new key with the same value is set under the new name.
+3. In `entity.entity.custom_fields` (when present), the key under the old name is removed and a new key with the same value is set under the new name.
+
+This mirrors the cleanup pattern of `handleFieldDelete` in `EntityCard.tsx`.
+
+#### Scenario: field_mappings entry is renamed in place
+
+- **GIVEN** an entity has a custom field mapping at index 2 with `field_name: "dob"`, `value: "2010-01-01"`, `field_type: "date"`, `required: false`
+- **WHEN** the user renames the field to `date_of_birth`
+- **THEN** the mapping at index 2 SHALL have `field_name: "date_of_birth"`
+- **AND** the mapping at index 2 SHALL still have `value: "2010-01-01"`, `field_type: "date"`, `required: false`, `source: "custom_field"`
+- **AND** the array length SHALL be unchanged
+- **AND** no other mapping in the array SHALL be modified
+
+#### Scenario: entity.entity key is renamed
+
+- **GIVEN** an entity has `entity.entity = { first_name: "Sam", dob: "2010-01-01", custom_fields: { dob: "2010-01-01" } }`
+- **WHEN** the user renames custom field `dob` to `date_of_birth`
+- **THEN** `entity.entity` SHALL NOT have a key `dob`
+- **AND** `entity.entity.date_of_birth` SHALL equal `"2010-01-01"`
+- **AND** `entity.entity.first_name` SHALL still equal `"Sam"`
+
+#### Scenario: entity.entity.custom_fields key is renamed
+
+- **GIVEN** the same starting state as the previous scenario
+- **WHEN** the user renames custom field `dob` to `date_of_birth`
+- **THEN** `entity.entity.custom_fields` SHALL NOT have a key `dob`
+- **AND** `entity.entity.custom_fields.date_of_birth` SHALL equal `"2010-01-01"`
+
+### Requirement: Renames SHALL propagate through finalize to the saved model definition
+
+When a renamed `ExtractionResult` is submitted via `POST /tenants/{tenant_id}/finalize/commit`, the resulting model definition stored in DataCore SHALL contain the renamed custom field under its new name, with all other field properties (`type`, `required`, `options`, `multiple`) preserved from the edit session. The backend SHALL NOT introduce any validator or transformation that would reject or alter the `field_name` value supplied by the client.
+
+#### Scenario: Renamed custom field is persisted with the new name
+
+- **GIVEN** the user has renamed a custom field from `dob` to `date_of_birth` in the review screen, with `field_type: "date"`, `required: false`
+- **WHEN** the user clicks Finalize and the backend processes the commit
+- **THEN** the JSON payload sent in the `httpx.put` call to DataCore's `/models/{tenant_id}` endpoint SHALL contain, in `model_definition[<entity_type>]["custom_fields"]`, an object with `{"name": "date_of_birth", "type": "date", "required": false}`
+- **AND** SHALL NOT contain any object with `"name": "dob"` in either `custom_fields` or `base_fields` of that entity
+
+#### Scenario: Backend does not reject renamed field_name values
+
+- **GIVEN** a finalize request payload with one or more renamed custom-field `field_name` values
+- **WHEN** the request is processed by `_build_model_definition`
+- **THEN** the function SHALL produce a model definition using the new names without raising
+- **AND** the call to `PUT /models/{tenant_id}` on DataCore SHALL be made with those new names in the payload
+
+### Requirement: Reopening a saved model SHALL allow further custom-field renames
+
+When a user reopens a previously-saved model definition for editing (LandingPage → Edit), every custom-field name SHALL be editable through the same interaction. Names persisted from a prior session SHALL appear as the current values in the review screen and SHALL remain renameable. Base-field names SHALL remain non-editable.
+
+#### Scenario: Renamed custom field can be renamed again on next edit
+
+- **GIVEN** a model definition exists in DataCore with a custom field originally named `dob`, renamed to `date_of_birth` in a prior session
+- **WHEN** the user opens the model via the LandingPage Edit action
+- **THEN** the review screen SHALL show the field as `date_of_birth`
+- **AND** clicking the name SHALL enter edit mode
+- **AND** the user SHALL be able to rename it to `birth_date` and commit

--- a/openspec/changes/papermite-editable-attribute-names/tasks.md
+++ b/openspec/changes/papermite-editable-attribute-names/tasks.md
@@ -1,0 +1,56 @@
+## 1. Frontend — FieldRow editable name cell (custom fields only)
+
+- [ ] 1.1 Add `onFieldNameChange?: (oldName: string, newName: string) => { ok: true } | { ok: false; error: string }` to the `Props` interface in `papermite/frontend/src/components/FieldRow.tsx`.
+- [ ] 1.2 Add local state for name editing inside `FieldRow`: `editingName: boolean`, `editName: string` (initialized to `fieldName` when entering edit mode), and `nameError: string | null` for transient inline validation feedback. Use `useEffect` to auto-clear `nameError` ~3 seconds after it's set.
+- [ ] 1.3 In the name cell (currently the `<td className="field-row__name">` at lines 134–136), branch on `isBase`:
+  - If `isBase` is true (or `onFieldNameChange` is not provided): keep the existing `<code>{fieldName}</code>` rendering exactly as it is — no click handler, no `title`.
+  - If `isBase` is false and `onFieldNameChange` is provided: render the value-cell pattern — a clickable `<span className="field-row__display field-row__name-display" title="Click to edit" onClick={() => setEditingName(true)}>{fieldName}</span>` when not editing, and an `<input autoFocus className="input field-row__input" value={editName} onChange={...} onBlur={handleNameSave} onKeyDown={handleNameKeyDown} />` when editing.
+- [ ] 1.4 Implement `handleNameSave`: trim `editName`; if the trimmed value equals `fieldName` exit edit mode silently (no-op); otherwise call `onFieldNameChange!(fieldName, trimmed)`. If the result is `{ ok: true }` exit edit mode. If `{ ok: false, error }` set `nameError = error`, leave display showing the original `fieldName`, exit edit mode.
+- [ ] 1.5 Implement `handleNameKeyDown`: on `Enter` call `handleNameSave()` and `e.preventDefault()`; on `Escape` set `editingName=false` without committing.
+- [ ] 1.6 Render `nameError` as a small inline message immediately under the name cell (`<div className="field-row__name-error">{nameError}</div>`) when non-null. Place it inside the same `<td>` so it does not break table layout.
+
+## 2. Frontend — EntityCard rename plumbing
+
+- [ ] 2.1 Add `handleFieldNameChange(oldName: string, newName: string): { ok: true } | { ok: false; error: string }` to `papermite/frontend/src/components/EntityCard.tsx`. It must NOT throw.
+- [ ] 2.2 Validation inside `handleFieldNameChange` (executed in this order):
+  - Trim `newName`. If empty, return `{ ok: false, error: "Name cannot be empty" }`.
+  - If trimmed equals `oldName`, return `{ ok: true }` without mutating state (no-op).
+  - If any other mapping in `entity.field_mappings` (any source — both base and custom) has `field_name === trimmed`, return `{ ok: false, error: \`"\${trimmed}" is already used by another field\` }`.
+- [ ] 2.3 On success, build a new `EntityResult` by applying ALL of:
+  - `updated.field_mappings = entity.field_mappings.map(m => m.field_name === oldName ? { ...m, field_name: trimmed } : m)` — preserves array order and other properties.
+  - `updated.entity = { ...entity.entity }`, then `updated.entity[trimmed] = updated.entity[oldName]; delete updated.entity[oldName];`.
+  - If `updated.entity.custom_fields` exists and is an object containing key `oldName`: clone it (`{ ...(updated.entity.custom_fields as Record<string, unknown>) }`), copy the value to `trimmed`, delete `oldName`, assign back.
+  - Then call `onUpdate(index, updated)` and return `{ ok: true }`.
+- [ ] 2.4 Pass `onFieldNameChange={handleFieldNameChange}` to the `<FieldRow />` element (next to `onUpdate`, `onRequiredToggle`, etc.) at `EntityCard.tsx:137`.
+
+## 3. Frontend — styling affordance
+
+- [ ] 3.1 In `papermite/frontend/src/components/EntityCard.css`, add a hover/focus state on `.field-row__name-display` (or whichever class name task 1.3 picked) — `cursor: pointer`, a subtle background change on hover, mirroring how `.field-row__display` looks today. Do NOT add the hover state to plain `.field-row__name code` (base-field rendering must stay visually inert).
+- [ ] 3.2 Add a style for `.field-row__name-error`: small font-size (~12px), `color: var(--danger-text)` or equivalent red, `margin-top: 4px`. Must not push the table row height noticeably.
+
+## 4. Frontend — TypeScript and lint
+
+- [ ] 4.1 Run `npm run build` in `papermite/frontend/` and resolve any TypeScript errors.
+- [ ] 4.2 Run `npm run lint` in `papermite/frontend/` and resolve any new warnings/errors.
+
+## 5. Backend — regression test for custom-field rename pass-through
+
+- [ ] 5.1 Add `papermite/backend/tests/test_finalize_api.py` modeled on `test_extract_api.py`:
+  - Use `TestClient(app)` and override `require_admin` with a fake admin `UserRecord` (tenant_id `"t1"`).
+  - Build an `ExtractionResult` with one entity (e.g., `entity_type="student"`) whose `field_mappings` includes a custom field named `"date_of_birth"` (with `source="custom_field"`, `field_type="date"`, `required=False`) — note this name is *not* the conventional LLM default `"dob"`, so a regression that pinned `field_name` to a fixed list would fail.
+  - Mock `httpx.put` at `app.api.finalize.httpx.put` to return a `MagicMock` with `status_code=200` and `.json()` returning a dict with the required keys (`status`, `version`, `model_definition`, `source_filename`, `created_by`, `created_at`).
+  - POST the payload to `/api/tenants/t1/finalize/commit`.
+  - Assert `httpx.put` was called once; inspect the captured `json=` kwarg; assert `payload["model_definition"]["student"]["custom_fields"]` contains an object with `name == "date_of_birth"`; assert no object in either `custom_fields` or `base_fields` has `name == "dob"`.
+- [ ] 5.2 Run `cd papermite/backend && uv run python -m pytest tests/test_finalize_api.py -v` (or the project's standard test invocation) and confirm the new test passes alongside existing tests.
+
+## 6. Manual verification
+
+- [ ] 6.1 Start papermite backend + frontend (via `./start-services.sh` from repo root, or per service `CLAUDE.md`). Upload a sample document so an extraction with at least one custom field is generated.
+- [ ] 6.2 On the review page, click a **custom-field** name — confirm an input appears, prefilled and focused.
+- [ ] 6.3 Type a new name and press Enter — confirm the row updates, the displayed name is the new one, and no error appears.
+- [ ] 6.4 Click a **base-field** name — confirm nothing happens (no input, no cursor change beyond default).
+- [ ] 6.5 Try renaming a custom field to an existing custom-field name; confirm the input reverts and the inline error appears, then auto-clears within ~3 seconds.
+- [ ] 6.6 Try renaming a custom field to an existing base-field name (e.g. `first_name` on a student); confirm rejection and error.
+- [ ] 6.7 Try committing an empty / whitespace-only name; confirm rejection with the empty-name error.
+- [ ] 6.8 Press Escape mid-edit; confirm the value reverts and no error fires.
+- [ ] 6.9 Click Finalize; confirm no errors. Then via LandingPage → Edit, reopen the saved model and verify the renamed custom field shows up under the new name and is still renameable.

--- a/papermite/backend/tests/test_finalize_api.py
+++ b/papermite/backend/tests/test_finalize_api.py
@@ -1,0 +1,134 @@
+"""Regression tests for POST /api/tenants/{tenant_id}/finalize/commit.
+
+Pins the contract that custom-field renames flow from the request payload
+straight into the model definition sent to DataCore.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.models.registry import UserRecord
+
+client = TestClient(app)
+
+FAKE_USER = UserRecord(
+    user_id="u1",
+    name="Test Admin",
+    email="admin@test.com",
+    password_hash="",
+    tenant_id="t1",
+    tenant_name="Test Tenant",
+    role="admin",
+    created_at="",
+)
+
+
+@pytest.fixture(autouse=True)
+def mock_auth():
+    """Bypass auth for all tests using FastAPI dependency override."""
+    from app.api.auth import require_admin
+
+    app.dependency_overrides[require_admin] = lambda: FAKE_USER
+    yield
+    app.dependency_overrides.pop(require_admin, None)
+
+
+def _payload_with_renamed_custom_field() -> dict:
+    """A finalize payload with one custom field renamed away from any LLM default."""
+    return {
+        "extraction": {
+            "extraction_id": "e1",
+            "tenant_id": "t1",
+            "filename": "app.pdf",
+            "entities": [
+                {
+                    "entity_type": "student",
+                    "entity": {
+                        "first_name": "Sam",
+                        "date_of_birth": "2010-01-01",
+                        "custom_fields": {"date_of_birth": "2010-01-01"},
+                    },
+                    "field_mappings": [
+                        {
+                            "field_name": "first_name",
+                            "value": "Sam",
+                            "source": "base_model",
+                            "required": True,
+                            "field_type": "str",
+                        },
+                        {
+                            "field_name": "date_of_birth",
+                            "value": "2010-01-01",
+                            "source": "custom_field",
+                            "required": False,
+                            "field_type": "date",
+                        },
+                    ],
+                }
+            ],
+            "status": "pending_review",
+        }
+    }
+
+
+def _datacore_response_payload(model_definition: dict) -> dict:
+    """Shape that `finalize_commit` expects back from DataCore."""
+    return {
+        "status": "ok",
+        "version": 1,
+        "model_definition": model_definition,
+        "source_filename": "app.pdf",
+        "created_by": "Test Admin",
+        "created_at": "2026-05-16T00:00:00Z",
+    }
+
+
+def test_renamed_custom_field_is_passed_through_to_datacore():
+    """Frontend rename must reach DataCore's model_definition payload verbatim."""
+    captured: dict = {}
+
+    def fake_put(url, *, json, timeout):  # noqa: ARG001 - signature matches httpx.put
+        captured["url"] = url
+        captured["json"] = json
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = _datacore_response_payload(
+            json["model_definition"]
+        )
+        return mock_resp
+
+    with patch("app.api.finalize.httpx.put", side_effect=fake_put):
+        resp = client.post(
+            "/api/tenants/t1/finalize/commit",
+            json=_payload_with_renamed_custom_field(),
+        )
+
+    assert resp.status_code == 200, resp.text
+
+    # The renamed custom field reached DataCore under its new name.
+    sent_model = captured["json"]["model_definition"]
+    assert "student" in sent_model, sent_model
+    student = sent_model["student"]
+
+    custom_names = [f["name"] for f in student["custom_fields"]]
+    base_names = [f["name"] for f in student["base_fields"]]
+
+    assert "date_of_birth" in custom_names, custom_names
+    # Critically: no trace of the LLM-default name anywhere.
+    assert "dob" not in custom_names, custom_names
+    assert "dob" not in base_names, base_names
+
+    # And the renamed field's other properties were preserved.
+    renamed = next(f for f in student["custom_fields"] if f["name"] == "date_of_birth")
+    assert renamed["type"] == "date"
+    assert renamed["required"] is False
+
+
+def test_finalize_rejects_tenant_mismatch():
+    """Sanity: the existing tenant guard still works with the test setup."""
+    bad = _payload_with_renamed_custom_field()
+    bad["extraction"]["tenant_id"] = "other_tenant"
+    resp = client.post("/api/tenants/t1/finalize/commit", json=bad)
+    assert resp.status_code == 400, resp.text

--- a/papermite/frontend/src/components/EntityCard.css
+++ b/papermite/frontend/src/components/EntityCard.css
@@ -86,6 +86,29 @@
   padding: 0;
 }
 
+.field-row__name-display {
+  font-family: var(--font-sans);
+  font-size: 13px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  padding: 4px 0;
+  border-bottom: 1px dashed transparent;
+  transition: border-color 0.2s;
+  display: inline-block;
+}
+
+.field-row__name-display:hover {
+  border-bottom-color: var(--text-tertiary);
+}
+
+.field-row__name-error {
+  margin-top: 4px;
+  font-family: var(--font-sans);
+  font-size: 12px;
+  color: var(--accent-danger, #d4537e);
+  line-height: 1.3;
+}
+
 .field-row__value {
   overflow: hidden;
 }

--- a/papermite/frontend/src/components/EntityCard.tsx
+++ b/papermite/frontend/src/components/EntityCard.tsx
@@ -65,6 +65,57 @@ export default function EntityCard({ entity, index, onUpdate }: Props) {
     onUpdate(index, updated);
   };
 
+  const handleFieldNameChange = (
+    oldName: string,
+    newName: string
+  ): { ok: true } | { ok: false; error: string } => {
+    const trimmed = newName.trim();
+    if (trimmed.length === 0) {
+      return { ok: false, error: "Name cannot be empty" };
+    }
+    if (trimmed === oldName) {
+      return { ok: true };
+    }
+    const collision = entity.field_mappings.some(
+      (m) => m.field_name !== oldName && m.field_name === trimmed
+    );
+    if (collision) {
+      return {
+        ok: false,
+        error: `"${trimmed}" is already used by another field`,
+      };
+    }
+
+    const newMappings = entity.field_mappings.map((m) =>
+      m.field_name === oldName ? { ...m, field_name: trimmed } : m
+    );
+
+    const newEntity: Record<string, unknown> = { ...entity.entity };
+    if (Object.prototype.hasOwnProperty.call(newEntity, oldName)) {
+      newEntity[trimmed] = newEntity[oldName];
+      delete newEntity[oldName];
+    }
+
+    const cf = newEntity.custom_fields;
+    if (
+      cf &&
+      typeof cf === "object" &&
+      Object.prototype.hasOwnProperty.call(cf, oldName)
+    ) {
+      const cfClone = { ...(cf as Record<string, unknown>) };
+      cfClone[trimmed] = cfClone[oldName];
+      delete cfClone[oldName];
+      newEntity.custom_fields = cfClone;
+    }
+
+    onUpdate(index, {
+      ...entity,
+      entity: newEntity,
+      field_mappings: newMappings,
+    });
+    return { ok: true };
+  };
+
   const handleFieldDelete = (fieldName: string) => {
     const updated = { ...entity };
     const newEntity = { ...updated.entity };
@@ -147,6 +198,11 @@ export default function EntityCard({ entity, index, onUpdate }: Props) {
                 onRequiredToggle={handleRequiredToggle}
                 onTypeChange={handleTypeChange}
                 onOptionsChange={handleOptionsChange}
+                onFieldNameChange={
+                  mapping.source === "custom_field"
+                    ? handleFieldNameChange
+                    : undefined
+                }
                 onDelete={
                   mapping.source === "custom_field"
                     ? () => handleFieldDelete(mapping.field_name)

--- a/papermite/frontend/src/components/FieldRow.tsx
+++ b/papermite/frontend/src/components/FieldRow.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { FIELD_TYPES } from "../types/models";
 import type { FieldType } from "../types/models";
 
@@ -14,6 +14,10 @@ interface Props {
   onRequiredToggle: (fieldName: string, required: boolean) => void;
   onTypeChange: (fieldName: string, fieldType: FieldType) => void;
   onOptionsChange: (fieldName: string, options: string[], multiple: boolean) => void;
+  onFieldNameChange?: (
+    oldName: string,
+    newName: string
+  ) => { ok: true } | { ok: false; error: string };
   onDelete?: () => void;
 }
 
@@ -108,11 +112,21 @@ export default function FieldRow({
   onRequiredToggle,
   onTypeChange,
   onOptionsChange,
+  onFieldNameChange,
   onDelete,
 }: Props) {
   const [editing, setEditing] = useState(false);
   const [editValue, setEditValue] = useState(toEditString(value));
   const [showOptions, setShowOptions] = useState(false);
+  const [editingName, setEditingName] = useState(false);
+  const [editName, setEditName] = useState(fieldName);
+  const [nameError, setNameError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (nameError === null) return;
+    const t = setTimeout(() => setNameError(null), 3000);
+    return () => clearTimeout(t);
+  }, [nameError]);
 
   const handleSave = () => {
     onUpdate(fieldName, editValue);
@@ -124,6 +138,39 @@ export default function FieldRow({
     if (e.key === "Escape") setEditing(false);
   };
 
+  const handleNameSave = () => {
+    const trimmed = editName.trim();
+    if (trimmed === fieldName) {
+      setEditingName(false);
+      setEditName(fieldName);
+      return;
+    }
+    if (!onFieldNameChange) {
+      setEditingName(false);
+      setEditName(fieldName);
+      return;
+    }
+    const result = onFieldNameChange(fieldName, trimmed);
+    if (result.ok) {
+      setEditingName(false);
+    } else {
+      setNameError(result.error);
+      setEditingName(false);
+      setEditName(fieldName);
+    }
+  };
+
+  const handleNameKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleNameSave();
+    }
+    if (e.key === "Escape") {
+      setEditingName(false);
+      setEditName(fieldName);
+    }
+  };
+
   const displayValue = toEditString(value) || "—";
 
   const isBase = source === "base_model";
@@ -132,7 +179,34 @@ export default function FieldRow({
     <>
       <tr className="field-row">
         <td className="field-row__name">
-          <code>{fieldName}</code>
+          {isBase ? (
+            <code>{fieldName}</code>
+          ) : editingName ? (
+            <input
+              className="input field-row__input"
+              value={editName}
+              onChange={(e) => setEditName(e.target.value)}
+              onBlur={handleNameSave}
+              onKeyDown={handleNameKeyDown}
+              autoFocus
+            />
+          ) : (
+            <span
+              className="field-row__name-display"
+              onClick={() => {
+                setEditName(fieldName);
+                setEditingName(true);
+              }}
+              title="Click to edit"
+            >
+              {fieldName}
+            </span>
+          )}
+          {nameError && (
+            <div className="field-row__name-error" role="alert">
+              {nameError}
+            </div>
+          )}
         </td>
         <td className="field-row__value">
           {fieldType === "selection" && (options?.length ?? 0) > 0 ? (


### PR DESCRIPTION
## Summary

- Custom-field attribute names on the Papermite review screen are now editable via inline click-to-edit — same UX as the value cell. Base-field names remain locked, matching the existing lock on base-field types and required toggles.
- Renames are validated for non-emptiness and per-entity uniqueness against **all** sibling mappings (base + custom), preventing silent collisions that `_build_model_definition` would split across `base_fields`/`custom_fields` arrays.
- The rename keeps three in-memory locations consistent: `entity.field_mappings`, `entity.entity`, and `entity.entity.custom_fields` — mirroring the existing `handleFieldDelete` cleanup pattern.
- Backend `_build_model_definition` already accepts renamed `field_name` values verbatim; a new regression test pins this contract by mocking `httpx.put` and asserting the captured DataCore payload carries the new name.

Closes #67.

## Spec & plan
- OpenSpec change: `openspec/changes/papermite-editable-attribute-names/` (proposal, design, spec, tasks)
- Implementation plan: `docs/superpowers/plans/2026-05-16-papermite-editable-attribute-names.md`

## Test plan

- [x] `cd papermite/frontend && npm run build` — clean
- [x] `cd papermite/frontend && npm run lint` — no new warnings introduced
- [x] `cd papermite/backend && uv run python -m pytest tests/test_finalize_api.py -v` — 2 passed
- [x] Manual: rename a custom field → Finalize → Confirm & Save → DataCore stores the renamed name (verified via direct query against `models` table)
- [x] Manual: base-field name cell is non-clickable (no input, no cursor change)
- [x] Manual: duplicate rejection (custom-vs-custom AND custom-vs-base) shows inline error and auto-clears
- [x] Manual: empty/whitespace rejection shows inline error
- [x] Manual: Escape cancels without committing
- [x] Manual: reopen via LandingPage → Edit → renamed field appears under new name and is still renameable

## Known follow-ups (not in this PR)

- **admindash session cache invalidation** — `ModelContext.clearCache()` is defined but never called, so admindash holds the previously-loaded model_definition for the session lifetime. Symptoms surface after model edits in Papermite while admindash is open. Tracked as a separate change.
- **AddFieldForm duplicate validation** — `AddFieldForm.handleSubmit` only checks for non-empty name; doesn't reject duplicates. Same uniqueness rule should apply there for consistency, but out of scope for #67.
- **`papermite/CLAUDE.md` is stale** — mentions port 8000 (actual is 5710 per `services.json`) and a `/finalize/preview` endpoint that doesn't exist. Doc cleanup ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)