### PR TITLE
fix(papermite): mapper guarantees all ENTITY_CLASSES types in extraction output

### DIFF
--- a/docs/superpowers/plans/2026-05-20-papermite-include-missing-default-entities.md
+++ b/docs/superpowers/plans/2026-05-20-papermite-include-missing-default-entities.md
@@ -1,0 +1,544 @@
+# Papermite Include Missing Default Entities Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ensure `mapper.map_extraction` returns exactly one `EntityResult` per entity type declared in `app.models.domain.ENTITY_CLASSES`, adding a placeholder (full base-field coverage, `value=None`) for any type the AI did not extract. Fixes the bug where a document missing a given entity type produces a model definition that omits it entirely.
+
+**Architecture:** Single coverage-backstop block added immediately after `entities = _consolidate_entities(entities)` inside `map_extraction`. The block iterates `ENTITY_CLASSES.items()` and calls `_map_entity_list([{}], entity_type, model_class, tenant_id)` for any type not already represented in `entities`. Leverages existing helpers (`_map_entity_list`, `_map_entity`, `_consolidate_entities`) without modifying them. No changes outside `mapper.py` and one new test file (well, additions to existing test file).
+
+**Tech Stack:** Python 3, Pydantic, pytest, `uv` for dependency management. Tests run from `papermite/backend/`.
+
+**Spec source (authoritative):**
+- `/Users/kennylee/Development/NeoApex/openspec/changes/papermite-include-missing-default-entities/proposal.md`
+- `/Users/kennylee/Development/NeoApex/openspec/changes/papermite-include-missing-default-entities/design.md`
+- `/Users/kennylee/Development/NeoApex/openspec/changes/papermite-include-missing-default-entities/specs/papermite-mapper-default-entity-coverage/spec.md`
+- `/Users/kennylee/Development/NeoApex/openspec/changes/papermite-include-missing-default-entities/tasks.md`
+
+**Out of scope:** UI changes, DataCore changes, Launchpad changes, changes to `ENTITY_CLASSES` contents, changes to `_build_model_definition`.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `papermite/backend/app/services/mapper.py` | Modify (single insertion after line ~293) | Add coverage-backstop loop in `map_extraction` |
+| `papermite/backend/tests/test_mapper.py` | Modify (append tests) | Cover the 7 mapper-level scenarios |
+| `papermite/backend/tests/test_finalize_mapper_integration.py` | Create | One integration test that wires `map_extraction` → `_build_model_definition` |
+
+Three commits total (one per task group). No new modules.
+
+---
+
+## Conventions
+
+- All paths absolute, relative to repo root `/Users/kennylee/Development/NeoApex`.
+- Test runs: `cd papermite/backend && uv run python -m pytest <args>` (the `cd` is required — backend has its own `pyproject.toml`).
+- Commit messages follow `<type>(papermite): <summary>` per repo convention. Final commit includes issue reference.
+- TDD: write failing test → run to confirm failure → implement minimum code → run to confirm pass → commit.
+
+---
+
+### Task 1: Add the coverage backstop to `map_extraction`
+
+**Files:**
+- Modify: `papermite/backend/app/services/mapper.py:267-299` (function `map_extraction`)
+- Modify: `papermite/backend/tests/test_mapper.py` (append the trigger test)
+
+This task adds the production code AND the smallest failing test that drives it. Subsequent tasks layer more tests on top.
+
+- [ ] **Step 1.1: Add the failing trigger test**
+
+Append the following to `/Users/kennylee/Development/NeoApex/papermite/backend/tests/test_mapper.py` (preserve all existing content, two blank lines before the new test):
+
+```python
+
+
+def test_map_extraction_all_placeholders_when_raw_is_empty():
+    """With nothing extracted, every entity type in ENTITY_CLASSES must appear."""
+    from app.models.domain import ENTITY_CLASSES
+
+    raw = RawExtraction()
+    result = map_extraction(raw, "t1", "f.pdf")
+
+    types = {e.entity_type for e in result.entities}
+    expected = {k.upper() for k in ENTITY_CLASSES}
+    assert types == expected
+    assert len(result.entities) == len(ENTITY_CLASSES)
+```
+
+- [ ] **Step 1.2: Run the test and confirm it fails**
+
+```
+cd papermite/backend && uv run python -m pytest tests/test_mapper.py::test_map_extraction_all_placeholders_when_raw_is_empty -v
+```
+
+Expected: FAIL. Today, `RawExtraction()` produces 0 entities (every guard `if raw.tenant` / `if raw_list:` is false). The assertion `len(result.entities) == 8` will fail with `0 != 8`. Either failure mode is fine.
+
+- [ ] **Step 1.3: Add the coverage backstop in `mapper.py`**
+
+Use the Edit tool on `/Users/kennylee/Development/NeoApex/papermite/backend/app/services/mapper.py`. Find this exact block (currently the tail of `map_extraction`):
+
+```python
+    # Consolidate multiple entities of the same type into one
+    entities = _consolidate_entities(entities)
+
+    return ExtractionResult(
+        tenant_id=tenant_id,
+        filename=filename,
+        entities=entities,
+    )
+```
+
+Replace it with:
+
+```python
+    # Consolidate multiple entities of the same type into one
+    entities = _consolidate_entities(entities)
+
+    # Coverage backstop: every entity type in ENTITY_CLASSES must be present.
+    # When the AI did not extract a type, add a placeholder EntityResult with
+    # full base-field coverage so downstream model definitions stay canonical.
+    existing_types = {e.entity_type.lower() for e in entities}
+    for entity_type, model_class in ENTITY_CLASSES.items():
+        if entity_type in existing_types:
+            continue
+        entities.extend(
+            _map_entity_list([{}], entity_type, model_class, tenant_id)
+        )
+
+    return ExtractionResult(
+        tenant_id=tenant_id,
+        filename=filename,
+        entities=entities,
+    )
+```
+
+Note: `ENTITY_CLASSES`, `_map_entity_list`, `EntityResult`, and `ExtractionResult` are already imported at the top of `mapper.py` (lines 1-13). No new imports needed.
+
+- [ ] **Step 1.4: Run the test and confirm it passes**
+
+```
+cd papermite/backend && uv run python -m pytest tests/test_mapper.py::test_map_extraction_all_placeholders_when_raw_is_empty -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 1.5: Run all existing mapper tests to confirm no regression**
+
+```
+cd papermite/backend && uv run python -m pytest tests/test_mapper.py -v
+```
+
+Expected: all pre-existing tests still pass (test_map_family, test_map_contact_guardian, test_map_contact_medical, test_map_no_guardian_entity_type, test_map_contact_custom_fields, test_student_selection_fields_are_single_select, test_program_multi_select_fields, test_consolidator_preserves_single_select_cardinality, test_extraction_result_has_no_raw_text_field) PLUS the new test.
+
+Note: pre-existing tests check entity counts for specific types (e.g., `test_map_family` asserts `len(family_entities) == 1` for FAMILY). The backstop adds placeholders for OTHER types, not duplicating FAMILY. So those filtered-by-type asserts remain green. If any pre-existing test asserts a total entity count (e.g., `len(result.entities) == 1`), it WILL break — but skim the existing tests first; they appear to filter by type, not count total. If a regression appears, STOP and report.
+
+- [ ] **Step 1.6: Commit**
+
+```
+git add papermite/backend/app/services/mapper.py papermite/backend/tests/test_mapper.py
+git commit -m "feat(papermite): mapper guarantees all ENTITY_CLASSES types in extraction output"
+```
+
+---
+
+### Task 2: Cover the only-tenant scenario
+
+**Files:**
+- Modify: `papermite/backend/tests/test_mapper.py` (append one test)
+
+- [ ] **Step 2.1: Append the test**
+
+Append to `/Users/kennylee/Development/NeoApex/papermite/backend/tests/test_mapper.py` (two blank lines before):
+
+```python
+
+
+def test_map_extraction_only_tenant_extracted_yields_7_placeholders():
+    """When AI extracts ONLY tenant, the other 7 entity types appear as placeholders."""
+    from app.models.domain import ENTITY_CLASSES
+
+    raw = RawExtraction(tenant={"name": "Acme School"})
+    result = map_extraction(raw, "t1", "f.pdf")
+
+    # 8 total: TENANT (extracted) + 7 placeholders
+    assert len(result.entities) == len(ENTITY_CLASSES)
+
+    # TENANT carries the extracted name
+    tenant = next(e for e in result.entities if e.entity_type == "TENANT")
+    name_mapping = next(m for m in tenant.field_mappings if m.field_name == "name")
+    assert name_mapping.value == "Acme School"
+    assert name_mapping.source == "base_model"
+
+    # Every other entity type has only base_model mappings with value=None
+    # (placeholders have no extracted values)
+    for e in result.entities:
+        if e.entity_type == "TENANT":
+            continue
+        for m in e.field_mappings:
+            assert m.source == "base_model", (
+                f"{e.entity_type}.{m.field_name} unexpectedly has source={m.source}"
+            )
+            # Non-selection placeholder values are None.
+            # Selection fields (List[str] with defaults) carry the default list as value.
+            if m.field_type != "selection":
+                assert m.value is None, (
+                    f"{e.entity_type}.{m.field_name} expected None, got {m.value!r}"
+                )
+```
+
+- [ ] **Step 2.2: Run the test and confirm it passes**
+
+(Backstop from Task 1 already handles this case — test should pass on first run.)
+
+```
+cd papermite/backend && uv run python -m pytest tests/test_mapper.py::test_map_extraction_only_tenant_extracted_yields_7_placeholders -v
+```
+
+Expected: PASS. If it fails, STOP — investigate before changing the test.
+
+- [ ] **Step 2.3: Commit**
+
+```
+git add papermite/backend/tests/test_mapper.py
+git commit -m "test(papermite): cover only-tenant extraction yields 7 placeholders"
+```
+
+---
+
+### Task 3: Cover multi-student consolidation + 7 placeholders
+
+**Files:**
+- Modify: `papermite/backend/tests/test_mapper.py`
+
+- [ ] **Step 3.1: Append the test**
+
+```python
+
+
+def test_map_extraction_multiple_students_consolidate_others_are_placeholders():
+    """Three extracted students consolidate to one STUDENT EntityResult;
+    7 other entity types appear as placeholders."""
+    from app.models.domain import ENTITY_CLASSES
+
+    raw = RawExtraction(students=[
+        {"first_name": "A"},
+        {"first_name": "B"},
+        {"first_name": "C"},
+    ])
+    result = map_extraction(raw, "t1", "f.pdf")
+
+    # Total = 8 (one per ENTITY_CLASSES key)
+    assert len(result.entities) == len(ENTITY_CLASSES)
+
+    # Exactly one STUDENT after consolidation
+    students = [e for e in result.entities if e.entity_type == "STUDENT"]
+    assert len(students) == 1
+
+    # first_name mapping exists with one of the three input values
+    # (consolidator keeps the first encountered)
+    student = students[0]
+    first_name_mappings = [m for m in student.field_mappings if m.field_name == "first_name"]
+    assert len(first_name_mappings) == 1
+    assert first_name_mappings[0].value in {"A", "B", "C"}
+
+    # The other 7 types are present and have no consolidated extracted data
+    # (they were never extracted — the backstop added them)
+    non_student_types = {k.upper() for k in ENTITY_CLASSES if k != "student"}
+    actual_non_student_types = {e.entity_type for e in result.entities if e.entity_type != "STUDENT"}
+    assert actual_non_student_types == non_student_types
+```
+
+- [ ] **Step 3.2: Run the test and confirm it passes**
+
+```
+cd papermite/backend && uv run python -m pytest tests/test_mapper.py::test_map_extraction_multiple_students_consolidate_others_are_placeholders -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 3.3: Commit**
+
+```
+git add papermite/backend/tests/test_mapper.py
+git commit -m "test(papermite): cover multi-student consolidation with placeholders for other types"
+```
+
+---
+
+### Task 4: Cover full base-field coverage on a placeholder
+
+**Files:**
+- Modify: `papermite/backend/tests/test_mapper.py`
+
+This task verifies the placeholder shape requirement: a placeholder STUDENT has ALL Student base fields, with `source="base_model"`, selection options carried through for `grade_level`/`gender`/`status`.
+
+- [ ] **Step 4.1: Append the test**
+
+```python
+
+
+def test_placeholder_student_has_full_base_field_coverage():
+    """Placeholder STUDENT entity contains all base fields from the Student Pydantic class."""
+    from app.models.domain import Student
+
+    raw = RawExtraction()
+    result = map_extraction(raw, "t1", "f.pdf")
+
+    student = next(e for e in result.entities if e.entity_type == "STUDENT")
+
+    # Every base field declared on Student (excluding system fields) appears in
+    # field_mappings exactly once. System fields are tenant_id, entity_type, custom_fields.
+    SYSTEM = {"tenant_id", "entity_type", "custom_fields"}
+    expected_fields = set(Student.model_fields.keys()) - SYSTEM
+    mapping_names = {m.field_name for m in student.field_mappings}
+    assert mapping_names == expected_fields
+
+    # All mappings are sourced from base_model (no custom fields in a placeholder)
+    for m in student.field_mappings:
+        assert m.source == "base_model"
+
+    # Selection-type Student fields carry non-empty options lists from the
+    # Pydantic class defaults
+    selection_field_names = {"grade_level", "gender", "status"}
+    for name in selection_field_names:
+        m = next(m for m in student.field_mappings if m.field_name == name)
+        assert m.field_type == "selection", f"{name} expected selection type, got {m.field_type}"
+        assert m.options, f"{name} expected non-empty options list, got {m.options}"
+```
+
+- [ ] **Step 4.2: Run and confirm pass**
+
+```
+cd papermite/backend && uv run python -m pytest tests/test_mapper.py::test_placeholder_student_has_full_base_field_coverage -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 4.3: Commit**
+
+```
+git add papermite/backend/tests/test_mapper.py
+git commit -m "test(papermite): assert placeholder STUDENT has full base-field coverage"
+```
+
+---
+
+### Task 5: Cover placeholder list-entity tenant_id and UUID id behavior
+
+**Files:**
+- Modify: `papermite/backend/tests/test_mapper.py`
+
+The placeholder list-entities (FAMILY, STUDENT, CONTACT, PROGRAM, ENROLLMENT, ATTENDANCE, REGISTRATION_APPLICATION) get their `<entity_type>_id` auto-filled with a UUID slice via `_map_entity_list`. TENANT does NOT — its `tenant_id` is set via `setdefault` before the UUID check.
+
+- [ ] **Step 5.1: Append both tests**
+
+```python
+
+
+def test_placeholder_list_entity_gets_tenant_id_and_uuid_id():
+    """A placeholder FAMILY has tenant_id == 't1' and an auto-generated family_id."""
+    raw = RawExtraction()
+    result = map_extraction(raw, "t1", "f.pdf")
+
+    family = next(e for e in result.entities if e.entity_type == "FAMILY")
+
+    assert family.entity["tenant_id"] == "t1"
+    # _map_entity_list generates an 8-character UUID slice when the id field
+    # is None on a list-type entity
+    family_id = family.entity.get("family_id")
+    assert isinstance(family_id, str)
+    assert len(family_id) == 8
+
+
+def test_placeholder_tenant_keeps_caller_provided_tenant_id():
+    """A placeholder TENANT keeps tenant_id='t1' — no UUID overwrite happens
+    because _map_entity_list's setdefault sets tenant_id before the UUID gate."""
+    raw = RawExtraction()  # raw.tenant is None
+    result = map_extraction(raw, "t1", "f.pdf")
+
+    tenant = next(e for e in result.entities if e.entity_type == "TENANT")
+
+    assert tenant.entity["tenant_id"] == "t1"
+    # Sanity: tenant_id is not an 8-char UUID slice
+    assert tenant.entity["tenant_id"] != "t1"[:8] or tenant.entity["tenant_id"] == "t1"
+    # Stronger: tenant_id is literally the caller-provided value
+    assert tenant.entity["tenant_id"] == "t1"
+```
+
+- [ ] **Step 5.2: Run both and confirm pass**
+
+```
+cd papermite/backend && uv run python -m pytest tests/test_mapper.py::test_placeholder_list_entity_gets_tenant_id_and_uuid_id tests/test_mapper.py::test_placeholder_tenant_keeps_caller_provided_tenant_id -v
+```
+
+Expected: 2 passed.
+
+- [ ] **Step 5.3: Commit**
+
+```
+git add papermite/backend/tests/test_mapper.py
+git commit -m "test(papermite): cover placeholder tenant_id and UUID id behavior"
+```
+
+---
+
+### Task 6: Cover the attendance-placeholder case
+
+**Files:**
+- Modify: `papermite/backend/tests/test_mapper.py`
+
+`ATTENDANCE` is the special case: `Attendance` is in `ENTITY_CLASSES` but has NO corresponding field on `RawExtraction` (no `raw.attendances`). The existing extraction logic NEVER produces an ATTENDANCE entity. The backstop is the only way it can appear.
+
+- [ ] **Step 6.1: Append the test**
+
+```python
+
+
+def test_placeholder_attendance_is_added_despite_no_raw_field():
+    """ATTENDANCE has no raw.attendances source field but still appears as
+    a placeholder thanks to the coverage backstop iterating ENTITY_CLASSES."""
+    from app.models.domain import Attendance
+
+    raw = RawExtraction()
+    result = map_extraction(raw, "t1", "f.pdf")
+
+    attendances = [e for e in result.entities if e.entity_type == "ATTENDANCE"]
+    assert len(attendances) == 1
+
+    att = attendances[0]
+    # Attendance base fields (excluding system fields) all appear
+    SYSTEM = {"tenant_id", "entity_type", "custom_fields"}
+    expected = set(Attendance.model_fields.keys()) - SYSTEM
+    actual = {m.field_name for m in att.field_mappings}
+    assert actual == expected
+
+    # tenant_id is the caller-provided value
+    assert att.entity["tenant_id"] == "t1"
+```
+
+- [ ] **Step 6.2: Run and confirm pass**
+
+```
+cd papermite/backend && uv run python -m pytest tests/test_mapper.py::test_placeholder_attendance_is_added_despite_no_raw_field -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 6.3: Commit**
+
+```
+git add papermite/backend/tests/test_mapper.py
+git commit -m "test(papermite): cover ATTENDANCE placeholder despite no raw extraction field"
+```
+
+---
+
+### Task 7: Integration test through `_build_model_definition`
+
+**Files:**
+- Create: `papermite/backend/tests/test_finalize_mapper_integration.py`
+
+The whole point of the change is that downstream consumers get a complete model definition. Verify that by piping an empty extraction through `mapper.map_extraction` and then through `finalize._build_model_definition`, the resulting dict has all 8 entity-type keys with non-empty `base_fields`.
+
+- [ ] **Step 7.1: Create the integration test file**
+
+Create `/Users/kennylee/Development/NeoApex/papermite/backend/tests/test_finalize_mapper_integration.py` with:
+
+```python
+"""Integration: mapper.map_extraction → finalize._build_model_definition.
+
+Verifies that the backstop in map_extraction propagates through to the
+model definition dict that gets written to DataCore — every entity type
+in ENTITY_CLASSES appears with non-empty base_fields, even when the
+source document had nothing to extract.
+"""
+from app.api.finalize import _build_model_definition
+from app.models.domain import ENTITY_CLASSES
+from app.models.extraction import RawExtraction
+from app.services.mapper import map_extraction
+
+
+def test_build_model_definition_includes_all_entity_types_for_empty_extraction():
+    raw = RawExtraction()
+    result = map_extraction(raw, "t1", "f.pdf")
+
+    model_def = _build_model_definition(result.entities)
+
+    # Every ENTITY_CLASSES key appears in the model definition
+    expected_keys = set(ENTITY_CLASSES.keys())
+    actual_keys = set(model_def.keys())
+    assert actual_keys == expected_keys
+
+    # Every entry has non-empty base_fields (each Pydantic class declares at
+    # least one base field beyond the system fields)
+    for entity_type, definition in model_def.items():
+        assert "base_fields" in definition, f"{entity_type} missing base_fields"
+        assert isinstance(definition["base_fields"], list)
+        assert len(definition["base_fields"]) > 0, (
+            f"{entity_type} has empty base_fields"
+        )
+        # custom_fields is always present (placeholders carry zero custom fields)
+        assert "custom_fields" in definition
+        assert definition["custom_fields"] == []
+```
+
+- [ ] **Step 7.2: Run and confirm pass**
+
+```
+cd papermite/backend && uv run python -m pytest tests/test_finalize_mapper_integration.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 7.3: Commit**
+
+```
+git add papermite/backend/tests/test_finalize_mapper_integration.py
+git commit -m "test(papermite): integration covers all 8 entity types in built model definition"
+```
+
+---
+
+### Task 8: Full-suite verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 8.1: Run the full Papermite backend test suite**
+
+```
+cd papermite/backend && uv run python -m pytest tests/ --ignore=tests/test_auth.py -v
+```
+
+The `--ignore=tests/test_auth.py` skips a pre-existing collection error unrelated to this change (`get_registry_store` was removed from `app.storage` in earlier work — not introduced by this branch). Verify this is still the same pre-existing failure by running:
+
+```
+git log -1 --oneline -- papermite/backend/tests/test_auth.py
+```
+
+The output's commit SHA should be on `main`, not the current branch.
+
+Expected: full suite (~92 tests including the new ones) passes. If anything fails, STOP and report.
+
+- [ ] **Step 8.2: No commit (verification step)**
+
+---
+
+### Task 9: Manual end-to-end smoke (optional)
+
+**Files:** none (manual verification)
+
+Skip in subagent-driven execution unless explicitly requested. If executed manually:
+
+- [ ] **Step 9.1:** `./start-services.sh`
+- [ ] **Step 9.2:** Upload a PDF with only tenant info via Papermite UI (http://localhost:5700). On the Review page, confirm all 8 entity cards appear: TENANT (populated), STUDENT/FAMILY/CONTACT/PROGRAM/ENROLLMENT/ATTENDANCE/REGISTRATION_APPLICATION (empty fields).
+- [ ] **Step 9.3:** Click Finalize → Confirm. Open Launchpad's Model section and confirm all 8 entity types are listed in the saved model.
+
+---
+
+## Final wrap-up
+
+After Task 8 passes (and optionally Task 9), the OpenSpec change `papermite-include-missing-default-entities` is ready for the archive step. Open a PR using the existing pattern (push branch → `gh pr create`). The plan does not handle PR creation or archive — that's the finishing-a-development-branch skill's job.
+
+**Reference:** the previous change (`papermite-persist-tenant-on-finalize`, merged as PR #74 with archive commit `cfd3a43`) used the same workflow shape.

--- a/openspec/changes/papermite-include-missing-default-entities/.openspec.yaml
+++ b/openspec/changes/papermite-include-missing-default-entities/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-20

--- a/openspec/changes/papermite-include-missing-default-entities/design.md
+++ b/openspec/changes/papermite-include-missing-default-entities/design.md
@@ -1,0 +1,103 @@
+## Context
+
+`mapper.map_extraction(raw, tenant_id, filename)` at `papermite/backend/app/services/mapper.py:267-299` builds the `ExtractionResult.entities` list. The current logic:
+
+```python
+if raw.tenant:
+    data, mappings = _map_entity(raw.tenant, ENTITY_CLASSES["tenant"])
+    data.setdefault("tenant_id", tenant_id)
+    entities.append(EntityResult(entity_type="TENANT", entity=data, field_mappings=mappings))
+
+entity_list_map = {"program": raw.programs, "student": raw.students, ...}
+for entity_type, raw_list in entity_list_map.items():
+    if raw_list:
+        entities.extend(_map_entity_list(raw_list, entity_type, ENTITY_CLASSES[entity_type], tenant_id))
+
+entities = _consolidate_entities(entities)
+```
+
+Two relevant existing behaviors:
+
+1. **`_map_entity({}, model_class)` returns a fully-populated placeholder.** When called with an empty raw dict, the iteration `for key, value in raw.items()` is a no-op, but the "ensure ALL base model fields appear" loop (mapper.py lines 159-200) then populates `base_data` with `None` and `field_mappings` with one entry per base model field (with `value=None`, `source="base_model"`, `required` derived from `Optional[]` annotations, type inferred from name). This is exactly the placeholder shape the user wants.
+
+2. **`_map_entity_list([{}], entity_type, model_class, tenant_id)` returns a single placeholder `EntityResult`.** It calls `_map_entity({}, model_class)` for the empty dict, then sets `tenant_id` and auto-generates a UUID for the `<entity_type>_id` field. One placeholder per empty input dict.
+
+Today's guards (`if raw.tenant`, `if raw_list:`) skip these calls when the AI returned nothing, producing the missing-entity bug.
+
+`_consolidate_entities` (mapper.py:230-264) merges multiple `EntityResult`s of the same type into one (union of field names, merged selection options). It is invoked after the extraction loop. Placeholders interact with it cleanly: a placeholder's field_mappings are a strict subset (just base fields) and would simply be the sole entry for its type when the AI extracted nothing.
+
+`ENTITY_CLASSES` (`papermite/backend/app/models/domain.py:165-173`) maps the 8 canonical entity types — `tenant`, `program`, `student`, `family`, `contact`, `enrollment`, `attendance`, `registration_application` — to their Pydantic classes. The mapper today builds `entity_list_map` with 6 of these and treats `tenant` separately. **`attendance` is currently missing from `entity_list_map`** — see Decision below.
+
+## Goals / Non-Goals
+
+**Goals:**
+- After this change, `mapper.map_extraction` returns an `entities` list containing exactly one `EntityResult` per entity type in `ENTITY_CLASSES`, every time.
+- The Papermite review UI shows every canonical entity type as a card the user can edit before finalize, with sensible default base fields.
+- Downstream consumers (`_build_model_definition`, Launchpad's `get_model`, admindash) see a complete model schema regardless of source-document content.
+
+**Non-Goals:**
+- No new entity types added to `ENTITY_CLASSES`. The set of "default" entities is exactly what the Pydantic schema declares today.
+- No change to `_build_model_definition` — it already iterates `extraction.entities` correctly.
+- No change to the review UI — empty-base-field entities already render today.
+- Not addressing the pre-existing inconsistency that `attendance` is in `ENTITY_CLASSES` but absent from `raw` extraction fields. This change uses `ENTITY_CLASSES` as the source of truth and includes `attendance` placeholders for consistency.
+- Not deduplicating against the user's intent — if AI extracts an entity AND a placeholder would have been added for the same type, the AI version wins (already true via the guard order).
+
+## Decisions
+
+### Decision: Drive coverage from `ENTITY_CLASSES`, not from `entity_list_map`
+
+The mapper currently has two sources of "what entity types matter":
+- `entity_list_map` in `map_extraction` — 6 list types.
+- `ENTITY_CLASSES` in `domain.py` — 8 types (includes `tenant` and `attendance`).
+
+After this change, the placeholder-coverage loop SHALL iterate `ENTITY_CLASSES.keys()` and produce a placeholder for every entry not already represented in `entities`. Rationale: `ENTITY_CLASSES` is the canonical source of truth for "what entity types exist in NeoApex." The `entity_list_map` is an implementation detail of how the AI's `RawExtraction` shape gets unpacked.
+
+**Implication:** `attendance` will get a placeholder card even though the existing extraction path never produces a real `ATTENDANCE` entity. The placeholder is harmless (one empty card, base fields only) and it makes the model definition canonical.
+
+### Decision: Add a single coverage backstop after consolidation; leave existing extraction guards in place
+
+Implementation shape — keep the current tenant singleton path and list loop unchanged. Add ONE new block immediately after `entities = _consolidate_entities(entities)`:
+
+```python
+# Coverage backstop: every entity type in ENTITY_CLASSES must be present.
+existing_types = {e.entity_type.lower() for e in entities}
+for entity_type, model_class in ENTITY_CLASSES.items():
+    if entity_type in existing_types:
+        continue
+    entities.extend(_map_entity_list([{}], entity_type, model_class, tenant_id))
+```
+
+**Why a single backstop, not three edit points:** `_map_entity_list([{}], entity_type, model_class, tenant_id)` produces the correct placeholder for every entity type, including TENANT. Internally:
+1. `_map_entity({}, model_class)` populates all base fields via the existing "ensure ALL base model fields appear" loop (mapper.py:159-200), yielding a `data` dict and `field_mappings` whose values are `None` (or Pydantic defaults for List[str] / Enum fields).
+2. `_map_entity_list` then sets `data.setdefault("tenant_id", tenant_id)` AND auto-generates a UUID for the `<entity_type>_id` field only when `data.get(id_field)` is falsy. For TENANT, `id_field == "tenant_id"` and `data["tenant_id"]` was just set in the line above — so the UUID step is skipped. For other entities (student, family, …), the `<entity_type>_id` field was populated as `None` by `_map_entity` and so the UUID step runs, producing a placeholder id consistent with how the existing list path already auto-generates ids for AI-extracted entities missing an id.
+3. The returned `EntityResult` has `entity_type=entity_type.upper()`, matching the casing of TENANT, STUDENT, etc.
+
+Net effect: placeholder TENANT carries `tenant_id` and no extra UUID; placeholder STUDENT/FAMILY/etc. carry `tenant_id` + a UUID `<entity_type>_id`. All identical to how `_map_entity_list` handles AI-extracted entities today.
+
+**Alternatives considered:**
+- *Change the existing tenant singleton guard (`if raw.tenant:`) and list-loop guard (`if raw_list:`) to provide empty defaults instead.* Three edit points doing what one backstop accomplishes. Rejected — minimum code.
+- *Add `attendance` to `entity_list_map` and a corresponding field to `RawExtraction`.* Out of scope — extraction-shape changes belong in a separate change.
+- *Only iterate `entity_list_map` for the backstop.* Misses `attendance` and any future addition to `ENTITY_CLASSES`. Rejected.
+
+### Decision: Placeholder UUID for list-entity ids is fine
+
+`_map_entity_list` auto-generates a UUID for the `<entity_type>_id` field when the entity has no id. For placeholders, the generated UUID is essentially throwaway data (model_definition cares only about field schema, not values). It does no harm and keeps the mapper code path uniform between real and placeholder entities.
+
+No special-case handling for placeholders — they look identical to "AI extracted an entity but provided no id" today.
+
+### Decision: TENANT is covered by the same backstop as every other type
+
+The `TENANT` entity SHALL appear in `entities` every time. When `raw.tenant` exists, today's singleton path (`if raw.tenant: ... _map_entity(raw.tenant, ENTITY_CLASSES["tenant"])`) handles it. When `raw.tenant` is missing, the backstop produces the placeholder via `_map_entity_list([{}], "tenant", Tenant, tenant_id)`. The placeholder's `tenant_id` is set to the caller-provided value (via `setdefault` before the UUID check), so no UUID overwrite happens — TENANT placeholders never have an auto-generated stub id.
+
+## Risks / Trade-offs
+
+- **`attendance` placeholder appears even though the existing AI flow never produces one** → A new empty card in the review UI for an entity the user may not need. Mitigation accepted: this matches the user's stated request ("model should still include the missing entity") and `attendance` is a real entity in NeoApex. If undesired in practice, a follow-up change can prune which entities get placeholders.
+- **One extra empty card per missing type could clutter the review UI** → Review UI is already designed to handle multiple entity cards; eight cards is the canonical NeoApex schema and a deliberate decision per the user's request. Mitigation: none required — this is the desired UX.
+- **Placeholder `<entity_type>_id` UUIDs go unused** → No observable effect; model_definition does not store entity values. Mitigation: none required.
+- **A future addition to `ENTITY_CLASSES` automatically gets a placeholder** → Intended behavior, since `ENTITY_CLASSES` is canonical. Anyone adding a new entity type can rely on the placeholder backstop.
+
+## Migration Plan
+
+- No data migration. The change affects only how `mapper.map_extraction` constructs its output. Previously-finalized model definitions in DataCore are unchanged; the next finalize after this change ships will produce a model that includes all 8 entity types.
+- No backward-incompatible API change. The `ExtractionResult` and `EntityResult` shapes are unchanged.
+- Rollback: revert the diff in `papermite/backend/app/services/mapper.py`. No other code or data to undo.

--- a/openspec/changes/papermite-include-missing-default-entities/proposal.md
+++ b/openspec/changes/papermite-include-missing-default-entities/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+When a user uploads a document to Papermite that the AI cannot extract some entity types from (e.g., a tenant-policy PDF with no student information), `mapper.map_extraction` omits those entity types entirely from `ExtractionResult.entities`. The resulting model definition stored at finalize then lacks those entities — a downstream consumer that expects the canonical NeoApex schema (Student, Family, Contact, …) gets a partial model and either fails or silently renders empty.
+
+The user's stated expectation: a model built from any document SHALL still include every canonical entity type, with default base fields populated from the Pydantic schema. Missing entities should appear in the Papermite review UI as empty cards the user can optionally fill in, not silently disappear.
+
+## What Changes
+
+- `mapper.map_extraction` SHALL produce exactly one `EntityResult` for every entity type in `app.models.domain.ENTITY_CLASSES` (tenant, student, family, contact, program, enrollment, attendance, registration_application) regardless of what the AI returned.
+- When the AI did not extract an entity type, the corresponding `EntityResult` SHALL be a "placeholder" with `entity` and `field_mappings` derived from the canonical Pydantic class (one mapping per base field, `value=None`, `source="base_model"`). This is the same shape produced today by the "ensure ALL base model fields appear" branch of `_map_entity` when AI extracts an entity but omits some fields.
+- For list-type entities (student, family, contact, program, enrollment, attendance, registration_application) the placeholder SHALL be exactly **one** `EntityResult` per missing entity type — not zero (today's behavior) and not many. When the AI list contains items, today's behavior is preserved (`_consolidate_entities` already collapses duplicates to one entity per type).
+- For the singleton `tenant` entity, the placeholder SHALL be produced when `raw.tenant` is missing, matching list-entity behavior.
+
+No UI changes. The Papermite review screen already renders entities with base fields of `value=None` (this happens today for any extracted entity whose AI output omits some base fields).
+
+## Capabilities
+
+### New Capabilities
+- `papermite-mapper-default-entity-coverage`: Behavior of `mapper.map_extraction` with respect to guaranteeing that every canonical entity type appears in the output, with a placeholder when the AI extracted nothing for that type.
+
+### Modified Capabilities
+<!-- None — no existing spec covers map_extraction's entity-coverage guarantees. -->
+
+## Impact
+
+- **Code touched**: `papermite/backend/app/services/mapper.py`, function `map_extraction` (lines ~267-299). Two guards (`if raw.tenant:` and `if raw_list:`) are replaced with always-call-mapper using empty defaults.
+- **Tests**: New tests in `papermite/backend/tests/test_mapper.py` covering: (a) all 8 entity types appear when AI returns nothing, (b) all 8 appear when AI returns only one entity type, (c) extracted entities still consolidate to one per type, (d) placeholder field_mappings shape matches the existing "ensure all base fields" output.
+- **Downstream effect on model definition**: `_build_model_definition` already iterates whatever is in `extraction.entities` and produces one entry per entity type. Once mapper guarantees full coverage, finalize's resulting model definition will include all 8 entity types automatically — no change to `_build_model_definition` needed.
+- **No frontend changes.** The review UI already handles entities with `value=None` field_mappings — placeholder entities will render as empty cards, identical to how a partially-extracted entity already looks.
+- **No DataCore, Launchpad, or admindash changes.**
+- **Backward-compatibility**: existing extractions that DID return entities are unaffected — they still flow through `_consolidate_entities` exactly as today. Only the missing-entity-type case behaves differently.

--- a/openspec/changes/papermite-include-missing-default-entities/specs/papermite-mapper-default-entity-coverage/spec.md
+++ b/openspec/changes/papermite-include-missing-default-entities/specs/papermite-mapper-default-entity-coverage/spec.md
@@ -1,0 +1,93 @@
+## ADDED Requirements
+
+### Requirement: map_extraction SHALL produce one EntityResult per entity type in ENTITY_CLASSES
+
+When `mapper.map_extraction` returns an `ExtractionResult`, the `entities` list SHALL contain exactly one `EntityResult` for every key in `app.models.domain.ENTITY_CLASSES`. The set of `EntityResult.entity_type` values (upper-cased) SHALL equal `{key.upper() for key in ENTITY_CLASSES}`. This guarantee SHALL hold regardless of which entity types the AI populated in `raw` — including when the AI returns `RawExtraction()` with all fields empty.
+
+Entity types that the AI extracted SHALL preserve today's behavior: they flow through `_map_entity` / `_map_entity_list` and are consolidated by `_consolidate_entities` to exactly one `EntityResult` per type. Entity types absent from `raw` SHALL be represented by a single placeholder `EntityResult` as described in the "Placeholder shape" requirement below.
+
+#### Scenario: AI returns nothing — all 8 placeholders present
+
+- **GIVEN** `raw = RawExtraction()` (every field empty / default)
+- **WHEN** `mapper.map_extraction(raw, tenant_id="t1", filename="f.pdf")` runs
+- **THEN** the returned `ExtractionResult.entities` SHALL contain exactly 8 entries
+- **AND** the set of `entity_type` values SHALL equal `{"TENANT", "PROGRAM", "STUDENT", "FAMILY", "CONTACT", "ENROLLMENT", "ATTENDANCE", "REGISTRATION_APPLICATION"}`
+
+#### Scenario: AI extracts only tenant — other 7 are placeholders
+
+- **GIVEN** `raw.tenant = {"name": "Acme"}` and every other `raw.<type>` is empty
+- **WHEN** `mapper.map_extraction(...)` runs
+- **THEN** `entities` SHALL contain 8 entries (one per `ENTITY_CLASSES` key)
+- **AND** the `TENANT` entity's `field_mappings` SHALL include a mapping with `field_name="name"` and `value="Acme"`
+- **AND** every other entity type SHALL have its `field_mappings` populated with base-model entries whose `value` is `None`
+
+#### Scenario: AI extracts multiple students — they consolidate to one STUDENT entity, others remain placeholders
+
+- **GIVEN** `raw.students = [{"first_name": "Sam"}, {"first_name": "Alex"}]` and every other `raw.<type>` is empty
+- **WHEN** `mapper.map_extraction(...)` runs
+- **THEN** `entities` SHALL contain 8 entries
+- **AND** exactly one entry SHALL have `entity_type == "STUDENT"` (consolidated)
+- **AND** the remaining 7 entries SHALL each correspond to one of the other `ENTITY_CLASSES` keys, with placeholder content
+
+### Requirement: Placeholder EntityResults SHALL carry full base-model field_mappings with value=None
+
+A placeholder `EntityResult` (one created for an entity type absent from `raw`) SHALL have its `field_mappings` populated identically to the output produced by calling `_map_entity({}, ENTITY_CLASSES[entity_type])` today. This SHALL mean: one `FieldMapping` per base field declared on the entity's Pydantic class (excluding the system fields `tenant_id`, `entity_type`, `custom_fields`), with `value=None` (or the Pydantic default for `List[str]` selection fields), `source="base_model"`, `required` derived from whether the field is `Optional[...]`, `field_type` inferred via `_infer_field_type`, and `options`/`multiple` set for selection-type fields.
+
+The placeholder's `entity` dict SHALL contain `tenant_id` set to the caller-provided `tenant_id`, and (for list-type entities) an auto-generated UUID for the `<entity_type>_id` field — identical to today's behavior when `_map_entity_list` processes an empty dict.
+
+#### Scenario: Placeholder STUDENT has all Student base fields with value=None
+
+- **GIVEN** `raw.students` is empty
+- **WHEN** `mapper.map_extraction(raw, tenant_id="t1", filename="f.pdf")` runs
+- **AND** the placeholder `STUDENT` `EntityResult` is located in the output
+- **THEN** every base field declared on `Student` (excluding `tenant_id`, `entity_type`, `custom_fields`) SHALL appear in the placeholder's `field_mappings`
+- **AND** each non-selection mapping's `value` SHALL be `None`
+- **AND** each mapping's `source` SHALL equal `"base_model"`
+- **AND** each selection-type mapping (e.g., `grade_level`, `gender`, `status`) SHALL carry its `options` list from the Pydantic field default
+
+#### Scenario: Placeholder list-entity gets tenant_id and a UUID id
+
+- **GIVEN** `raw.families` is empty and `tenant_id == "t1"`
+- **WHEN** `mapper.map_extraction(...)` runs
+- **AND** the placeholder `FAMILY` `EntityResult` is located
+- **THEN** the placeholder's `entity` dict SHALL contain `tenant_id == "t1"`
+- **AND** the placeholder's `entity` dict SHALL contain a non-empty `family_id` (auto-generated)
+
+#### Scenario: Placeholder TENANT does not get a UUID overwrite of tenant_id
+
+- **GIVEN** `raw.tenant` is `None`
+- **WHEN** `mapper.map_extraction(raw, tenant_id="t1", filename="f.pdf")` runs
+- **AND** the placeholder `TENANT` `EntityResult` is located
+- **THEN** the placeholder's `entity` dict SHALL contain `tenant_id == "t1"` (the caller-provided value)
+- **AND** the placeholder's `tenant_id` SHALL NOT be overwritten with an 8-character UUID slice (no other `<entity_type>_id` field exists for tenant — `tenant_id` is the entity id itself, and `_map_entity_list`'s UUID-generation step is gated on `not data.get(id_field)` which is False because `tenant_id` was set just above the gate)
+
+### Requirement: AI-extracted entities SHALL retain today's per-type consolidation behavior
+
+When the AI returns one or more entities of the same type, `mapper.map_extraction` SHALL invoke `_consolidate_entities` exactly as today, producing one `EntityResult` per extracted entity type. Placeholders SHALL only be added for types not produced by the consolidation step. Placeholders SHALL NOT be consolidated with extracted entities (the placeholder is added only when no extracted entity exists for that type).
+
+#### Scenario: Three extracted students consolidate into one STUDENT EntityResult; no placeholder added for STUDENT
+
+- **GIVEN** `raw.students = [{"first_name": "A"}, {"first_name": "B"}, {"first_name": "C"}]`
+- **WHEN** `mapper.map_extraction(...)` runs
+- **THEN** `entities` SHALL contain exactly one `EntityResult` with `entity_type == "STUDENT"`
+- **AND** that STUDENT's `field_mappings` SHALL be the consolidated union of the three input entities (per existing `_consolidate_entities` behavior)
+- **AND** no placeholder STUDENT SHALL be added
+
+### Requirement: Coverage backstop SHALL iterate ENTITY_CLASSES as the source of truth
+
+The placeholder-injection step SHALL iterate `ENTITY_CLASSES.items()` to determine which entity types are canonical. It SHALL NOT iterate `entity_list_map` alone. This guarantees that any entity type declared in `ENTITY_CLASSES` but not present in `entity_list_map` (currently `attendance`) still receives a placeholder.
+
+#### Scenario: Attendance placeholder is added even though raw has no attendances field
+
+- **GIVEN** `raw = RawExtraction()` (no `attendances` field exists on `RawExtraction`)
+- **WHEN** `mapper.map_extraction(...)` runs
+- **THEN** `entities` SHALL contain exactly one `EntityResult` with `entity_type == "ATTENDANCE"`
+- **AND** that ATTENDANCE entity SHALL be a placeholder with base-model field_mappings (per the "Placeholder shape" requirement)
+
+#### Scenario: Future entity added to ENTITY_CLASSES automatically gets coverage
+
+- **GIVEN** a hypothetical future entity type `FOO` is added to `ENTITY_CLASSES` but not to `entity_list_map` or `RawExtraction`
+- **WHEN** `mapper.map_extraction(...)` runs
+- **THEN** `entities` SHALL contain a placeholder `EntityResult` with `entity_type == "FOO"`
+
+This scenario is for documentation only — it does not require a test. The backstop's loop over `ENTITY_CLASSES.items()` provides this guarantee by construction.

--- a/openspec/changes/papermite-include-missing-default-entities/tasks.md
+++ b/openspec/changes/papermite-include-missing-default-entities/tasks.md
@@ -1,0 +1,23 @@
+## 1. Modify `map_extraction` in mapper
+
+- [ ] 1.1 In `papermite/backend/app/services/mapper.py`, leave the existing tenant singleton block (lines ~271-275) and list loop (lines ~277-290) untouched. Immediately AFTER the existing `entities = _consolidate_entities(entities)` line (line ~293), add a coverage-backstop loop: compute `existing_types = {e.entity_type.lower() for e in entities}`; iterate `ENTITY_CLASSES.items()`; for each `(entity_type, model_class)` not in `existing_types`, call `_map_entity_list([{}], entity_type, model_class, tenant_id)` and extend `entities` with the result. The backstop uses `_map_entity_list` uniformly for every missing type — including `tenant`, where the existing `data.setdefault("tenant_id", tenant_id)` inside `_map_entity_list` ensures no UUID overwrite happens.
+
+## 2. Unit tests in `papermite/backend/tests/test_mapper.py`
+
+- [ ] 2.1 Add `test_map_extraction_all_placeholders_when_raw_is_empty`: pass `RawExtraction()` with every field at default; assert `len(result.entities) == 8` and the set of `entity_type` values equals `{"TENANT", "PROGRAM", "STUDENT", "FAMILY", "CONTACT", "ENROLLMENT", "ATTENDANCE", "REGISTRATION_APPLICATION"}`.
+- [ ] 2.2 Add `test_map_extraction_only_tenant_extracted_yields_7_placeholders`: pass `RawExtraction(tenant={"name": "Acme"})`; assert 8 entities total, TENANT has a `name` field with `value="Acme"`, and each of the other 7 has all `value=None` on its field_mappings (no extracted values).
+- [ ] 2.3 Add `test_map_extraction_extracted_students_consolidate_no_student_placeholder`: pass `RawExtraction(students=[{"first_name": "A"}, {"first_name": "B"}, {"first_name": "C"}])`; assert exactly one STUDENT entity exists, its field_mappings reflect consolidation (one mapping per unique field name across the three inputs), and 7 placeholders exist for the other entity types.
+- [ ] 2.4 Add `test_placeholder_student_has_full_base_field_coverage`: pass empty `RawExtraction`; locate the STUDENT placeholder; assert every base field in `Student.model_fields` (excluding `tenant_id`, `entity_type`, `custom_fields`) appears in `field_mappings` with `source="base_model"`; assert selection fields (`grade_level`, `gender`, `status`) have non-empty `options` lists from the Pydantic defaults.
+- [ ] 2.5 Add `test_placeholder_list_entity_gets_tenant_id_and_uuid_id`: pass empty `RawExtraction`; locate the FAMILY placeholder; assert `entity["tenant_id"] == "t1"` and `entity["family_id"]` is a non-empty string (UUID slice from `_map_entity_list`).
+- [ ] 2.6 Add `test_placeholder_tenant_keeps_caller_provided_tenant_id`: pass empty `RawExtraction` (no `raw.tenant`); locate the TENANT placeholder; assert `entity["tenant_id"] == "t1"` (the caller-provided value, not an 8-char UUID slice). Verify by checking `len(entity["tenant_id"]) != 8` or directly `entity["tenant_id"] == "t1"`.
+- [ ] 2.7 Add `test_placeholder_attendance_is_added_despite_no_raw_field`: pass empty `RawExtraction`; assert exactly one ATTENDANCE EntityResult exists and its field_mappings include `student_id`, `date`, `program_id`, `class_id`, `status` (the `Attendance` base fields).
+
+## 3. Integration check via `_build_model_definition`
+
+- [ ] 3.1 Add `test_build_model_definition_includes_all_entity_types_for_empty_extraction`: construct an `ExtractionResult` via `mapper.map_extraction(RawExtraction(), "t1", "f.pdf")`; pass `result.entities` to `_build_model_definition` (in `app/api/finalize.py`); assert the returned dict has keys for all 8 entity types (`tenant`, `student`, `family`, `contact`, `program`, `enrollment`, `attendance`, `registration_application`) and each value has non-empty `base_fields`.
+
+## 4. Verify
+
+- [ ] 4.1 Run `cd papermite/backend && uv run python -m pytest tests/test_mapper.py -v` and confirm all new tests pass alongside pre-existing mapper tests.
+- [ ] 4.2 Run the full Papermite backend suite (`cd papermite/backend && uv run python -m pytest tests/ --ignore=tests/test_auth.py -v`) and confirm no regressions. (The `test_auth.py` ignore is for a pre-existing unrelated import error.)
+- [ ] 4.3 Manually verify in dev: start services via `./start-services.sh`; upload a document that contains only tenant info via Papermite; on the Review screen confirm that all 8 entity cards appear, with the TENANT card carrying extracted values and the other 7 showing empty fields ready for the user to edit.

--- a/papermite/backend/app/services/mapper.py
+++ b/papermite/backend/app/services/mapper.py
@@ -292,6 +292,17 @@ def map_extraction(raw: RawExtraction, tenant_id: str, filename: str) -> Extract
     # Consolidate multiple entities of the same type into one
     entities = _consolidate_entities(entities)
 
+    # Coverage backstop: every entity type in ENTITY_CLASSES must be present.
+    # When the AI did not extract a type, add a placeholder EntityResult with
+    # full base-field coverage so downstream model definitions stay canonical.
+    existing_types = {e.entity_type.lower() for e in entities}
+    for entity_type, model_class in ENTITY_CLASSES.items():
+        if entity_type in existing_types:
+            continue
+        entities.extend(
+            _map_entity_list([{}], entity_type, model_class, tenant_id)
+        )
+
     return ExtractionResult(
         tenant_id=tenant_id,
         filename=filename,

--- a/papermite/backend/tests/test_finalize_mapper_integration.py
+++ b/papermite/backend/tests/test_finalize_mapper_integration.py
@@ -1,0 +1,35 @@
+"""Integration: mapper.map_extraction → finalize._build_model_definition.
+
+Verifies that the backstop in map_extraction propagates through to the
+model definition dict that gets written to DataCore — every entity type
+in ENTITY_CLASSES appears with non-empty base_fields, even when the
+source document had nothing to extract.
+"""
+from app.api.finalize import _build_model_definition
+from app.models.domain import ENTITY_CLASSES
+from app.models.extraction import RawExtraction
+from app.services.mapper import map_extraction
+
+
+def test_build_model_definition_includes_all_entity_types_for_empty_extraction():
+    raw = RawExtraction()
+    result = map_extraction(raw, "t1", "f.pdf")
+
+    model_def = _build_model_definition(result.entities)
+
+    # Every ENTITY_CLASSES key appears in the model definition
+    expected_keys = set(ENTITY_CLASSES.keys())
+    actual_keys = set(model_def.keys())
+    assert actual_keys == expected_keys
+
+    # Every entry has non-empty base_fields (each Pydantic class declares at
+    # least one base field beyond the system fields)
+    for entity_type, definition in model_def.items():
+        assert "base_fields" in definition, f"{entity_type} missing base_fields"
+        assert isinstance(definition["base_fields"], list)
+        assert len(definition["base_fields"]) > 0, (
+            f"{entity_type} has empty base_fields"
+        )
+        # custom_fields is always present (placeholders carry zero custom fields)
+        assert "custom_fields" in definition
+        assert definition["custom_fields"] == []

--- a/papermite/backend/tests/test_mapper.py
+++ b/papermite/backend/tests/test_mapper.py
@@ -273,3 +273,33 @@ def test_placeholder_student_has_full_base_field_coverage():
         m = next(m for m in student.field_mappings if m.field_name == name)
         assert m.field_type == "selection", f"{name} expected selection type, got {m.field_type}"
         assert m.options, f"{name} expected non-empty options list, got {m.options}"
+
+
+def test_placeholder_list_entity_gets_tenant_id_and_uuid_id():
+    """A placeholder FAMILY has tenant_id == 't1' and an auto-generated family_id."""
+    raw = RawExtraction()
+    result = map_extraction(raw, "t1", "f.pdf")
+
+    family = next(e for e in result.entities if e.entity_type == "FAMILY")
+
+    assert family.entity["tenant_id"] == "t1"
+    # _map_entity_list generates an 8-character UUID slice when the id field
+    # is None on a list-type entity
+    family_id = family.entity.get("family_id")
+    assert isinstance(family_id, str)
+    assert len(family_id) == 8
+
+
+def test_placeholder_tenant_keeps_caller_provided_tenant_id():
+    """A placeholder TENANT keeps tenant_id='t1' — no UUID overwrite happens
+    because _map_entity_list's setdefault sets tenant_id before the UUID gate."""
+    raw = RawExtraction()  # raw.tenant is None
+    result = map_extraction(raw, "t1", "f.pdf")
+
+    tenant = next(e for e in result.entities if e.entity_type == "TENANT")
+
+    assert tenant.entity["tenant_id"] == "t1"
+    # Sanity: tenant_id is not an 8-char UUID slice
+    assert tenant.entity["tenant_id"] != "t1"[:8] or tenant.entity["tenant_id"] == "t1"
+    # Stronger: tenant_id is literally the caller-provided value
+    assert tenant.entity["tenant_id"] == "t1"

--- a/papermite/backend/tests/test_mapper.py
+++ b/papermite/backend/tests/test_mapper.py
@@ -165,3 +165,16 @@ def test_extraction_result_has_no_raw_text_field():
     """raw_text was removed in the extract-pipeline consolidation."""
     from app.models.extraction import ExtractionResult
     assert "raw_text" not in ExtractionResult.model_fields
+
+
+def test_map_extraction_all_placeholders_when_raw_is_empty():
+    """With nothing extracted, every entity type in ENTITY_CLASSES must appear."""
+    from app.models.domain import ENTITY_CLASSES
+
+    raw = RawExtraction()
+    result = map_extraction(raw, "t1", "f.pdf")
+
+    types = {e.entity_type for e in result.entities}
+    expected = {k.upper() for k in ENTITY_CLASSES}
+    assert types == expected
+    assert len(result.entities) == len(ENTITY_CLASSES)

--- a/papermite/backend/tests/test_mapper.py
+++ b/papermite/backend/tests/test_mapper.py
@@ -303,3 +303,25 @@ def test_placeholder_tenant_keeps_caller_provided_tenant_id():
     assert tenant.entity["tenant_id"] != "t1"[:8] or tenant.entity["tenant_id"] == "t1"
     # Stronger: tenant_id is literally the caller-provided value
     assert tenant.entity["tenant_id"] == "t1"
+
+
+def test_placeholder_attendance_is_added_despite_no_raw_field():
+    """ATTENDANCE has no raw.attendances source field but still appears as
+    a placeholder thanks to the coverage backstop iterating ENTITY_CLASSES."""
+    from app.models.domain import Attendance
+
+    raw = RawExtraction()
+    result = map_extraction(raw, "t1", "f.pdf")
+
+    attendances = [e for e in result.entities if e.entity_type == "ATTENDANCE"]
+    assert len(attendances) == 1
+
+    att = attendances[0]
+    # Attendance base fields (excluding system fields) all appear
+    SYSTEM = {"tenant_id", "entity_type", "custom_fields"}
+    expected = set(Attendance.model_fields.keys()) - SYSTEM
+    actual = {m.field_name for m in att.field_mappings}
+    assert actual == expected
+
+    # tenant_id is the caller-provided value
+    assert att.entity["tenant_id"] == "t1"

--- a/papermite/backend/tests/test_mapper.py
+++ b/papermite/backend/tests/test_mapper.py
@@ -244,3 +244,32 @@ def test_map_extraction_multiple_students_consolidate_others_are_placeholders():
     non_student_types = {k.upper() for k in ENTITY_CLASSES if k != "student"}
     actual_non_student_types = {e.entity_type for e in result.entities if e.entity_type != "STUDENT"}
     assert actual_non_student_types == non_student_types
+
+
+def test_placeholder_student_has_full_base_field_coverage():
+    """Placeholder STUDENT entity contains all base fields from the Student Pydantic class."""
+    from app.models.domain import Student
+
+    raw = RawExtraction()
+    result = map_extraction(raw, "t1", "f.pdf")
+
+    student = next(e for e in result.entities if e.entity_type == "STUDENT")
+
+    # Every base field declared on Student (excluding system fields) appears in
+    # field_mappings exactly once. System fields are tenant_id, entity_type, custom_fields.
+    SYSTEM = {"tenant_id", "entity_type", "custom_fields"}
+    expected_fields = set(Student.model_fields.keys()) - SYSTEM
+    mapping_names = {m.field_name for m in student.field_mappings}
+    assert mapping_names == expected_fields
+
+    # All mappings are sourced from base_model (no custom fields in a placeholder)
+    for m in student.field_mappings:
+        assert m.source == "base_model"
+
+    # Selection-type Student fields carry non-empty options lists from the
+    # Pydantic class defaults
+    selection_field_names = {"grade_level", "gender", "status"}
+    for name in selection_field_names:
+        m = next(m for m in student.field_mappings if m.field_name == name)
+        assert m.field_type == "selection", f"{name} expected selection type, got {m.field_type}"
+        assert m.options, f"{name} expected non-empty options list, got {m.options}"

--- a/papermite/backend/tests/test_mapper.py
+++ b/papermite/backend/tests/test_mapper.py
@@ -178,3 +178,36 @@ def test_map_extraction_all_placeholders_when_raw_is_empty():
     expected = {k.upper() for k in ENTITY_CLASSES}
     assert types == expected
     assert len(result.entities) == len(ENTITY_CLASSES)
+
+
+def test_map_extraction_only_tenant_extracted_yields_7_placeholders():
+    """When AI extracts ONLY tenant, the other 7 entity types appear as placeholders."""
+    from app.models.domain import ENTITY_CLASSES
+
+    raw = RawExtraction(tenant={"name": "Acme School"})
+    result = map_extraction(raw, "t1", "f.pdf")
+
+    # 8 total: TENANT (extracted) + 7 placeholders
+    assert len(result.entities) == len(ENTITY_CLASSES)
+
+    # TENANT carries the extracted name
+    tenant = next(e for e in result.entities if e.entity_type == "TENANT")
+    name_mapping = next(m for m in tenant.field_mappings if m.field_name == "name")
+    assert name_mapping.value == "Acme School"
+    assert name_mapping.source == "base_model"
+
+    # Every other entity type has only base_model mappings with value=None
+    # (placeholders have no extracted values)
+    for e in result.entities:
+        if e.entity_type == "TENANT":
+            continue
+        for m in e.field_mappings:
+            assert m.source == "base_model", (
+                f"{e.entity_type}.{m.field_name} unexpectedly has source={m.source}"
+            )
+            # Non-selection placeholder values are None.
+            # Selection fields (List[str] with defaults) carry the default list as value.
+            if m.field_type != "selection":
+                assert m.value is None, (
+                    f"{e.entity_type}.{m.field_name} expected None, got {m.value!r}"
+                )

--- a/papermite/backend/tests/test_mapper.py
+++ b/papermite/backend/tests/test_mapper.py
@@ -211,3 +211,36 @@ def test_map_extraction_only_tenant_extracted_yields_7_placeholders():
                 assert m.value is None, (
                     f"{e.entity_type}.{m.field_name} expected None, got {m.value!r}"
                 )
+
+
+def test_map_extraction_multiple_students_consolidate_others_are_placeholders():
+    """Three extracted students consolidate to one STUDENT EntityResult;
+    7 other entity types appear as placeholders."""
+    from app.models.domain import ENTITY_CLASSES
+
+    raw = RawExtraction(students=[
+        {"first_name": "A"},
+        {"first_name": "B"},
+        {"first_name": "C"},
+    ])
+    result = map_extraction(raw, "t1", "f.pdf")
+
+    # Total = 8 (one per ENTITY_CLASSES key)
+    assert len(result.entities) == len(ENTITY_CLASSES)
+
+    # Exactly one STUDENT after consolidation
+    students = [e for e in result.entities if e.entity_type == "STUDENT"]
+    assert len(students) == 1
+
+    # first_name mapping exists with one of the three input values
+    # (consolidator keeps the first encountered)
+    student = students[0]
+    first_name_mappings = [m for m in student.field_mappings if m.field_name == "first_name"]
+    assert len(first_name_mappings) == 1
+    assert first_name_mappings[0].value in {"A", "B", "C"}
+
+    # The other 7 types are present and have no consolidated extracted data
+    # (they were never extracted — the backstop added them)
+    non_student_types = {k.upper() for k in ENTITY_CLASSES if k != "student"}
+    actual_non_student_types = {e.entity_type for e in result.entities if e.entity_type != "STUDENT"}
+    assert actual_non_student_types == non_student_types


### PR DESCRIPTION
## Summary

Bug: `mapper.map_extraction` dropped entity types the AI didn't extract — a document with only tenant info produced a model definition that omitted STUDENT, FAMILY, CONTACT, etc. entirely, breaking downstream consumers that expect the canonical NeoApex schema.

**Fix:** Added a single coverage backstop in `papermite/backend/app/services/mapper.py` after `_consolidate_entities`. The backstop iterates `ENTITY_CLASSES.items()` and adds a placeholder `EntityResult` via `_map_entity_list([{}], …)` for any entity type not already present. Placeholders carry full base-field coverage (from the Pydantic class) with `value=None`, `source="base_model"`, and selection options from defaults — exactly the shape `_map_entity` already produces today when AI extracts an entity but omits some fields.

**Behavior:**
- Empty extraction → 8 placeholder entities (one per ENTITY_CLASSES key)
- Partial extraction (e.g., only tenant) → extracted TENANT + 7 placeholders
- Multi-entity extraction (e.g., 3 students) → consolidated to 1 STUDENT + 7 placeholders for other types
- TENANT placeholder keeps caller-provided `tenant_id` (no UUID overwrite, because `_map_entity_list` sets `tenant_id` via `setdefault` before its UUID gate)
- List-entity placeholders get a UUID `<entity_type>_id` (consistent with how `_map_entity_list` already handles AI-extracted entities missing an id)
- `ATTENDANCE` placeholder appears even though `RawExtraction` has no `attendances` field — the backstop's iteration over `ENTITY_CLASSES` is the source of truth, not `entity_list_map`

## Test Plan

- [x] 7 new tests in `papermite/backend/tests/test_mapper.py` covering: all-8-placeholders case, only-tenant case, multi-student consolidation + 7 placeholders, full-base-field coverage on a placeholder, list-entity UUID id behavior, TENANT-keeps-tenant_id behavior, ATTENDANCE placeholder despite no raw field
- [x] 1 new integration test in `papermite/backend/tests/test_finalize_mapper_integration.py` verifies that piping `RawExtraction()` through `mapper.map_extraction` → `finalize._build_model_definition` produces a dict with all 8 entity-type keys, each with non-empty `base_fields`
- [x] Full Papermite backend suite passes (93/93 excluding pre-existing unrelated `test_auth.py` `ImportError`)
- [ ] Manual E2E: upload a doc with only tenant info → on Review screen confirm all 8 entity cards appear (TENANT populated, others empty); finalize and verify saved model definition includes all 8 entity types

## Artifacts

- OpenSpec change: `openspec/changes/papermite-include-missing-default-entities/`
- Implementation plan: `docs/superpowers/plans/2026-05-20-papermite-include-missing-default-entities.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)