### PR TITLE
feat: per-field default values (Papermite → AdminDash prefill) — closes #70

### DIFF
--- a/admindash/frontend/src/components/DynamicForm.tsx
+++ b/admindash/frontend/src/components/DynamicForm.tsx
@@ -192,7 +192,21 @@ export default function DynamicForm({
   const buildValues = (overrides?: Record<string, unknown>) => {
     const result: Record<string, unknown> = {};
     for (const field of allFields) {
-      result[field.name] = overrides?.[field.name] ?? (field.type === 'bool' ? false : '');
+      const override = overrides?.[field.name];
+      const fallback = field.type === 'bool' ? false : '';
+      let resolved: unknown;
+      if (override !== undefined) {
+        resolved = override;
+      } else if (field.default !== undefined) {
+        resolved = field.default;
+      } else {
+        resolved = fallback;
+      }
+      if (field.type === 'number' && resolved !== '' && resolved !== null && resolved !== undefined) {
+        const coerced = Number(resolved);
+        resolved = Number.isNaN(coerced) ? '' : coerced;
+      }
+      result[field.name] = resolved;
     }
     return result;
   };

--- a/admindash/frontend/src/types/models.ts
+++ b/admindash/frontend/src/types/models.ts
@@ -47,6 +47,7 @@ export interface ModelFieldDefinition {
   required: boolean;
   options?: string[];
   multiple?: boolean;
+  default?: unknown;
 }
 
 export interface ModelDefinition {

--- a/docs/superpowers/plans/2026-05-26-field-default-values.md
+++ b/docs/superpowers/plans/2026-05-26-field-default-values.md
@@ -1,0 +1,1605 @@
+# Field Default Values Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let Papermite tenant admins set a per-field default value in the form builder, persist it in the stored model definition, and prefill it into AdminDash's Add Entity form (still editable).
+
+**Architecture:**
+1. Papermite backend adds `default: Optional[Any] = None` to `FieldMapping`; `_build_model_definition` writes the key only when non-`None` (never `null`).
+2. Papermite frontend adds `default?: unknown` to `FieldMapping`/`FieldDefinition`, renders a new "Default" cell in `FieldRow` between Value and Data Type, wires `handleDefaultChange` in `EntityCard`, clears `default` on type or `multiple` change, adds an optional Default input to `AddFieldForm`, and rehydrates `default` in `modelToExtraction` on edit.
+3. AdminDash frontend adds `default?: unknown` to `ModelFieldDefinition` and prefills it in `DynamicForm.buildValues` (`overrides ?? default ?? empty`); the `number` type runs the prefill through `Number(...)` to avoid submitting strings.
+4. DataCore is unchanged — model definitions are opaque JSON; `normalize`-then-compare round-trips defaults; omitting `default` for fields with no default keeps byte-equality with pre-feature models.
+
+**Tech Stack:** Python 3.13 + FastAPI + Pydantic + pytest (papermite/admindash backends); React 19 + TypeScript + Vite + vitest + @testing-library/react (papermite frontend); React 19 + TypeScript + Vite, no test framework (admindash frontend).
+
+**Spec source:** `openspec/changes/field-default-values/{proposal,design,tasks}.md` + `specs/field-default-values/spec.md`.
+
+---
+
+## Branch setup
+
+- [ ] **Step 0.1: Create feature branch off main**
+
+```bash
+cd /Users/kennylee/Development/NeoApex
+git checkout main
+git pull origin main
+git checkout -b feat/field-default-values
+```
+
+---
+
+## Task 1: Papermite backend — `FieldMapping.default` Pydantic field
+
+**Files:**
+- Modify: `papermite/backend/app/models/extraction.py:20-27`
+
+- [ ] **Step 1.1: Add `default` to `FieldMapping`**
+
+Edit `papermite/backend/app/models/extraction.py`. The current `FieldMapping` class (lines 20–27) is:
+
+```python
+class FieldMapping(BaseModel):
+    field_name: str
+    value: Any
+    source: Literal["base_model", "custom_field"]
+    required: bool = True
+    field_type: Literal["str", "number", "bool", "date", "datetime", "email", "phone", "selection"] = "str"
+    options: Optional[list[str]] = None
+    multiple: Optional[bool] = None
+```
+
+Change to:
+
+```python
+class FieldMapping(BaseModel):
+    field_name: str
+    value: Any
+    source: Literal["base_model", "custom_field"]
+    required: bool = True
+    field_type: Literal["str", "number", "bool", "date", "datetime", "email", "phone", "selection"] = "str"
+    options: Optional[list[str]] = None
+    multiple: Optional[bool] = None
+    default: Optional[Any] = None
+```
+
+- [ ] **Step 1.2: Verify Pydantic still parses existing payloads**
+
+```bash
+cd /Users/kennylee/Development/NeoApex
+uv run --project papermite python -c "
+from app.models.extraction import FieldMapping
+m1 = FieldMapping(field_name='age', value=10, source='base_model', required=True, field_type='number')
+assert m1.default is None
+m2 = FieldMapping(field_name='age', value=10, source='base_model', required=True, field_type='number', default=9)
+assert m2.default == 9
+print('ok')
+" 2>&1 | tail -5
+```
+
+Run from `papermite/backend/`:
+
+```bash
+cd /Users/kennylee/Development/NeoApex/papermite/backend
+uv run python -c "
+from app.models.extraction import FieldMapping
+m1 = FieldMapping(field_name='age', value=10, source='base_model', required=True, field_type='number')
+assert m1.default is None
+m2 = FieldMapping(field_name='age', value=10, source='base_model', required=True, field_type='number', default=9)
+assert m2.default == 9
+print('ok')
+"
+```
+
+Expected: `ok`.
+
+- [ ] **Step 1.3: Commit**
+
+```bash
+cd /Users/kennylee/Development/NeoApex
+git add papermite/backend/app/models/extraction.py
+git commit -m "feat(papermite): add optional default to FieldMapping"
+```
+
+---
+
+## Task 2: Papermite backend — `_build_model_definition` writes `default`
+
+**Files:**
+- Modify: `papermite/backend/app/api/finalize.py:178-224` (`_build_model_definition`)
+- Test: `papermite/backend/tests/test_finalize_helpers.py` (append)
+
+- [ ] **Step 2.1: Add failing tests to `test_finalize_helpers.py`**
+
+Append these tests to the end of `papermite/backend/tests/test_finalize_helpers.py`:
+
+```python
+def test_build_model_definition_omits_default_when_none():
+    """A field with default=None must NOT emit 'default' (not even as null)."""
+    from app.api.finalize import _build_model_definition
+    from app.models.extraction import EntityResult, FieldMapping
+
+    entity = EntityResult(
+        entity_type="student",
+        entity={"first_name": "Sam"},
+        field_mappings=[
+            FieldMapping(
+                field_name="first_name", value="Sam",
+                source="base_model", required=True, field_type="str",
+            ),
+        ],
+    )
+    md = _build_model_definition([entity])
+    field = md["student"]["base_fields"][0]
+    assert "default" not in field
+    assert field == {"name": "first_name", "type": "str", "required": True}
+
+
+def test_build_model_definition_includes_default_when_set():
+    """A field with a non-None default emits 'default'."""
+    from app.api.finalize import _build_model_definition
+    from app.models.extraction import EntityResult, FieldMapping
+
+    entity = EntityResult(
+        entity_type="student",
+        entity={"school_year": "2026-2027"},
+        field_mappings=[
+            FieldMapping(
+                field_name="school_year", value="2026-2027",
+                source="custom_field", required=False, field_type="str",
+                default="2026-2027",
+            ),
+        ],
+    )
+    md = _build_model_definition([entity])
+    field = md["student"]["custom_fields"][0]
+    assert field == {
+        "name": "school_year",
+        "type": "str",
+        "required": False,
+        "default": "2026-2027",
+    }
+
+
+def test_build_model_definition_preserves_bool_false_default():
+    """default=False is a meaningful value and MUST be persisted."""
+    from app.api.finalize import _build_model_definition
+    from app.models.extraction import EntityResult, FieldMapping
+
+    entity = EntityResult(
+        entity_type="student",
+        entity={"is_active": False},
+        field_mappings=[
+            FieldMapping(
+                field_name="is_active", value=True,
+                source="custom_field", required=False, field_type="bool",
+                default=False,
+            ),
+        ],
+    )
+    md = _build_model_definition([entity])
+    field = md["student"]["custom_fields"][0]
+    assert field["default"] is False
+
+
+def test_build_model_definition_preserves_selection_multi_default():
+    """Selection (multi) default preserved verbatim alongside options/multiple."""
+    from app.api.finalize import _build_model_definition
+    from app.models.extraction import EntityResult, FieldMapping
+
+    entity = EntityResult(
+        entity_type="student",
+        entity={"subjects": ["math"]},
+        field_mappings=[
+            FieldMapping(
+                field_name="subjects", value=["math"],
+                source="custom_field", required=False, field_type="selection",
+                options=["math", "science", "history"], multiple=True,
+                default=["math"],
+            ),
+        ],
+    )
+    md = _build_model_definition([entity])
+    field = md["student"]["custom_fields"][0]
+    assert field == {
+        "name": "subjects",
+        "type": "selection",
+        "required": False,
+        "options": ["math", "science", "history"],
+        "multiple": True,
+        "default": ["math"],
+    }
+```
+
+- [ ] **Step 2.2: Run tests, confirm they fail**
+
+```bash
+cd /Users/kennylee/Development/NeoApex/papermite/backend
+uv run pytest tests/test_finalize_helpers.py::test_build_model_definition_omits_default_when_none tests/test_finalize_helpers.py::test_build_model_definition_includes_default_when_set tests/test_finalize_helpers.py::test_build_model_definition_preserves_bool_false_default tests/test_finalize_helpers.py::test_build_model_definition_preserves_selection_multi_default -v
+```
+
+Expected: 4 FAILED — fields are missing the `default` key.
+
+- [ ] **Step 2.3: Update `_build_model_definition`**
+
+Edit `papermite/backend/app/api/finalize.py`. Locate the `field_def` block inside the per-mapping loop (around lines 193–202):
+
+```python
+        for mapping in entity_result.field_mappings:
+            field_type = mapping.field_type if mapping.field_type != "str" else _infer_type(mapping.value)
+            field_def: dict = {
+                "name": mapping.field_name,
+                "type": field_type,
+                "required": mapping.required,
+            }
+            if field_type == "selection":
+                field_def["options"] = mapping.options or []
+                field_def["multiple"] = mapping.multiple or False
+```
+
+Add a `default` clause **after** the selection block, **before** the source-based append:
+
+```python
+        for mapping in entity_result.field_mappings:
+            field_type = mapping.field_type if mapping.field_type != "str" else _infer_type(mapping.value)
+            field_def: dict = {
+                "name": mapping.field_name,
+                "type": field_type,
+                "required": mapping.required,
+            }
+            if field_type == "selection":
+                field_def["options"] = mapping.options or []
+                field_def["multiple"] = mapping.multiple or False
+            if mapping.default is not None:
+                field_def["default"] = mapping.default
+```
+
+- [ ] **Step 2.4: Run tests, confirm pass**
+
+```bash
+cd /Users/kennylee/Development/NeoApex/papermite/backend
+uv run pytest tests/test_finalize_helpers.py -v
+```
+
+Expected: All tests pass (existing tests stay green, 4 new tests pass).
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+cd /Users/kennylee/Development/NeoApex
+git add papermite/backend/app/api/finalize.py papermite/backend/tests/test_finalize_helpers.py
+git commit -m "feat(papermite): persist field default in model definition"
+```
+
+---
+
+## Task 3: Papermite backend — integration test that default flows to DataCore PUT
+
+**Files:**
+- Test: `papermite/backend/tests/test_finalize_api.py` (append)
+
+- [ ] **Step 3.1: Add failing integration test**
+
+Append to `papermite/backend/tests/test_finalize_api.py`:
+
+```python
+def test_finalize_commit_sends_default_in_datacore_put():
+    """Defaults on FieldMappings flow into the PUT payload to DataCore /api/models."""
+    payload = {
+        "extraction": {
+            "extraction_id": "e2",
+            "tenant_id": "t1",
+            "filename": "app.pdf",
+            "entities": [
+                {
+                    "entity_type": "student",
+                    "entity": {"first_name": "Sam", "school_year": "2026-2027"},
+                    "field_mappings": [
+                        {
+                            "field_name": "first_name",
+                            "value": "Sam",
+                            "source": "base_model",
+                            "required": True,
+                            "field_type": "str",
+                        },
+                        {
+                            "field_name": "school_year",
+                            "value": "",
+                            "source": "custom_field",
+                            "required": False,
+                            "field_type": "str",
+                            "default": "2026-2027",
+                        },
+                        {
+                            "field_name": "is_active",
+                            "value": "",
+                            "source": "custom_field",
+                            "required": False,
+                            "field_type": "bool",
+                            "default": False,
+                        },
+                    ],
+                }
+            ],
+            "status": "pending_review",
+        }
+    }
+
+    captured = {}
+
+    def fake_put(url, json=None, timeout=None):
+        captured["url"] = url
+        captured["json"] = json
+        return MagicMock(
+            status_code=200,
+            json=MagicMock(return_value=_datacore_response_payload(json["model_definition"])),
+        )
+
+    with patch("app.api.finalize.httpx.put", side_effect=fake_put):
+        resp = client.post("/api/tenants/t1/finalize/commit", json=payload)
+
+    assert resp.status_code == 200, resp.text
+    md = captured["json"]["model_definition"]
+    student_custom = md["student"]["custom_fields"]
+    school_year = next(f for f in student_custom if f["name"] == "school_year")
+    assert school_year["default"] == "2026-2027"
+    is_active = next(f for f in student_custom if f["name"] == "is_active")
+    assert is_active["default"] is False
+    first_name = next(f for f in md["student"]["base_fields"] if f["name"] == "first_name")
+    assert "default" not in first_name
+```
+
+- [ ] **Step 3.2: Run test, confirm pass**
+
+```bash
+cd /Users/kennylee/Development/NeoApex/papermite/backend
+uv run pytest tests/test_finalize_api.py::test_finalize_commit_sends_default_in_datacore_put -v
+```
+
+Expected: PASS (the change from Task 2 already implements this).
+
+- [ ] **Step 3.3: Run the full backend test suite to check nothing regressed**
+
+```bash
+cd /Users/kennylee/Development/NeoApex/papermite/backend
+uv run pytest -v
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 3.4: Commit**
+
+```bash
+cd /Users/kennylee/Development/NeoApex
+git add papermite/backend/tests/test_finalize_api.py
+git commit -m "test(papermite): assert default flows to datacore PUT payload"
+```
+
+---
+
+## Task 4: Papermite frontend — extend types
+
+**Files:**
+- Modify: `papermite/frontend/src/types/models.ts:13-21` (`FieldMapping`), `:51-57` (`FieldDefinition`)
+
+- [ ] **Step 4.1: Add `default?: unknown` to both interfaces**
+
+Edit `papermite/frontend/src/types/models.ts`. Current `FieldMapping` (lines 13–21):
+
+```typescript
+export interface FieldMapping {
+  field_name: string;
+  value: unknown;
+  source: "base_model" | "custom_field";
+  required: boolean;
+  field_type: FieldType;
+  options?: string[];
+  multiple?: boolean;
+}
+```
+
+Change to:
+
+```typescript
+export interface FieldMapping {
+  field_name: string;
+  value: unknown;
+  source: "base_model" | "custom_field";
+  required: boolean;
+  field_type: FieldType;
+  options?: string[];
+  multiple?: boolean;
+  default?: unknown;
+}
+```
+
+Current `FieldDefinition` (lines 51–57):
+
+```typescript
+export interface FieldDefinition {
+  name: string;
+  type: FieldType;
+  required: boolean;
+  options?: string[];
+  multiple?: boolean;
+}
+```
+
+Change to:
+
+```typescript
+export interface FieldDefinition {
+  name: string;
+  type: FieldType;
+  required: boolean;
+  options?: string[];
+  multiple?: boolean;
+  default?: unknown;
+}
+```
+
+- [ ] **Step 4.2: Type-check**
+
+```bash
+cd /Users/kennylee/Development/NeoApex/papermite/frontend
+npx tsc -b
+```
+
+Expected: no errors.
+
+- [ ] **Step 4.3: Commit**
+
+```bash
+cd /Users/kennylee/Development/NeoApex
+git add papermite/frontend/src/types/models.ts
+git commit -m "feat(papermite): add optional default to FieldMapping/FieldDefinition types"
+```
+
+---
+
+## Task 5: Papermite frontend — `FieldRow` Default cell
+
+**Files:**
+- Modify: `papermite/frontend/src/components/FieldRow.tsx` (props, state, render)
+- Modify: `papermite/frontend/src/components/FieldRow.test.tsx` (test helper + new cases)
+
+- [ ] **Step 5.1: Extend the test helper and add failing tests**
+
+Edit `papermite/frontend/src/components/FieldRow.test.tsx`. First, extend `FieldRowTestProps` to include the new props (around line 6):
+
+```typescript
+interface FieldRowTestProps {
+  fieldName?: string;
+  value?: unknown;
+  source?: "base_model" | "custom_field";
+  required?: boolean;
+  fieldType?: FieldType;
+  options?: string[];
+  multiple?: boolean;
+  defaultVal?: unknown;
+  onUpdate?: (fieldName: string, value: unknown) => void;
+  onRequiredToggle?: (fieldName: string, required: boolean) => void;
+  onTypeChange?: (fieldName: string, fieldType: FieldType) => void;
+  onOptionsChange?: (
+    fieldName: string,
+    options: string[],
+    multiple: boolean
+  ) => void;
+  onDefaultChange?: (fieldName: string, value: unknown) => void;
+  onDelete?: () => void;
+}
+```
+
+Update `renderRow` to wire the new prop and stub (extend the block around lines 25–53):
+
+```typescript
+function renderRow(overrides: FieldRowTestProps = {}) {
+  const onUpdate = overrides.onUpdate ?? vi.fn();
+  const onRequiredToggle = overrides.onRequiredToggle ?? vi.fn();
+  const onTypeChange = overrides.onTypeChange ?? vi.fn();
+  const onOptionsChange = overrides.onOptionsChange ?? vi.fn();
+  const onDefaultChange = overrides.onDefaultChange ?? vi.fn();
+
+  const utils = render(
+    <table>
+      <tbody>
+        <FieldRow
+          fieldName={overrides.fieldName ?? "grade_level"}
+          value={overrides.value}
+          source={overrides.source ?? "custom_field"}
+          required={overrides.required ?? false}
+          fieldType={overrides.fieldType ?? "str"}
+          options={overrides.options}
+          multiple={overrides.multiple}
+          defaultVal={overrides.defaultVal}
+          onUpdate={onUpdate}
+          onRequiredToggle={onRequiredToggle}
+          onTypeChange={onTypeChange}
+          onOptionsChange={onOptionsChange}
+          onDefaultChange={onDefaultChange}
+          onDelete={overrides.onDelete}
+        />
+      </tbody>
+    </table>
+  );
+
+  return { ...utils, onUpdate, onRequiredToggle, onTypeChange, onOptionsChange, onDefaultChange };
+}
+```
+
+Append these new tests inside the existing `describe("FieldRow", ...)` block:
+
+```typescript
+  it("renders an empty Default cell click-to-edit input", () => {
+    const { onDefaultChange } = renderRow({ fieldType: "str" });
+    const cell = screen.getByTestId("field-row-default");
+    const display = cell.querySelector(".field-row__default-display") as HTMLElement;
+    expect(display).toBeInTheDocument();
+    fireEvent.click(display);
+    const input = cell.querySelector("input") as HTMLInputElement;
+    expect(input).toBeInTheDocument();
+    expect(input.value).toBe("");
+    fireEvent.change(input, { target: { value: "9" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onDefaultChange).toHaveBeenCalledWith("grade_level", "9");
+  });
+
+  it("Escape in the Default input cancels without firing onDefaultChange", () => {
+    const { onDefaultChange } = renderRow({ fieldType: "str", defaultVal: "9" });
+    const cell = screen.getByTestId("field-row-default");
+    const display = cell.querySelector(".field-row__default-display") as HTMLElement;
+    fireEvent.click(display);
+    const input = cell.querySelector("input") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "11" } });
+    fireEvent.keyDown(input, { key: "Escape" });
+    expect(onDefaultChange).not.toHaveBeenCalled();
+  });
+
+  it("clearing the Default input commits undefined (not the empty string)", () => {
+    const { onDefaultChange } = renderRow({ fieldType: "str", defaultVal: "9" });
+    const cell = screen.getByTestId("field-row-default");
+    const display = cell.querySelector(".field-row__default-display") as HTMLElement;
+    fireEvent.click(display);
+    const input = cell.querySelector("input") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onDefaultChange).toHaveBeenCalledWith("grade_level", undefined);
+  });
+
+  it("bool Default cell renders a checkbox bound to defaultVal", () => {
+    const { onDefaultChange } = renderRow({ fieldType: "bool", defaultVal: false });
+    const cell = screen.getByTestId("field-row-default");
+    const checkbox = cell.querySelector("input[type='checkbox']") as HTMLInputElement;
+    expect(checkbox.checked).toBe(false);
+    fireEvent.click(checkbox);
+    expect(onDefaultChange).toHaveBeenCalledWith("grade_level", true);
+  });
+
+  it("selection-single Default cell renders a <select> with — none — option", () => {
+    const { onDefaultChange } = renderRow({
+      fieldType: "selection",
+      options: ["9", "10", "11"],
+      multiple: false,
+      defaultVal: "10",
+    });
+    const cell = screen.getByTestId("field-row-default");
+    const select = cell.querySelector("select") as HTMLSelectElement;
+    expect(select.value).toBe("10");
+    const optionValues = Array.from(select.options).map((o) => o.value);
+    expect(optionValues).toEqual(["", "9", "10", "11"]);
+    fireEvent.change(select, { target: { value: "" } });
+    expect(onDefaultChange).toHaveBeenCalledWith("grade_level", undefined);
+  });
+
+  it("selection-multi Default cell renders checkboxes and commits arrays", () => {
+    const { onDefaultChange } = renderRow({
+      fieldType: "selection",
+      options: ["math", "science", "history"],
+      multiple: true,
+      defaultVal: ["math"],
+    });
+    const cell = screen.getByTestId("field-row-default");
+    const checkboxes = cell.querySelectorAll<HTMLInputElement>("input[type='checkbox']");
+    expect(checkboxes).toHaveLength(3);
+    expect(checkboxes[0].checked).toBe(true);
+    expect(checkboxes[1].checked).toBe(false);
+    fireEvent.click(checkboxes[1]);
+    expect(onDefaultChange).toHaveBeenCalledWith("grade_level", ["math", "science"]);
+  });
+
+  it("selection-multi clearing the last checked option commits undefined", () => {
+    const { onDefaultChange } = renderRow({
+      fieldType: "selection",
+      options: ["math", "science"],
+      multiple: true,
+      defaultVal: ["math"],
+    });
+    const cell = screen.getByTestId("field-row-default");
+    const checkboxes = cell.querySelectorAll<HTMLInputElement>("input[type='checkbox']");
+    fireEvent.click(checkboxes[0]);
+    expect(onDefaultChange).toHaveBeenCalledWith("grade_level", undefined);
+  });
+```
+
+- [ ] **Step 5.2: Run tests, confirm they fail**
+
+```bash
+cd /Users/kennylee/Development/NeoApex/papermite/frontend
+npx vitest run src/components/FieldRow.test.tsx
+```
+
+Expected: 7 new tests FAIL — `defaultVal`/`onDefaultChange` props don't exist on `FieldRow`, the `field-row-default` cell isn't rendered.
+
+- [ ] **Step 5.3: Add `defaultVal`/`onDefaultChange` to FieldRow Props and render the cell**
+
+Edit `papermite/frontend/src/components/FieldRow.tsx`.
+
+**(a)** Update the `Props` interface (lines 5–22) to include the new props:
+
+```typescript
+interface Props {
+  fieldName: string;
+  value: unknown;
+  source: "base_model" | "custom_field";
+  required: boolean;
+  fieldType: FieldType;
+  options?: string[];
+  multiple?: boolean;
+  defaultVal?: unknown;
+  onUpdate: (fieldName: string, value: unknown) => void;
+  onRequiredToggle: (fieldName: string, required: boolean) => void;
+  onTypeChange: (fieldName: string, fieldType: FieldType) => void;
+  onOptionsChange: (fieldName: string, options: string[], multiple: boolean) => void;
+  onDefaultChange?: (fieldName: string, value: unknown) => void;
+  onFieldNameChange?: (
+    oldName: string,
+    newName: string
+  ) => { ok: true } | { ok: false; error: string };
+  onDelete?: () => void;
+}
+```
+
+**(b)** Destructure the new props in the component signature (currently lines 103–117):
+
+```typescript
+export default function FieldRow({
+  fieldName,
+  value,
+  source,
+  required,
+  fieldType,
+  options,
+  multiple,
+  defaultVal,
+  onUpdate,
+  onRequiredToggle,
+  onTypeChange,
+  onOptionsChange,
+  onDefaultChange,
+  onFieldNameChange,
+  onDelete,
+}: Props) {
+```
+
+**(c)** Add the new state hooks below the existing `useState` calls (after the `nameError` state, around line 123):
+
+```typescript
+  const [editingDefault, setEditingDefault] = useState(false);
+  const [editDefault, setEditDefault] = useState(toEditString(defaultVal));
+```
+
+**(d)** Add the handlers below `handleNameKeyDown` (around line 172):
+
+```typescript
+  const handleDefaultSave = () => {
+    if (!onDefaultChange) {
+      setEditingDefault(false);
+      setEditDefault(toEditString(defaultVal));
+      return;
+    }
+    const trimmed = editDefault.trim();
+    const next = trimmed === "" ? undefined : editDefault;
+    onDefaultChange(fieldName, next);
+    setEditingDefault(false);
+  };
+
+  const handleDefaultKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleDefaultSave();
+    }
+    if (e.key === "Escape") {
+      setEditingDefault(false);
+      setEditDefault(toEditString(defaultVal));
+    }
+  };
+
+  const handleDefaultSelectionSingle = (newValue: string) => {
+    if (!onDefaultChange) return;
+    onDefaultChange(fieldName, newValue === "" ? undefined : newValue);
+  };
+
+  const handleDefaultSelectionMulti = (option: string, checked: boolean) => {
+    if (!onDefaultChange) return;
+    const current = Array.isArray(defaultVal)
+      ? defaultVal.filter((s): s is string => typeof s === "string")
+      : [];
+    const next = checked
+      ? [...current, option]
+      : current.filter((s) => s !== option);
+    onDefaultChange(fieldName, next.length === 0 ? undefined : next);
+  };
+
+  const handleDefaultBool = (checked: boolean) => {
+    if (!onDefaultChange) return;
+    onDefaultChange(fieldName, checked);
+  };
+```
+
+**(e)** Insert the new `<td>` immediately AFTER the `<td className="field-row__value">…</td>` block (the value `<td>` closes at the line that reads `</td>` right before `<td className="field-row__data-type">` — currently around line 282). Insert this between them:
+
+```tsx
+        <td className="field-row__default" data-testid="field-row-default">
+          {fieldType === "selection" && (options?.length ?? 0) > 0 ? (
+            multiple ? (
+              (options ?? []).map((opt) => {
+                const selected = Array.isArray(defaultVal)
+                  ? defaultVal.filter((s): s is string => typeof s === "string")
+                  : [];
+                return (
+                  <label key={opt} className="field-row__default-multi-label">
+                    <input
+                      type="checkbox"
+                      checked={selected.includes(opt)}
+                      onChange={(e) => handleDefaultSelectionMulti(opt, e.target.checked)}
+                    />
+                    {opt}
+                  </label>
+                );
+              })
+            ) : (
+              <select
+                className="input field-row__input"
+                value={typeof defaultVal === "string" ? defaultVal : ""}
+                onChange={(e) => handleDefaultSelectionSingle(e.target.value)}
+              >
+                <option value="">— none —</option>
+                {(options ?? []).map((opt) => (
+                  <option key={opt} value={opt}>{opt}</option>
+                ))}
+              </select>
+            )
+          ) : fieldType === "bool" ? (
+            <input
+              type="checkbox"
+              checked={Boolean(defaultVal)}
+              onChange={(e) => handleDefaultBool(e.target.checked)}
+            />
+          ) : editingDefault ? (
+            <input
+              className="input field-row__input"
+              value={editDefault}
+              onChange={(e) => setEditDefault(e.target.value)}
+              onBlur={handleDefaultSave}
+              onKeyDown={handleDefaultKeyDown}
+              autoFocus
+            />
+          ) : (
+            <span
+              className="field-row__default-display"
+              onClick={() => {
+                setEditDefault(toEditString(defaultVal));
+                setEditingDefault(true);
+              }}
+              title="Click to edit default"
+            >
+              {toEditString(defaultVal) || "—"}
+            </span>
+          )}
+        </td>
+```
+
+- [ ] **Step 5.4: Run tests, confirm pass**
+
+```bash
+cd /Users/kennylee/Development/NeoApex/papermite/frontend
+npx vitest run src/components/FieldRow.test.tsx
+```
+
+Expected: All FieldRow tests pass (existing 5 + new 7).
+
+- [ ] **Step 5.5: Commit**
+
+```bash
+cd /Users/kennylee/Development/NeoApex
+git add papermite/frontend/src/components/FieldRow.tsx papermite/frontend/src/components/FieldRow.test.tsx
+git commit -m "feat(papermite): render Default cell in FieldRow with click-to-edit and per-type inputs"
+```
+
+---
+
+## Task 6: Papermite frontend — `EntityCard` wires Default + type/multi clearing
+
+**Files:**
+- Modify: `papermite/frontend/src/components/EntityCard.tsx` (`handleTypeChange`, `handleOptionsChange`, add `handleDefaultChange`, header `<th>`, pass props)
+- Create: `papermite/frontend/src/components/EntityCard.test.tsx`
+
+- [ ] **Step 6.1: Add failing tests for type-change and multi-toggle clearing**
+
+Create `papermite/frontend/src/components/EntityCard.test.tsx`:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import EntityCard from "./EntityCard";
+import type { EntityResult } from "../types/models";
+
+function makeEntity(): EntityResult {
+  return {
+    entity_type: "STUDENT",
+    entity: { grade_level: "9", subjects: ["math"] },
+    field_mappings: [
+      {
+        field_name: "grade_level",
+        value: "9",
+        source: "custom_field",
+        required: false,
+        field_type: "str",
+        default: "9",
+      },
+      {
+        field_name: "subjects",
+        value: ["math"],
+        source: "custom_field",
+        required: false,
+        field_type: "selection",
+        options: ["math", "science"],
+        multiple: true,
+        default: ["math"],
+      },
+    ],
+  };
+}
+
+describe("EntityCard", () => {
+  it("renders a Default column header between Value and Data Type", () => {
+    const entity = makeEntity();
+    render(<EntityCard entity={entity} index={0} onUpdate={() => {}} />);
+    const headers = screen.getAllByRole("columnheader").map((h) => h.textContent?.trim() ?? "");
+    const valueIdx = headers.indexOf("Value");
+    const defaultIdx = headers.indexOf("Default");
+    const dataTypeIdx = headers.indexOf("Data Type");
+    expect(valueIdx).toBeGreaterThanOrEqual(0);
+    expect(defaultIdx).toBe(valueIdx + 1);
+    expect(dataTypeIdx).toBe(defaultIdx + 1);
+  });
+
+  it("clears default when a field's type changes", () => {
+    const entity = makeEntity();
+    let latest: EntityResult | null = null;
+    render(
+      <EntityCard
+        entity={entity}
+        index={0}
+        onUpdate={(_, updated) => {
+          latest = updated;
+        }}
+      />
+    );
+    const typeSelects = screen.getAllByRole("combobox").filter(
+      (el) => el.classList.contains("field-row__type-select")
+    );
+    const gradeLevelType = typeSelects[0];
+    fireEvent.change(gradeLevelType, { target: { value: "number" } });
+    expect(latest).not.toBeNull();
+    const grade = latest!.field_mappings.find((m) => m.field_name === "grade_level")!;
+    expect(grade.field_type).toBe("number");
+    expect(grade.default).toBeUndefined();
+  });
+
+  it("clears default when multiple toggles on a selection field", () => {
+    const entity = makeEntity();
+    let latest: EntityResult | null = null;
+    const { container } = render(
+      <EntityCard
+        entity={entity}
+        index={0}
+        onUpdate={(_, updated) => {
+          latest = updated;
+        }}
+      />
+    );
+    const optionsButtons = container.querySelectorAll(".field-row__options-btn");
+    fireEvent.click(optionsButtons[0]);
+    const multipleCheckbox = container.querySelector(
+      ".options-editor__multiple input[type='checkbox']"
+    ) as HTMLInputElement;
+    fireEvent.click(multipleCheckbox);
+    expect(latest).not.toBeNull();
+    const subjects = latest!.field_mappings.find((m) => m.field_name === "subjects")!;
+    expect(subjects.multiple).toBe(false);
+    expect(subjects.default).toBeUndefined();
+  });
+
+  it("does NOT clear default when only options change (no multi toggle)", () => {
+    const entity = makeEntity();
+    let latest: EntityResult | null = null;
+    const { container } = render(
+      <EntityCard
+        entity={entity}
+        index={0}
+        onUpdate={(_, updated) => {
+          latest = updated;
+        }}
+      />
+    );
+    const optionsButtons = container.querySelectorAll(".field-row__options-btn");
+    fireEvent.click(optionsButtons[0]);
+    const addInput = container.querySelector(
+      ".options-editor__input"
+    ) as HTMLInputElement;
+    fireEvent.change(addInput, { target: { value: "history" } });
+    const addBtn = container.querySelector(
+      ".options-editor__add .btn"
+    ) as HTMLButtonElement;
+    fireEvent.click(addBtn);
+    expect(latest).not.toBeNull();
+    const subjects = latest!.field_mappings.find((m) => m.field_name === "subjects")!;
+    expect(subjects.options).toEqual(["math", "science", "history"]);
+    expect(subjects.multiple).toBe(true);
+    expect(subjects.default).toEqual(["math"]);
+  });
+});
+```
+
+- [ ] **Step 6.2: Run tests, confirm they fail**
+
+```bash
+cd /Users/kennylee/Development/NeoApex/papermite/frontend
+npx vitest run src/components/EntityCard.test.tsx
+```
+
+Expected: 4 FAILED — no Default header, type change doesn't clear default, etc.
+
+- [ ] **Step 6.3: Update `EntityCard` — header, handlers, prop wiring**
+
+Edit `papermite/frontend/src/components/EntityCard.tsx`.
+
+**(a)** Replace `handleTypeChange` (currently lines 43–58):
+
+```typescript
+  const handleTypeChange = (fieldName: string, field_type: FieldType) => {
+    const updated = { ...entity };
+    updated.field_mappings = updated.field_mappings.map((m) =>
+      m.field_name === fieldName
+        ? {
+            ...m,
+            field_type,
+            default: undefined,
+            // Reset selection-specific fields when switching away
+            ...(field_type !== "selection" ? { options: undefined, multiple: undefined } : {}),
+            // Init selection defaults when switching to selection
+            ...(field_type === "selection" && !m.options ? { options: [], multiple: false } : {}),
+          }
+        : m
+    );
+    onUpdate(index, updated);
+  };
+```
+
+**(b)** Replace `handleOptionsChange` (currently lines 60–66) — clear `default` only when `multiple` differs from prior:
+
+```typescript
+  const handleOptionsChange = (fieldName: string, options: string[], multiple: boolean) => {
+    const updated = { ...entity };
+    updated.field_mappings = updated.field_mappings.map((m) => {
+      if (m.field_name !== fieldName) return m;
+      const multipleChanged = m.multiple !== multiple;
+      return {
+        ...m,
+        options,
+        multiple,
+        ...(multipleChanged ? { default: undefined } : {}),
+      };
+    });
+    onUpdate(index, updated);
+  };
+```
+
+**(c)** Add a new `handleDefaultChange` handler beneath `handleOptionsChange`:
+
+```typescript
+  const handleDefaultChange = (fieldName: string, value: unknown) => {
+    const updated = { ...entity };
+    updated.field_mappings = updated.field_mappings.map((m) =>
+      m.field_name === fieldName ? { ...m, default: value } : m
+    );
+    onUpdate(index, updated);
+  };
+```
+
+**(d)** Update the table header (currently lines 173–182). Change:
+
+```tsx
+          <thead>
+            <tr>
+              <th>Field</th>
+              <th>Value</th>
+              <th>Data Type</th>
+              <th>Source</th>
+              <th>Required</th>
+              <th></th>
+            </tr>
+          </thead>
+```
+
+to:
+
+```tsx
+          <thead>
+            <tr>
+              <th>Field</th>
+              <th>Value</th>
+              <th>Default</th>
+              <th>Data Type</th>
+              <th>Source</th>
+              <th>Required</th>
+              <th></th>
+            </tr>
+          </thead>
+```
+
+**(e)** Update the `<FieldRow … />` call (currently around lines 188–211) to pass `defaultVal` and `onDefaultChange`:
+
+```tsx
+              <FieldRow
+                key={mapping.field_name}
+                fieldName={mapping.field_name}
+                value={mapping.value}
+                source={mapping.source}
+                required={mapping.required}
+                fieldType={mapping.field_type}
+                options={mapping.options}
+                multiple={mapping.multiple}
+                defaultVal={mapping.default}
+                onUpdate={handleFieldUpdate}
+                onRequiredToggle={handleRequiredToggle}
+                onTypeChange={handleTypeChange}
+                onOptionsChange={handleOptionsChange}
+                onDefaultChange={handleDefaultChange}
+                onFieldNameChange={
+                  mapping.source === "custom_field"
+                    ? handleFieldNameChange
+                    : undefined
+                }
+                onDelete={
+                  mapping.source === "custom_field"
+                    ? () => handleFieldDelete(mapping.field_name)
+                    : undefined
+                }
+              />
+```
+
+**(f)** Update the `<tr>` colspan in `FieldRow.tsx` for the options-row. Edit `papermite/frontend/src/components/FieldRow.tsx`, near the bottom (currently line 341):
+
+```tsx
+      {showOptions && fieldType === "selection" && (
+        <tr className="field-row__options-row">
+          <td colSpan={6}>
+```
+
+Change `colSpan={6}` to `colSpan={7}` to account for the new Default column.
+
+- [ ] **Step 6.4: Run EntityCard tests, confirm pass**
+
+```bash
+cd /Users/kennylee/Development/NeoApex/papermite/frontend
+npx vitest run src/components/EntityCard.test.tsx src/components/FieldRow.test.tsx
+```
+
+Expected: All EntityCard tests (4) and FieldRow tests (12) pass.
+
+- [ ] **Step 6.5: Commit**
+
+```bash
+cd /Users/kennylee/Development/NeoApex
+git add papermite/frontend/src/components/EntityCard.tsx papermite/frontend/src/components/EntityCard.test.tsx papermite/frontend/src/components/FieldRow.tsx
+git commit -m "feat(papermite): wire Default column in EntityCard; clear default on type/multi change"
+```
+
+---
+
+## Task 7: Papermite frontend — `AddFieldForm` optional Default input
+
+**Files:**
+- Modify: `papermite/frontend/src/components/AddFieldForm.tsx`
+- Modify: `papermite/frontend/src/components/EntityCard.tsx` (`handleAddField`)
+
+- [ ] **Step 7.1: Extend `AddFieldForm` to accept and emit `default`**
+
+Edit `papermite/frontend/src/components/AddFieldForm.tsx`. Replace the entire file with:
+
+```typescript
+import { useState } from "react";
+
+interface Props {
+  onAdd: (fieldName: string, value: string, defaultVal?: string) => void;
+}
+
+export default function AddFieldForm({ onAdd }: Props) {
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [value, setValue] = useState("");
+  const [defaultVal, setDefaultVal] = useState("");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) return;
+    const trimmedDefault = defaultVal.trim();
+    onAdd(name.trim(), value, trimmedDefault === "" ? undefined : defaultVal);
+    setName("");
+    setValue("");
+    setDefaultVal("");
+    setOpen(false);
+  };
+
+  if (!open) {
+    return (
+      <button
+        className="btn btn--sm add-field-btn"
+        onClick={() => setOpen(true)}
+      >
+        + Add custom field
+      </button>
+    );
+  }
+
+  return (
+    <form className="add-field-form" onSubmit={handleSubmit}>
+      <input
+        className="input"
+        placeholder="field_name"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        autoFocus
+        style={{ fontFamily: "var(--font-sans)", fontSize: "14px" }}
+      />
+      <input
+        className="input"
+        placeholder="value"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+      />
+      <input
+        className="input"
+        placeholder="default (optional)"
+        value={defaultVal}
+        onChange={(e) => setDefaultVal(e.target.value)}
+      />
+      <button className="btn btn--primary btn--sm" type="submit">
+        Add
+      </button>
+      <button
+        className="btn btn--sm"
+        type="button"
+        onClick={() => setOpen(false)}
+      >
+        Cancel
+      </button>
+    </form>
+  );
+}
+```
+
+(Why no type-conditional rendering here: `AddFieldForm` only creates `field_type: "str"` mappings — the type cell becomes editable after the field exists. So a plain text Default input is always correct.)
+
+- [ ] **Step 7.2: Update `handleAddField` in `EntityCard` to accept and persist the default**
+
+Edit `papermite/frontend/src/components/EntityCard.tsx`. Replace the `handleAddField` block (currently lines 138–151) with:
+
+```typescript
+  const handleAddField = (fieldName: string, value: string, defaultVal?: string) => {
+    const updated = { ...entity };
+    updated.entity = { ...updated.entity, [fieldName]: value };
+    const cf = {
+      ...((updated.entity.custom_fields as Record<string, unknown>) || {}),
+      [fieldName]: value,
+    };
+    updated.entity.custom_fields = cf;
+    updated.field_mappings = [
+      ...updated.field_mappings,
+      {
+        field_name: fieldName,
+        value,
+        source: "custom_field" as const,
+        required: false,
+        field_type: "str" as const,
+        ...(defaultVal !== undefined ? { default: defaultVal } : {}),
+      },
+    ];
+    onUpdate(index, updated);
+  };
+```
+
+- [ ] **Step 7.3: Type-check and run all Papermite frontend tests**
+
+```bash
+cd /Users/kennylee/Development/NeoApex/papermite/frontend
+npx tsc -b
+npx vitest run
+```
+
+Expected: typecheck succeeds; all tests pass.
+
+- [ ] **Step 7.4: Commit**
+
+```bash
+cd /Users/kennylee/Development/NeoApex
+git add papermite/frontend/src/components/AddFieldForm.tsx papermite/frontend/src/components/EntityCard.tsx
+git commit -m "feat(papermite): optional Default input in AddFieldForm; persist on new custom fields"
+```
+
+---
+
+## Task 8: Papermite frontend — `modelToExtraction` restores stored default
+
+**Files:**
+- Modify: `papermite/frontend/src/api/client.ts:128-182` (`modelToExtraction`)
+- (No new test — covered by manual E2E in Task 11)
+
+- [ ] **Step 8.1: Conditionally propagate `default` in base and custom loops**
+
+Edit `papermite/frontend/src/api/client.ts`.
+
+Replace the base-fields loop (currently lines 138–150):
+
+```typescript
+    for (const field of def.base_fields) {
+      const value = field.name === "tenant_id" ? model.tenant_id : "";
+      entity[field.name] = value;
+      fieldMappings.push({
+        field_name: field.name,
+        value,
+        source: "base_model",
+        required: field.required,
+        field_type: field.type,
+        ...(field.options && { options: field.options }),
+        ...(field.multiple !== undefined && { multiple: field.multiple }),
+      });
+    }
+```
+
+with:
+
+```typescript
+    for (const field of def.base_fields) {
+      const value = field.name === "tenant_id" ? model.tenant_id : "";
+      entity[field.name] = value;
+      fieldMappings.push({
+        field_name: field.name,
+        value,
+        source: "base_model",
+        required: field.required,
+        field_type: field.type,
+        ...(field.options && { options: field.options }),
+        ...(field.multiple !== undefined && { multiple: field.multiple }),
+        ...(field.default !== undefined && { default: field.default }),
+      });
+    }
+```
+
+Replace the custom-fields loop (currently lines 152–164):
+
+```typescript
+    for (const field of def.custom_fields) {
+      entity[field.name] = "";
+      customFields[field.name] = "";
+      fieldMappings.push({
+        field_name: field.name,
+        value: "",
+        source: "custom_field",
+        required: field.required,
+        field_type: field.type,
+        ...(field.options && { options: field.options }),
+        ...(field.multiple !== undefined && { multiple: field.multiple }),
+      });
+    }
+```
+
+with:
+
+```typescript
+    for (const field of def.custom_fields) {
+      entity[field.name] = "";
+      customFields[field.name] = "";
+      fieldMappings.push({
+        field_name: field.name,
+        value: "",
+        source: "custom_field",
+        required: field.required,
+        field_type: field.type,
+        ...(field.options && { options: field.options }),
+        ...(field.multiple !== undefined && { multiple: field.multiple }),
+        ...(field.default !== undefined && { default: field.default }),
+      });
+    }
+```
+
+- [ ] **Step 8.2: Type-check, build**
+
+```bash
+cd /Users/kennylee/Development/NeoApex/papermite/frontend
+npm run build
+```
+
+Expected: TypeScript check passes; Vite build succeeds.
+
+- [ ] **Step 8.3: Commit**
+
+```bash
+cd /Users/kennylee/Development/NeoApex
+git add papermite/frontend/src/api/client.ts
+git commit -m "feat(papermite): restore stored default in modelToExtraction"
+```
+
+---
+
+## Task 9: AdminDash frontend — types + `DynamicForm` prefill + number coerce
+
+**Files:**
+- Modify: `admindash/frontend/src/types/models.ts:44-50` (`ModelFieldDefinition`)
+- Modify: `admindash/frontend/src/components/DynamicForm.tsx:192-198` (`buildValues`), `:204-214` (`useEffect`)
+
+- [ ] **Step 9.1: Add `default?: unknown` to `ModelFieldDefinition`**
+
+Edit `admindash/frontend/src/types/models.ts`. Current (lines 44–50):
+
+```typescript
+export interface ModelFieldDefinition {
+  name: string;
+  type: 'str' | 'number' | 'bool' | 'date' | 'datetime' | 'email' | 'phone' | 'selection';
+  required: boolean;
+  options?: string[];
+  multiple?: boolean;
+}
+```
+
+Change to:
+
+```typescript
+export interface ModelFieldDefinition {
+  name: string;
+  type: 'str' | 'number' | 'bool' | 'date' | 'datetime' | 'email' | 'phone' | 'selection';
+  required: boolean;
+  options?: string[];
+  multiple?: boolean;
+  default?: unknown;
+}
+```
+
+- [ ] **Step 9.2: Update `buildValues` in `DynamicForm.tsx` to prefill from default + coerce numbers**
+
+Edit `admindash/frontend/src/components/DynamicForm.tsx`. Current `buildValues` (lines 192–198):
+
+```typescript
+  const buildValues = (overrides?: Record<string, unknown>) => {
+    const result: Record<string, unknown> = {};
+    for (const field of allFields) {
+      result[field.name] = overrides?.[field.name] ?? (field.type === 'bool' ? false : '');
+    }
+    return result;
+  };
+```
+
+Replace with:
+
+```typescript
+  const buildValues = (overrides?: Record<string, unknown>) => {
+    const result: Record<string, unknown> = {};
+    for (const field of allFields) {
+      const override = overrides?.[field.name];
+      const fallback = field.type === 'bool' ? false : '';
+      let resolved: unknown;
+      if (override !== undefined) {
+        resolved = override;
+      } else if (field.default !== undefined) {
+        resolved = field.default;
+      } else {
+        resolved = fallback;
+      }
+      if (field.type === 'number' && resolved !== '' && resolved !== null && resolved !== undefined) {
+        const coerced = Number(resolved);
+        resolved = Number.isNaN(coerced) ? '' : coerced;
+      }
+      result[field.name] = resolved;
+    }
+    return result;
+  };
+```
+
+- [ ] **Step 9.3: Run AdminDash frontend lint and build**
+
+```bash
+cd /Users/kennylee/Development/NeoApex/admindash/frontend
+npm run lint
+npm run build
+```
+
+Expected: both succeed.
+
+- [ ] **Step 9.4: Commit**
+
+```bash
+cd /Users/kennylee/Development/NeoApex
+git add admindash/frontend/src/types/models.ts admindash/frontend/src/components/DynamicForm.tsx
+git commit -m "feat(admindash): prefill DynamicForm from field.default; coerce number prefills"
+```
+
+---
+
+## Task 10: Local end-to-end verification
+
+**No code changes.** Confirm the feature end-to-end with the running stack.
+
+- [ ] **Step 10.1: Restart all services**
+
+```bash
+cd /Users/kennylee/Development/NeoApex
+./start-services.sh
+```
+
+Wait for the status table to show all 7 services `running`.
+
+- [ ] **Step 10.2: Papermite — set defaults via the Review page**
+
+1. Open `http://localhost:5700` in a browser (Papermite frontend).
+2. Log in with a test admin user (use whatever account exists; see `papermite/backend/app/config.py` for fixture users).
+3. Upload any existing document from `papermite/backend/uploads/<tenant>/` OR if a model already exists, click Edit Model.
+4. On the Review page, confirm the table header now reads: `Field | Value | Default | Data Type | Source | Required | (actions)`.
+5. For a `str` base field (e.g., `grade_level` on Student), click the Default cell, type `9`, press Enter. The cell should display `9`.
+6. For a `bool` custom field (add one via "+ Add custom field" if none exists; rename later), toggle the Default checkbox and confirm it persists across page interactions.
+7. Click Finalize → Confirm & Save.
+
+- [ ] **Step 10.3: DataCore — verify stored default**
+
+Replace `<tenant_id>` with the actual tenant id you used (e.g., `acme`):
+
+```bash
+curl -s -X POST http://localhost:5800/api/query \
+  -H "Content-Type: application/json" \
+  -d '{"tenant_id":"<tenant_id>","table":"tenant_models","sql":"SELECT entity_type, model_definition FROM data WHERE _status = '"'"'active'"'"' LIMIT 10"}' \
+  | python3 -m json.tool | head -200
+```
+
+Expected: the JSON includes `"default": "9"` on the field you set. Fields without defaults have NO `"default"` key (not `"default": null`).
+
+- [ ] **Step 10.4: Papermite — confirm rehydration on reopen**
+
+1. Reload `http://localhost:5700`.
+2. From LandingPage, click Edit Model.
+3. Verify the Default cells render the values you saved in Step 10.2.
+4. Change a field's type (e.g., `grade_level` from `str` to `number`) — confirm the Default cell immediately blanks out.
+5. Click Cancel (do NOT re-finalize; you want to preserve the saved defaults for the AdminDash step).
+
+- [ ] **Step 10.5: AdminDash — confirm prefill on Add Entity**
+
+1. Open `http://localhost:5600` in a browser (AdminDash frontend).
+2. Log in.
+3. Open Add Student.
+4. Confirm fields with defaults are prefilled.
+5. Submit WITHOUT touching a prefilled `number` field (if any). Then query DataCore:
+
+```bash
+curl -s -X POST http://localhost:5800/api/query \
+  -H "Content-Type: application/json" \
+  -d '{"tenant_id":"<tenant_id>","table":"entities","sql":"SELECT * FROM data WHERE entity_type = '"'"'student'"'"' ORDER BY _created_at DESC LIMIT 1"}' \
+  | python3 -m json.tool
+```
+
+Expected: any `number`-typed default appears as a JSON number (e.g., `9`), not a string (`"9"`).
+
+- [ ] **Step 10.6: AdminDash — confirm Edit precedence**
+
+1. Open the student you just created and click Edit.
+2. Verify the form shows the saved value (which equals the default for untouched fields, and the user-entered value for touched ones). This confirms `initialValues` precedence is preserved.
+
+- [ ] **Step 10.7: Re-finalize without changes — confirm no spurious version bump**
+
+1. In Papermite, click Edit Model again.
+2. Change nothing.
+3. Click Finalize → Confirm.
+4. The response payload should have `status: "unchanged"` and the same `version` as before. (Network tab in DevTools, or watch papermite-backend log via `tail -f .logs/papermite-backend.log`.)
+
+- [ ] **Step 10.8: Run all test suites**
+
+```bash
+cd /Users/kennylee/Development/NeoApex/papermite/backend
+uv run pytest -v
+
+cd /Users/kennylee/Development/NeoApex/papermite/frontend
+npm run lint
+npm run build
+npx vitest run
+
+cd /Users/kennylee/Development/NeoApex/admindash/frontend
+npm run lint
+npm run build
+```
+
+Expected: all suites pass with no errors.
+
+- [ ] **Step 10.9: No commit needed — this task is verification only.**
+
+---
+
+## Task 11: Wrap-up
+
+- [ ] **Step 11.1: Push the branch**
+
+```bash
+cd /Users/kennylee/Development/NeoApex
+git push -u origin feat/field-default-values
+```
+
+- [ ] **Step 11.2: Open a PR**
+
+```bash
+gh pr create --title "feat: per-field default values (Papermite → AdminDash prefill) — closes #70" --body "$(cat <<'EOF'
+## Summary
+
+Implements OpenSpec change `field-default-values`. Tenant admins can now set a per-field default in Papermite's form builder; AdminDash's Add Entity form prefills those defaults (still editable).
+
+- Papermite Review page gains a Default column between Value and Data Type
+- `FieldMapping` and stored `FieldDefinition` carry an optional `default`
+- AdminDash `DynamicForm.buildValues` prefills from `field.default` (overrides still win) and coerces number defaults to Number
+- Changing a field's type or toggling `multiple` clears the default to avoid stale shapes
+
+Closes #70.
+
+## Spec
+
+See `openspec/changes/field-default-values/` for proposal, design, specs (24 scenarios), and tasks.
+
+## Test plan
+
+- [x] `uv run pytest -v` in `papermite/backend/`
+- [x] `npx vitest run` in `papermite/frontend/`
+- [x] `npm run build` in `papermite/frontend/` and `admindash/frontend/`
+- [x] Manual end-to-end: set default in Papermite → confirm `default` key in stored model → reopen for edit (default shown) → AdminDash Add Entity prefilled → submit untouched number → number persisted as number
+- [x] Re-finalize without changes → response `status: "unchanged"` (no spurious version bump)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Return the PR URL.
+
+---
+
+## Self-Review Notes (for the executor)
+
+Cross-check against `openspec/changes/field-default-values/specs/field-default-values/spec.md`:
+
+| Spec requirement | Implementing task |
+|---|---|
+| Papermite Review page renders a Default cell per field row | Task 5 + Task 6 (header) |
+| AddFieldForm accepts an optional default value | Task 7 |
+| FieldMapping and FieldDefinition carry optional `default` | Task 1 (backend), Task 4 (frontend) |
+| `_build_model_definition` includes/omits `default` correctly | Task 2 + Task 3 |
+| `modelToExtraction` restores `default` | Task 8 |
+| DynamicForm prefills from `field.default` (overrides win) | Task 9 |
+| Type change clears default | Task 6 (`handleTypeChange`) |
+| Multiple toggle clears default | Task 6 (`handleOptionsChange`) |
+| DynamicForm coerces number prefills via Number(...) | Task 9 |
+
+No gaps detected. Number coercion edge case (NaN fallback) is in Task 9 `buildValues` change.
+
+Type/name consistency check:
+- `FieldRow` prop is `defaultVal` (not `default` or `defaultValue`) — consistent across Task 5, Task 6.
+- `onDefaultChange` is the handler name — consistent.
+- `EntityCard.handleDefaultChange` — consistent.
+- `AddFieldForm.onAdd(name, value, defaultVal?)` — third param consistent with `EntityCard.handleAddField` in Task 7.
+- Backend `FieldMapping.default` is `Optional[Any]` (Pydantic) and `default?: unknown` (TS) — consistent.
+
+Commit cadence: 9 feature commits + branch push. Each commit corresponds to one task group and leaves the codebase in a buildable + testable state.

--- a/openspec/changes/field-default-values/.openspec.yaml
+++ b/openspec/changes/field-default-values/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-21

--- a/openspec/changes/field-default-values/design.md
+++ b/openspec/changes/field-default-values/design.md
@@ -1,0 +1,139 @@
+## Context
+
+Papermite's Review page (`FieldRow.tsx`) currently exposes five cells per field row: **Name**, **Sample Value**, **Data Type**, **Base/Custom badge**, **Required toggle**, plus an actions cell. The Sample Value is what the AI extracted from the source document — useful for the user to verify the extraction, but it is **not** persisted as part of the model definition; only `name`, `type`, `required`, and (for `selection`) `options`/`multiple` are persisted via `_build_model_definition` in `app/api/finalize.py`.
+
+AdminDash's `DynamicForm.tsx` (used by `AddStudentModal`, `ProgramPage` Add, etc.) builds the form's initial value map (`buildValues`) by walking the model definition's `base_fields` + `custom_fields` and defaulting each to `false` (bool) or `''` (everything else). If the caller passes `initialValues` (e.g., values extracted from a document via Papermite's `/api/extract`), those override the empty defaults.
+
+Issue #70 asks for a third dimension: a tenant-configured **default value** per field, persisted in the model definition and prefilled into the Add Entity form. The user can still edit it before submitting.
+
+Touched components: Papermite frontend `FieldRow`/`EntityCard`/`AddFieldForm`/`api/client.ts`/`types/models.ts`, Papermite backend `models/extraction.py` + `api/finalize.py`, AdminDash frontend `types/models.ts` + `components/DynamicForm.tsx`. DataCore is unchanged (model definitions are opaque JSON to it).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Allow the tenant admin to set a per-field default value in Papermite's Review page (and in `AddFieldForm` when creating a new custom field).
+- Persist the default in the stored model definition under each field as `default: <value>`.
+- Prefill the default into AdminDash's Add Entity form when the field has no `initialValues` override.
+- Round-trip correctly: opening an existing model in Papermite (LandingPage → Edit) restores the saved default into the editor; saving again writes it back.
+- Backwards-compatible with existing model definitions (no `default` key ⇒ no prefill, blank input).
+
+**Non-Goals:**
+- Per-tenant or per-role defaults beyond what the model definition already encodes.
+- Required-on-save enforcement of defaults (defaults are purely UI prefill).
+- Bulk-add prefill changes (`BulkAddStudentsPage` is out of scope).
+- Locked/read-only defaults — users may always edit.
+- Default-value validation at finalize time (Papermite continues to accept any value the user typed; AdminDash's existing `validateField` runs at submit time and flags mismatches the same way it does today for user-typed input).
+
+## Decisions
+
+### D1. Storage shape: `default` lives on each field definition
+
+Store the default inline on the existing `FieldDefinition` shape:
+
+```json
+{ "name": "grade_level", "type": "str", "required": false, "default": "9" }
+```
+
+When unset, the key is **omitted entirely** (not stored as `null`). This keeps existing model definitions byte-identical when defaults are not used, which means `lance_store.py`'s normalized-comparison change detection continues to no-op on unchanged models.
+
+**Alternative considered:** a separate `defaults: { field_name: value }` map per entity. Rejected because (a) it splits a field's properties across two structures, complicating reads and the React state model, and (b) it makes round-tripping in `modelToExtraction` more bookkeeping for no gain.
+
+### D2. Type: `unknown` / `Any`, no per-type narrowing
+
+Both TypeScript (`FieldMapping.default?: unknown`, `FieldDefinition.default?: unknown`, `ModelFieldDefinition.default?: unknown`) and Pydantic (`FieldMapping.default: Optional[Any] = None`) keep the default loosely typed.
+
+Rationale: the value's shape already correlates with the field's `type` (string for `str`/`email`/`phone`/`date`/`datetime`, number for `number`, boolean for `bool`, string for single-select `selection`, `string[]` for multi-select `selection`). Adding a discriminated union for `default` would force a parallel codepath everywhere a `FieldDefinition` is touched, with little payoff: the same validation already happens at AdminDash submit time via `validateField`.
+
+**Alternative considered:** strict per-type union. Rejected as premature; revisit if defaults become a source of bugs.
+
+### D3. UI placement: a third inline-edit cell, between "Sample Value" and "Data Type"
+
+Add a **Default** `<th>` to the `EntityCard` table header and a corresponding `<td>` in `FieldRow`. The cell uses the **same inline-edit pattern** that already powers the Sample Value cell (click to edit → input → Enter/blur commits, Escape cancels) and, for `selection` fields, the same radio/checkbox rendering used in the value cell.
+
+Rationale: column-aligned consistency. The Sample Value cell already demonstrates the inline-edit + selection pattern, so users (and reviewers) get a free read on how Default behaves.
+
+**Alternative considered:**
+- A "⋯" overflow that opens a per-field popover with advanced options. Rejected for issue #70's scope — a single new column is the minimum and most discoverable change.
+- Reusing the Sample Value cell as the default. Rejected because Sample Value reflects the extracted value of the source document and is useful diagnostic context; conflating it with the persisted default would lose information.
+
+### D4. Defaults apply to both base and custom fields
+
+The Default cell appears on every row (base and custom), and `_build_model_definition` writes `default` into both `base_fields[]` and `custom_fields[]`. The base/custom distinction governs identity and required-ness — defaults are orthogonal.
+
+**Alternative considered:** defaults only on custom fields. Rejected because the issue describes the feature as "for each field" and base fields (e.g., `grade_level` on Student) are exactly the ones with repetitive values across records.
+
+### D5. Prefill precedence in `DynamicForm.buildValues`
+
+For each field, the initial form value is computed as:
+
+```
+overrides?.[field.name]   // existing initialValues (document extract, edit mode)
+  ?? field.default          // NEW
+  ?? (field.type === 'bool' ? false : '')   // current fallback
+```
+
+This means document-extracted values still win over the tenant default (extraction is more specific to this record). When editing an existing entity, `editingEntity` is passed as `initialValues`, which contains the actual saved values and so overrides the default — correct behavior.
+
+**Alternative considered:** apply default unconditionally on Add mode. Rejected — the existing override semantics already do the right thing (document extract should win), so a separate Add/Edit branch is unnecessary.
+
+### D6. Empty-string default ≡ no default
+
+When the Default cell is left empty (or cleared), the value is omitted from the persisted JSON. This avoids storing `"default": ""` and then having to special-case it in AdminDash's prefill (`"" ?? fallback` returns `""`, not the fallback). Bool defaults are stored as `true`/`false` explicitly; the absence of the key means "no default" (UI shows the cell unchecked / blank).
+
+The serialized contract is: `_build_model_definition` MUST omit the `"default"` key entirely when `mapping.default is None`. It MUST NOT emit `"default": null`. This preserves byte-equality with pre-feature models in DataCore's `normalize`-then-compare change detection (`datacore/src/datacore/api/routes.py:199`), so adding the feature does not spuriously bump versions for tenants who never touch defaults.
+
+### D7. `AddFieldForm` includes an optional Default input
+
+When the tenant admin creates a new custom field via `AddFieldForm`, the form gains an optional Default input alongside the existing Name and Type inputs. This is a quality-of-life decision: it avoids the "add field → immediately edit Default cell" two-step.
+
+**Alternative considered:** skip this and require the admin to set the default in the Review row afterwards. Rejected as a small UX wart for almost no implementation cost.
+
+### D8. Changing a field's `type` clears its `default`
+
+When the tenant admin changes a field's data type (e.g., `str → number`, or `selection → str`), `handleTypeChange` in `EntityCard.tsx` SHALL clear `default` to `undefined` on the affected mapping. This mirrors the existing pattern in `handleTypeChange` (`papermite/frontend/src/components/EntityCard.tsx:43`) that already clears `options` and `multiple` when switching away from `selection`, and re-initializes them when switching to `selection`.
+
+Rationale: a default value's shape is tightly coupled to the field type (string for `str`/`email`/`phone`/`date`/`datetime`, number for `number`, boolean for `bool`, string-or-string-array for `selection`). Carrying a stale default through a type change produces hard-to-debug downstream mismatches in AdminDash (a number input prefilled with `"abc"`, etc.). Clearing is the simplest, most predictable rule, and the admin can re-enter the default in the same Review session.
+
+**Alternative considered:** keep raw, let AdminDash's `validateField` flag at submit. Rejected — surfacing the error at the wrong layer; tenants see broken prefill instead of a clean blank input.
+
+### D9. Toggling `multiple` on a selection field clears its `default`
+
+Same rationale and pattern as D8: when the admin toggles `multiple` (single ↔ multi) on a `selection` field via `OptionsEditor`, `handleOptionsChange` SHALL clear `default` to `undefined`. The default's shape is single-string vs string-array — these are not interchangeable and coercion choices are error-prone.
+
+Rationale: avoids a single-string default rendering as a half-checked checkbox group, or a string-array default rendering as nothing-selected in a radio group.
+
+### D10. Type-inference override in `_build_model_definition` — known quirk, deferred
+
+`_build_model_definition` (`papermite/backend/app/api/finalize.py:194`) overrides `mapping.field_type` with `_infer_type(mapping.value)` when the user's chosen type is `"str"` and the extracted sample value looks like a number/bool/list. This means the **stored** `type` can differ from what the admin selected in the Review row, and the stored `default` (which is not re-inferred) can be shape-incompatible with the stored type.
+
+This change does **not** alter that behavior. The same misalignment would show up today for the Sample Value cell if a user types `"abc"` for a numeric-looking field. AdminDash's `validateField` (which runs at submit time) catches it as it does today. Revisiting `_infer_type` is out of scope for issue #70 and would need its own change.
+
+### D11. AdminDash `DynamicForm` coerces prefilled `number` defaults
+
+There is a pre-existing asymmetry in `admindash/frontend/src/components/DynamicForm.tsx`: the `number` field's `onChange` runs `Number(e.target.value)`, but `buildValues` initializes from `initialValues`/`default` verbatim. If the user submits without touching a prefilled `number` field, the submitted value is a string — only edits convert to `Number`.
+
+Defaults make this more visible (more fields are prefilled, more often). To prevent a regression in submitted shape, `buildValues` SHALL coerce the prefilled value to `Number` when `field.type === 'number'` (only when the resolved prefill is not `''` and not `null`/`undefined`). This is a targeted fix scoped to where the new default-prefill code already runs. Other types are left as-is (their existing fallback `''` is correct), and the broader "normalize all type prefills" rewrite is out of scope.
+
+## Risks / Trade-offs
+
+- **Type mismatch between default and field type.** A user could type `"abc"` as the default for a `number` field. → AdminDash's existing `validateField` runs at form submit and flags it the same way it would for a user-typed value. Acceptable for v1; a Papermite-side validation pass on the Default cell could come later.
+- **Empty-string vs. omitted-key semantics for selection.** For multi-select, an empty default is `[]`; we treat both `[]` and missing as "no default" and omit the key on save. → Documented in spec scenarios.
+- **Reopening an old model.** Existing stored models have no `default` keys; `modelToExtraction` simply produces `FieldMapping.default === undefined`. The Default cell renders blank. No migration script needed.
+- **Selection options changing after default is set.** If the admin sets `default = "9"` then removes `"9"` from the options list, AdminDash will prefill an out-of-options value. → Same risk already exists with the live entity data and is handled the same way: the radio group simply shows nothing selected for that value (rendering `checked={radioValue === opt}` matches nothing). No additional mitigation in this change.
+- **JSON shape divergence between papermite and admindash.** Both must agree on the `default` key name and that empty/null = omitted. → Spec scenarios pin this down; tests on both sides assert the shape.
+
+## Migration Plan
+
+- **No DB migration.** Model definitions are JSON-in-LanceDB; new `default` keys appear on next save. Old models continue to load and render with blank Default cells.
+- **Forward compatibility.** Adding `default?: unknown` to TS interfaces and `Optional[Any] = None` to Pydantic is additive — old clients that ignore `default` continue to work.
+- **Rollback.** If we revert the Papermite changes, AdminDash will simply stop seeing `default` keys in newly-saved models. Already-saved defaults in stored models remain in the JSON (harmless dead data). AdminDash code can also be reverted independently — without the prefill, the form just starts empty as today.
+
+## Open Questions
+
+None. Decisions D1–D11 cover the design surface; remaining choices are implementation detail captured in `tasks.md`.
+
+## Implementation Notes
+
+- **React prop name in `FieldRow`.** Since `default` is a reserved JS keyword (and `defaultValue` is a reserved DOM prop name on form elements), use `defaultVal` as the `FieldRow` prop. The corresponding `FieldMapping` object key remains `default` (object keys are fine).
+- **Rename and delete already carry `default` through.** `EntityCard.tsx`'s `handleFieldNameChange` and `handleFieldDelete` use `{ ...m }` spreads on the mapping object, so adding `default` to `FieldMapping` is automatically respected with no extra code.
+- **Table header label.** The existing header is `Value` (not "Sample Value"). The new column header is `Default`, inserted between `Value` and `Data Type`.

--- a/openspec/changes/field-default-values/proposal.md
+++ b/openspec/changes/field-default-values/proposal.md
@@ -1,0 +1,60 @@
+## Why
+
+Today, when a school admin opens the "Add Student" (or any add-entity) form in AdminDash, every field starts empty. For fields whose value is the same on almost every record (e.g., `grade_level = "9"`, `enrollment_status = "active"`, `school_year = "2026-2027"`), staff retype the same value over and over.
+
+Issue [#70](https://github.com/kennyhlee/neo-apex/issues/70) asks Papermite's form builder to let the tenant admin set a per-field **default value** as part of the model definition. AdminDash then prefills that default on the Add Entity form. The user can still edit before saving — the default is a starting point, not a constraint.
+
+## What Changes
+
+- Papermite Review page: each field row gets a new **Default** input (a third inline-edit cell, after Name and Sample Value), wired with the same edit pattern as the existing Sample Value cell.
+- Papermite extraction model (`FieldMapping`) gains an optional `default` field that flows through `_build_model_definition` into the stored model definition under each field's `default` key.
+- Stored model definition `FieldDefinition` shape extends to include `default?: unknown` (omitted when unset).
+- AdminDash `DynamicForm` reads `field.default` and uses it as the initial value when no `initialValues` override is supplied for that field. Document-extract prefill (`initialValues`) continues to win over `default`.
+- Reopening a saved model in Papermite (LandingPage → Edit) restores existing defaults into the editor (`modelToExtraction`).
+
+Out of scope (explicitly):
+
+- No new field type. Defaults are stored and prefilled as strings/booleans matching the field's existing `type`; validation rules are unchanged.
+- No server-side enforcement of defaults. If `default` is missing on save, AdminDash submits empty as it does today.
+- No bulk-add prefill changes. `BulkAddStudentsPage` and the bulk-add orchestrator are out of scope; this proposal targets the single-entity Add Entity form only.
+- No "lock default" / read-only feature. Default values are always editable in the Add form.
+- No changes to `_infer_type` in `_build_model_definition`. The existing override behavior (which can change the stored `type` based on the Sample Value) is left alone; submit-time validation in AdminDash continues to catch shape mismatches the same way it does today.
+
+Targeted edge-case behavior (in scope):
+
+- Changing a field's `type` clears its `default` (parallel to the existing clearing of `options`/`multiple`).
+- Toggling `multiple` on a selection field clears its `default` (string ↔ array shapes are not coerced).
+- AdminDash's `DynamicForm` coerces prefilled `number` defaults via `Number(...)` so untouched submissions still POST a number, not a string.
+
+## Capabilities
+
+### New Capabilities
+- `field-default-values`: a per-field default value is captured in Papermite's form builder, persisted in the model definition, and prefilled into AdminDash's Add Entity form (still editable).
+
+### Modified Capabilities
+- None. `papermite-attribute-rename` covers field-name editing only; the new Default cell is a parallel, independent cell. `admindash-backend-api` is a transparent proxy and needs no change.
+
+## Impact
+
+**Papermite frontend** (`papermite/frontend/`):
+- `src/types/models.ts`: add `default?: unknown` to `FieldMapping` and `FieldDefinition`.
+- `src/components/FieldRow.tsx`: render a Default cell (inline-edit, same pattern as the existing value cell); add `onDefaultChange` prop.
+- `src/components/EntityCard.tsx`: add a "Default" `<th>` and wire `onDefaultChange` through to update `field_mappings[i].default`.
+- `src/components/AddFieldForm.tsx`: gains an optional Default input so newly added custom fields can have one too.
+- `src/api/client.ts`: `modelToExtraction()` copies `default` from stored model fields back into `FieldMapping.default`.
+
+**Papermite backend** (`papermite/backend/`):
+- `app/models/extraction.py`: add `default: Optional[Any] = None` to `FieldMapping`.
+- `app/api/finalize.py`: `_build_model_definition()` includes `"default": mapping.default` in the field dict when not None.
+- New tests: `tests/test_finalize_helpers.py` covers default round-tripping in `_build_model_definition`.
+
+**AdminDash frontend** (`admindash/frontend/`):
+- `src/types/models.ts`: add `default?: unknown` to `ModelFieldDefinition`.
+- `src/components/DynamicForm.tsx`: `buildValues()` falls back to `field.default` (when defined) before the type-based empty default (`false` for bool, `''` otherwise). `initialValues` overrides still win.
+
+**DataCore** (no code change):
+- Model definitions are stored as opaque JSON by `papermite`'s LanceDB layer. The new `default` key travels through unchanged. No DataCore endpoints to modify.
+
+**Backwards compatibility**:
+- Existing model definitions without `default` keys continue to work; `default` is read with optional chaining and treated as "no default" when absent.
+- Reopening an existing model in Papermite shows blank Default cells until the user fills them in.

--- a/openspec/changes/field-default-values/specs/field-default-values/spec.md
+++ b/openspec/changes/field-default-values/specs/field-default-values/spec.md
@@ -1,0 +1,281 @@
+## ADDED Requirements
+
+### Requirement: Papermite Review page SHALL render a Default cell per field row
+
+The Review page table (`EntityCard` → `FieldRow`) SHALL render a new column labeled **Default**, positioned between the existing **Value** column and the **Data Type** column. The column header SHALL appear in the `<thead>` row for every entity table. Every field row (both `source: "base_model"` and `source: "custom_field"`) SHALL render a corresponding `<td>` for this column.
+
+For non-`selection` field types (`str`, `number`, `bool`, `date`, `datetime`, `email`, `phone`), the cell SHALL use the same inline-edit pattern as the existing Value cell: a clickable display element that swaps for an auto-focused `<input>` on click, with Enter or blur committing and Escape canceling. For `bool` field type, the cell SHALL render a checkbox bound to the default value (no inline-edit toggle needed).
+
+For `selection` field type with `multiple: false`, the cell SHALL render a single `<select>` with a `— none —` option followed by the configured options. For `selection` with `multiple: true`, the cell SHALL render a checkbox group bound to the array default, mirroring the existing multi-select pattern in the Value cell.
+
+#### Scenario: Default column appears in the table header
+
+- **GIVEN** the user opens the Review page for an extraction with at least one entity
+- **WHEN** the entity table renders
+- **THEN** the `<thead>` SHALL contain a `<th>` with the text `Default` positioned between the Value header and the Data Type header
+
+#### Scenario: Clicking an empty Default cell enters edit mode
+
+- **GIVEN** a string field with no default set (`default` is undefined)
+- **WHEN** the user clicks the Default cell
+- **THEN** the cell SHALL switch to an `<input>` element
+- **AND** the input SHALL be auto-focused
+- **AND** the input value SHALL be empty
+
+#### Scenario: Pressing Enter in the Default input commits the value
+
+- **GIVEN** the Default cell for a string field is in edit mode with the user-typed value `"9"`
+- **WHEN** the user presses Enter
+- **THEN** the cell SHALL exit edit mode and display `"9"`
+- **AND** the corresponding `FieldMapping` in the in-memory `ExtractionResult` SHALL have `default: "9"`
+
+#### Scenario: Pressing Escape cancels the Default edit
+
+- **GIVEN** the Default cell for a string field is in edit mode with a typed but uncommitted value
+- **WHEN** the user presses Escape
+- **THEN** the cell SHALL exit edit mode and revert to the prior display
+- **AND** the in-memory `FieldMapping.default` SHALL NOT be modified
+
+#### Scenario: Clearing the Default cell removes the default
+
+- **GIVEN** a field whose `FieldMapping.default` is `"9"`
+- **WHEN** the user opens the Default cell, clears the input, and commits
+- **THEN** the cell SHALL display as empty
+- **AND** the in-memory `FieldMapping.default` SHALL be undefined (not the empty string)
+
+#### Scenario: Default for a selection field uses the configured options
+
+- **GIVEN** a `selection` field with `multiple: false` and `options: ["9", "10", "11", "12"]`
+- **WHEN** the Default cell renders
+- **THEN** the cell SHALL render a `<select>` whose options are exactly `— none —`, `"9"`, `"10"`, `"11"`, `"12"`
+- **AND** selecting `"10"` SHALL set `FieldMapping.default` to `"10"`
+
+#### Scenario: Default for a multi-select uses checkboxes
+
+- **GIVEN** a `selection` field with `multiple: true` and `options: ["math", "science", "history"]`
+- **WHEN** the Default cell renders
+- **THEN** the cell SHALL render three checkboxes, one per option
+- **AND** checking `"math"` and `"science"` SHALL set `FieldMapping.default` to `["math", "science"]`
+
+#### Scenario: Default for a bool field is a checkbox
+
+- **GIVEN** a `bool` field with no default set
+- **WHEN** the Default cell renders
+- **THEN** the cell SHALL render a `<input type="checkbox">` that is unchecked
+- **AND** checking the box SHALL set `FieldMapping.default` to `true`
+
+### Requirement: AddFieldForm SHALL accept an optional default value
+
+When the tenant admin adds a new custom field via the `AddFieldForm` component, the form SHALL include an optional **Default** input below the existing Name and Type inputs. The input MAY be left empty. If provided, the value SHALL be passed through into the newly-created `FieldMapping` as the `default` property.
+
+For `selection` field types, the Default input SHALL be hidden in `AddFieldForm` (selection defaults are set after creation once options exist, in the row-level Default cell). For `bool`, the Default input SHALL render as a checkbox.
+
+#### Scenario: Adding a string field with a default
+
+- **GIVEN** the user opens AddFieldForm and selects type `str`
+- **WHEN** the user enters name `"school_year"`, default `"2026-2027"`, and clicks Add
+- **THEN** the newly added `FieldMapping` SHALL have `field_name: "school_year"`, `source: "custom_field"`, `field_type: "str"`, and `default: "2026-2027"`
+
+#### Scenario: Adding a field with no default
+
+- **GIVEN** the user opens AddFieldForm
+- **WHEN** the user enters a name and type but leaves Default empty, then clicks Add
+- **THEN** the newly added `FieldMapping.default` SHALL be undefined (not the empty string)
+
+#### Scenario: Selection fields do not show a Default input in AddFieldForm
+
+- **GIVEN** the user opens AddFieldForm and selects type `selection`
+- **WHEN** the form re-renders
+- **THEN** no Default input SHALL be visible
+- **AND** the user MAY set the default later in the row-level Default cell once options are configured
+
+### Requirement: FieldMapping and FieldDefinition SHALL carry an optional `default`
+
+The Pydantic `FieldMapping` model in `papermite/backend/app/models/extraction.py` SHALL include a field `default: Optional[Any] = None`. The TypeScript `FieldMapping` interface in `papermite/frontend/src/types/models.ts` SHALL include a field `default?: unknown`. The TypeScript `FieldDefinition` (Papermite) and `ModelFieldDefinition` (AdminDash) interfaces SHALL each include `default?: unknown`.
+
+#### Scenario: Pydantic accepts a FieldMapping without default
+
+- **WHEN** a `FieldMapping` is constructed with `field_name="age"`, `value=10`, `source="base_model"`, `required=True`, `field_type="number"`
+- **THEN** the resulting `FieldMapping.default` SHALL equal `None`
+
+#### Scenario: Pydantic accepts a FieldMapping with a default
+
+- **WHEN** a `FieldMapping` is constructed with the same arguments plus `default=9`
+- **THEN** the resulting `FieldMapping.default` SHALL equal `9`
+
+### Requirement: `_build_model_definition` SHALL include `default` when present and omit it when absent
+
+In `papermite/backend/app/api/finalize.py`, the `_build_model_definition` function SHALL include `"default": mapping.default` in each field's dict if and only if `mapping.default` is not `None`. When `mapping.default` is `None`, the resulting field dict SHALL NOT contain a `default` key. It MUST NOT emit `"default": null`.
+
+This applies to both `base_fields[]` and `custom_fields[]` entries in the model definition.
+
+#### Scenario: Field with default is persisted with the default key
+
+- **GIVEN** an `EntityResult` with one custom field mapping having `field_name="school_year"`, `field_type="str"`, `required=False`, `default="2026-2027"`
+- **WHEN** `_build_model_definition([entity])` is called
+- **THEN** the returned model definition SHALL contain, under that entity type's `custom_fields[0]`, an object equal to `{"name": "school_year", "type": "str", "required": False, "default": "2026-2027"}`
+
+#### Scenario: Field without default is persisted without the default key
+
+- **GIVEN** an `EntityResult` with one custom field mapping where `default` is `None`
+- **WHEN** `_build_model_definition([entity])` is called
+- **THEN** the returned field dict SHALL NOT contain the key `"default"`
+
+#### Scenario: Selection field default is preserved verbatim
+
+- **GIVEN** an `EntityResult` with a base field mapping having `field_type="selection"`, `options=["math","science"]`, `multiple=True`, `default=["math"]`
+- **WHEN** `_build_model_definition([entity])` is called
+- **THEN** the returned field dict SHALL equal `{"name": <name>, "type": "selection", "required": <required>, "options": ["math","science"], "multiple": True, "default": ["math"]}`
+
+#### Scenario: Default flows through finalize/commit to DataCore PUT payload
+
+- **GIVEN** a finalize request whose extraction has at least one field mapping with `default="9"`
+- **WHEN** `POST /tenants/{tenant_id}/finalize/commit` is processed
+- **THEN** the JSON body sent in the `httpx.put` call to DataCore's `/models/{tenant_id}` endpoint SHALL contain that field's dict with `"default": "9"` under `model_definition[<entity_type>][<bucket>]`
+
+### Requirement: `modelToExtraction` SHALL restore `default` when reopening a saved model
+
+The `modelToExtraction` helper in `papermite/frontend/src/api/client.ts` SHALL copy each field's `default` (when present in the stored model) into the corresponding `FieldMapping.default` of the produced `ExtractionResult`. If `default` is absent in the stored model, `FieldMapping.default` SHALL be `undefined`.
+
+#### Scenario: Existing default round-trips into the Review page
+
+- **GIVEN** a stored model definition for entity `student` whose `custom_fields` contains `{"name": "school_year", "type": "str", "required": false, "default": "2026-2027"}`
+- **WHEN** the user opens the model via LandingPage → Edit
+- **THEN** the Review page SHALL show the corresponding row's Default cell displaying `"2026-2027"`
+- **AND** the in-memory `FieldMapping.default` for that row SHALL equal `"2026-2027"`
+
+#### Scenario: Field without stored default produces undefined
+
+- **GIVEN** a stored model definition where a field has no `default` key
+- **WHEN** the model is opened via `modelToExtraction`
+- **THEN** the corresponding `FieldMapping.default` SHALL be `undefined`
+- **AND** the Default cell SHALL render blank
+
+### Requirement: AdminDash DynamicForm SHALL prefill from `field.default` when no override exists
+
+In `admindash/frontend/src/components/DynamicForm.tsx`, the `buildValues` function SHALL compute the initial value for each field using the precedence:
+
+1. `overrides?.[field.name]` (the existing `initialValues` argument) when present;
+2. otherwise `field.default` when it is not `undefined`;
+3. otherwise the existing fallback (`false` for `bool`, `''` otherwise).
+
+The behavior of `initialValues` overriding the default SHALL apply both to the initial render and to the `useEffect` that re-populates values when `initialValues` changes (e.g., after document extraction).
+
+#### Scenario: Add form prefills from default when no initialValues passed
+
+- **GIVEN** a model whose `custom_fields` contains `{"name": "school_year", "type": "str", "required": false, "default": "2026-2027"}`
+- **AND** `DynamicForm` is rendered with no `initialValues` for `school_year`
+- **WHEN** the form mounts
+- **THEN** the `school_year` input SHALL display the value `"2026-2027"`
+
+#### Scenario: User can edit the prefilled default
+
+- **GIVEN** the form prefilled `school_year` to `"2026-2027"` from its default
+- **WHEN** the user changes the input to `"2027-2028"` and submits
+- **THEN** the `onSubmit` callback SHALL receive `customFields.school_year === "2027-2028"`
+
+#### Scenario: initialValues override the default
+
+- **GIVEN** a field with `default: "9"` and `DynamicForm` is rendered with `initialValues: { grade_level: "11" }`
+- **WHEN** the form mounts
+- **THEN** the `grade_level` input SHALL display `"11"` (not `"9"`)
+
+#### Scenario: Field with no default and no initialValues falls back to empty
+
+- **GIVEN** a `str` field with `default: undefined` and no `initialValues` entry
+- **WHEN** the form mounts
+- **THEN** the input SHALL display the empty string
+
+#### Scenario: Bool field default of true prefills the checkbox
+
+- **GIVEN** a `bool` field with `default: true` and no `initialValues` entry
+- **WHEN** the form mounts
+- **THEN** the checkbox SHALL be checked
+
+#### Scenario: Selection (single) default prefills the radio group
+
+- **GIVEN** a `selection` field with `multiple: false`, `options: ["9","10","11"]`, `default: "10"`
+- **WHEN** the form mounts
+- **THEN** the radio for `"10"` SHALL be selected and the others SHALL NOT be
+
+#### Scenario: Selection (multi) default prefills the checkboxes
+
+- **GIVEN** a `selection` field with `multiple: true`, `options: ["math","science","history"]`, `default: ["math","science"]`
+- **WHEN** the form mounts
+- **THEN** the checkboxes for `"math"` and `"science"` SHALL be checked and `"history"` SHALL NOT be
+
+#### Scenario: Edit mode (initialValues is the existing entity) still wins
+
+- **GIVEN** a field with `default: "9"` and the user opens the Edit dialog for an entity whose stored value is `"12"`
+- **WHEN** `DynamicForm` is rendered with `initialValues: { grade_level: "12" }`
+- **THEN** the input SHALL display `"12"`
+
+### Requirement: Changing a field's type SHALL clear its default
+
+When the tenant admin changes the data type of a field via the type `<select>` in `FieldRow`, `handleTypeChange` in `EntityCard.tsx` SHALL set `default` to `undefined` on the affected mapping in the same immutable update that changes `field_type`. This mirrors the existing rule that clears `options` and `multiple` when switching away from `selection`, and applies to every type transition (including selection-to-selection-with-different-multiple, which is covered by the separate `multiple`-toggle requirement below).
+
+#### Scenario: Switching str to number clears the default
+
+- **GIVEN** a custom field with `field_type: "str"` and `default: "abc"`
+- **WHEN** the user changes the type to `number` via the type `<select>`
+- **THEN** the resulting mapping SHALL have `field_type: "number"` and `default: undefined`
+
+#### Scenario: Switching selection to str clears the default
+
+- **GIVEN** a custom field with `field_type: "selection"`, `multiple: false`, `options: ["a","b"]`, `default: "a"`
+- **WHEN** the user changes the type to `str`
+- **THEN** the resulting mapping SHALL have `field_type: "str"`, `options: undefined`, `multiple: undefined`, and `default: undefined`
+
+#### Scenario: Switching str to selection clears the default
+
+- **GIVEN** a custom field with `field_type: "str"` and `default: "abc"`
+- **WHEN** the user changes the type to `selection`
+- **THEN** the resulting mapping SHALL have `field_type: "selection"`, `options: []`, `multiple: false`, and `default: undefined`
+
+### Requirement: Toggling `multiple` on a selection field SHALL clear its default
+
+When the tenant admin toggles the `multiple` checkbox in `OptionsEditor` (the "Allow multiple" control), `handleOptionsChange` in `EntityCard.tsx` SHALL set `default` to `undefined` on the affected mapping in the same immutable update that flips `multiple`. Changes to `options` alone (adding or removing an option without toggling `multiple`) SHALL NOT clear the default.
+
+#### Scenario: Toggling single to multi clears the default
+
+- **GIVEN** a selection field with `multiple: false`, `options: ["math","science"]`, `default: "math"`
+- **WHEN** the user checks the "Allow multiple" checkbox
+- **THEN** the resulting mapping SHALL have `multiple: true` and `default: undefined`
+
+#### Scenario: Toggling multi to single clears the default
+
+- **GIVEN** a selection field with `multiple: true`, `options: ["math","science"]`, `default: ["math"]`
+- **WHEN** the user unchecks the "Allow multiple" checkbox
+- **THEN** the resulting mapping SHALL have `multiple: false` and `default: undefined`
+
+#### Scenario: Adding an option does not clear the default
+
+- **GIVEN** a selection field with `multiple: false`, `options: ["math","science"]`, `default: "math"`
+- **WHEN** the user adds the option `"history"` via `OptionsEditor`
+- **THEN** the resulting mapping SHALL have `options: ["math","science","history"]`, `multiple: false`, and `default: "math"` (unchanged)
+
+### Requirement: AdminDash `DynamicForm` SHALL coerce prefilled number defaults to Number
+
+In `admindash/frontend/src/components/DynamicForm.tsx`, when `buildValues` resolves the prefill for a field with `field.type === 'number'`, and the resolved value is not `''`, `null`, or `undefined`, the function SHALL pass that value through `Number(...)` before assigning it into the values map. If the conversion yields `NaN`, the field's value SHALL fall back to `''` (the existing empty-string fallback for non-bool types).
+
+This rule applies whether the prefill source is `overrides[field.name]` or `field.default`. It does NOT apply to fields of other types.
+
+#### Scenario: Number default of "9" prefills as the number 9
+
+- **GIVEN** a field with `type: "number"` and `default: "9"`, with no `initialValues` for the field
+- **WHEN** the form mounts
+- **THEN** the values map for that field SHALL equal `9` (the number), not `"9"` (the string)
+- **AND** if the user submits without editing the field, the submitted `customFields` SHALL contain `9` (number)
+
+#### Scenario: Number default of 9 (already a number) prefills unchanged
+
+- **GIVEN** a field with `type: "number"` and `default: 9`
+- **WHEN** the form mounts
+- **THEN** the values map for that field SHALL equal `9`
+
+#### Scenario: Invalid number default falls back to empty
+
+- **GIVEN** a field with `type: "number"` and `default: "abc"`
+- **WHEN** the form mounts
+- **THEN** the values map for that field SHALL equal `''` (the empty-string fallback for non-bool)
+- **AND** the field SHALL render as an empty `<input type="number">`

--- a/openspec/changes/field-default-values/tasks.md
+++ b/openspec/changes/field-default-values/tasks.md
@@ -1,0 +1,41 @@
+## 1. Papermite backend — model and finalize
+
+- [ ] 1.1 Add `default: Optional[Any] = None` to `FieldMapping` in `papermite/backend/app/models/extraction.py`.
+- [ ] 1.2 Update `_build_model_definition` in `papermite/backend/app/api/finalize.py` so each field dict includes `"default": mapping.default` only when `mapping.default is not None`. MUST NOT emit `"default": null`. Apply to both `base_fields` and `custom_fields` branches.
+- [ ] 1.3 Add tests in `papermite/backend/tests/test_finalize_helpers.py` covering: (a) field with `default` → key present in output, (b) field with `default=None` → key absent (not `"default": null`), (c) selection field with multi default `["math"]` → preserved verbatim, (d) bool default `False` → key present with value `False` (not omitted).
+- [ ] 1.4 Add a test in `papermite/backend/tests/test_finalize_api.py` (or extend an existing finalize-commit integration test) asserting the PUT payload to DataCore's `/models/{tenant_id}` carries `default` for fields that set it.
+- [ ] 1.5 Add a test asserting that a model whose fields previously had no `default` keys, re-finalized with no defaults added, produces a PUT payload byte-identical (after DataCore normalize) to the prior version — i.e., no spurious version bump.
+
+## 2. Papermite frontend — types, FieldRow, EntityCard, AddFieldForm
+
+- [ ] 2.1 In `papermite/frontend/src/types/models.ts`, add `default?: unknown` to both `FieldMapping` and `FieldDefinition`.
+- [ ] 2.2 In `papermite/frontend/src/components/FieldRow.tsx`: add new props `defaultVal: unknown` and `onDefaultChange: (fieldName: string, value: unknown) => void`. (Use `defaultVal`, not `default` — JS reserved word — nor `defaultValue` — DOM-reserved prop name on form elements.) Render a new `<td className="field-row__default">` positioned between the existing `<td className="field-row__value">` and the data-type `<td>`. Reuse the inline-edit state pattern (`editingDefault`, `editDefault`, `handleDefaultSave`, key handlers) — mirror the value cell. For `selection` (single), render a `<select>` with `— none —`; for `selection` (multi), render the checkbox group. For `bool`, render a bound `<input type="checkbox">`. For all other types (`str`/`number`/`date`/`datetime`/`email`/`phone`), use the click-to-edit `<input>` (plain text — same pattern as the existing Value cell).
+- [ ] 2.3 Treat an empty trimmed string committed in the Default cell as "clear default": call `onDefaultChange(fieldName, undefined)`. For multi-select with an empty array, also call with `undefined`. For single-select where the user picks the `— none —` option, call with `undefined`.
+- [ ] 2.4 In `papermite/frontend/src/components/EntityCard.tsx`:
+  - Add `<th>Default</th>` to the table header between `<th>Value</th>` and `<th>Data Type</th>`.
+  - Add `handleDefaultChange(fieldName, value)` mirroring `handleFieldUpdate`'s shape, updating `field_mappings[i].default`.
+  - **Modify `handleTypeChange`**: in the immutable update, also set `default: undefined` on the affected mapping (alongside the existing `options`/`multiple` resets). The cleared default must be `undefined` (not absent), so the spread preserves the change.
+  - **Modify `handleOptionsChange`**: when the new `multiple` differs from the prior `multiple` value on the mapping, also set `default: undefined`. When only `options` changes (multiple unchanged), preserve the existing default. (Read the prior mapping in the `.map` callback to detect the toggle.)
+  - Pass `defaultVal={mapping.default}` and `onDefaultChange={handleDefaultChange}` through to each `FieldRow`.
+- [ ] 2.5 In `papermite/frontend/src/components/AddFieldForm.tsx`: add an optional Default input below the existing inputs. Hide it when the selected type is `selection`. Render a checkbox for `bool`. Render a plain text `<input>` for all other types. On submit, attach `default: <value>` (or omit if empty) to the new `FieldMapping`. Extend the `onAdd` callback signature (or add a sibling param) to carry the optional default — also update `EntityCard.handleAddField` to pass it into the new mapping.
+- [ ] 2.6 In `papermite/frontend/src/api/client.ts`, update `modelToExtraction()` to copy `default` from each stored field into the produced `FieldMapping` (only set the property if defined in the source, mirroring the conditional spread pattern used for `options`/`multiple`).
+- [ ] 2.7 Extend `FieldRow.test.tsx` covering: (a) clicking an empty Default cell enters edit, (b) Enter commits, (c) Escape cancels, (d) clearing the input commits `undefined`, (e) bool checkbox toggle sets `true`/`false`, (f) selection-single picking `— none —` commits `undefined`, (g) selection-multi checkboxes set arrays, (h) selection-multi empty array commits `undefined`.
+- [ ] 2.8 Add a test (in `FieldRow.test.tsx` or a new `EntityCard.test.tsx`) covering `handleTypeChange` clears `default`, and `handleOptionsChange` clears `default` on `multiple` toggle but NOT on options-only change.
+
+## 3. AdminDash frontend — types and DynamicForm prefill
+
+- [ ] 3.1 In `admindash/frontend/src/types/models.ts`, add `default?: unknown` to `ModelFieldDefinition`.
+- [ ] 3.2 In `admindash/frontend/src/components/DynamicForm.tsx`:
+  - Change `buildValues` so each field's initial value is computed as `overrides?.[field.name] ?? field.default ?? (field.type === 'bool' ? false : '')`.
+  - For `field.type === 'number'`: after resolving the prefill, if the value is not `''`, `null`, or `undefined`, coerce via `Number(...)`. If the result is `NaN`, fall back to `''`.
+  - Apply the same precedence inside the `useEffect` that re-populates from `initialValues` (the existing `if (val != null && val !== '')` guard preserves user-typed values — verify the default-prefilled value is not stomped by a later empty `initialValues` push).
+- [ ] 3.3 Verify by manual browser test that `AddStudentModal`, `ProgramPage` (Add), and any other `DynamicForm` Add caller correctly prefill from `field.default`, and that Edit callers (which pass the entity as `initialValues`) still show the saved value. (Note: AdminDash frontend has no test framework — manual verification only, per `admindash/CLAUDE.md`.)
+
+## 4. End-to-end verification
+
+- [ ] 4.1 In Papermite, upload a document, set a Default value for a base field (e.g., `grade_level = "9"`) and a custom field, finalize. Verify via DataCore's `/api/query` or `/models/{tenant_id}` that the stored model definition contains the `default` keys.
+- [ ] 4.2 Reopen the same model in Papermite (Landing → Edit). Verify the Default cells render the previously-set values. Change a field's type and confirm the Default cell clears.
+- [ ] 4.3 In AdminDash, open Add Student. Verify the form prefills the fields with `default` set in Papermite, and that the user can edit them before saving. Submit without editing a prefilled `number` field and confirm the persisted value is numeric (not a string) via DataCore `/api/query`.
+- [ ] 4.4 In AdminDash, open Edit on an existing student whose `grade_level` differs from the default. Verify the form shows the saved value (default does not override).
+- [ ] 4.5 In Papermite, re-finalize a model that already exists in DataCore without changing any defaults. Verify the response status is `"unchanged"` (no version bump) — confirms byte-equality with pre-feature models.
+- [ ] 4.6 Run `cd papermite/backend && uv run pytest -v` and `cd papermite/frontend && npm run lint && npm run build` and `cd admindash/frontend && npm run lint && npm run build` — all SHALL pass.

--- a/papermite/backend/app/api/finalize.py
+++ b/papermite/backend/app/api/finalize.py
@@ -200,6 +200,8 @@ def _build_model_definition(entities: list[EntityResult]) -> dict:
             if field_type == "selection":
                 field_def["options"] = mapping.options or []
                 field_def["multiple"] = mapping.multiple or False
+            if mapping.default is not None:
+                field_def["default"] = mapping.default
 
             if mapping.source == "base_model":
                 base_fields.append(field_def)

--- a/papermite/backend/app/models/extraction.py
+++ b/papermite/backend/app/models/extraction.py
@@ -25,6 +25,7 @@ class FieldMapping(BaseModel):
     field_type: Literal["str", "number", "bool", "date", "datetime", "email", "phone", "selection"] = "str"
     options: Optional[list[str]] = None
     multiple: Optional[bool] = None
+    default: Optional[Any] = None
 
 
 class EntityResult(BaseModel):

--- a/papermite/backend/tests/test_finalize_api.py
+++ b/papermite/backend/tests/test_finalize_api.py
@@ -450,3 +450,69 @@ def test_finalize_does_not_attempt_tenant_work_when_model_put_fails():
     assert len(put_calls) == 1
     assert "/models/t1" in put_calls[0]["url"]
     assert mock_post.call_count == 0
+
+
+def test_finalize_commit_sends_default_in_datacore_put():
+    """Defaults on FieldMappings flow into the PUT payload to DataCore /api/models."""
+    payload = {
+        "extraction": {
+            "extraction_id": "e2",
+            "tenant_id": "t1",
+            "filename": "app.pdf",
+            "entities": [
+                {
+                    "entity_type": "student",
+                    "entity": {"first_name": "Sam", "school_year": "2026-2027"},
+                    "field_mappings": [
+                        {
+                            "field_name": "first_name",
+                            "value": "Sam",
+                            "source": "base_model",
+                            "required": True,
+                            "field_type": "str",
+                        },
+                        {
+                            "field_name": "school_year",
+                            "value": "",
+                            "source": "custom_field",
+                            "required": False,
+                            "field_type": "str",
+                            "default": "2026-2027",
+                        },
+                        {
+                            "field_name": "is_active",
+                            "value": "",
+                            "source": "custom_field",
+                            "required": False,
+                            "field_type": "bool",
+                            "default": False,
+                        },
+                    ],
+                }
+            ],
+            "status": "pending_review",
+        }
+    }
+
+    captured = {}
+
+    def fake_put(url, *, json, timeout):  # noqa: ARG001
+        captured["url"] = url
+        captured["json"] = json
+        return MagicMock(
+            status_code=200,
+            json=MagicMock(return_value=_datacore_response_payload(json["model_definition"])),
+        )
+
+    with patch("app.api.finalize.httpx.put", side_effect=fake_put):
+        resp = client.post("/api/tenants/t1/finalize/commit", json=payload)
+
+    assert resp.status_code == 200, resp.text
+    md = captured["json"]["model_definition"]
+    student_custom = md["student"]["custom_fields"]
+    school_year = next(f for f in student_custom if f["name"] == "school_year")
+    assert school_year["default"] == "2026-2027"
+    is_active = next(f for f in student_custom if f["name"] == "is_active")
+    assert is_active["default"] is False
+    first_name = next(f for f in md["student"]["base_fields"] if f["name"] == "first_name")
+    assert "default" not in first_name

--- a/papermite/backend/tests/test_finalize_helpers.py
+++ b/papermite/backend/tests/test_finalize_helpers.py
@@ -227,3 +227,100 @@ def test_fetch_existing_tenant_row_raises_502_on_connection_error():
 
     assert exc_info.value.status_code == 502
     assert exc_info.value.detail == "Failed to persist tenant from extraction"
+
+
+def test_build_model_definition_omits_default_when_none():
+    """A field with default=None must NOT emit 'default' (not even as null)."""
+    from app.api.finalize import _build_model_definition
+    from app.models.extraction import EntityResult, FieldMapping
+
+    entity = EntityResult(
+        entity_type="student",
+        entity={"first_name": "Sam"},
+        field_mappings=[
+            FieldMapping(
+                field_name="first_name", value="Sam",
+                source="base_model", required=True, field_type="str",
+            ),
+        ],
+    )
+    md = _build_model_definition([entity])
+    field = md["student"]["base_fields"][0]
+    assert "default" not in field
+    assert field == {"name": "first_name", "type": "str", "required": True}
+
+
+def test_build_model_definition_includes_default_when_set():
+    """A field with a non-None default emits 'default'."""
+    from app.api.finalize import _build_model_definition
+    from app.models.extraction import EntityResult, FieldMapping
+
+    entity = EntityResult(
+        entity_type="student",
+        entity={"school_year": "2026-2027"},
+        field_mappings=[
+            FieldMapping(
+                field_name="school_year", value="2026-2027",
+                source="custom_field", required=False, field_type="str",
+                default="2026-2027",
+            ),
+        ],
+    )
+    md = _build_model_definition([entity])
+    field = md["student"]["custom_fields"][0]
+    assert field == {
+        "name": "school_year",
+        "type": "str",
+        "required": False,
+        "default": "2026-2027",
+    }
+
+
+def test_build_model_definition_preserves_bool_false_default():
+    """default=False is a meaningful value and MUST be persisted."""
+    from app.api.finalize import _build_model_definition
+    from app.models.extraction import EntityResult, FieldMapping
+
+    entity = EntityResult(
+        entity_type="student",
+        entity={"is_active": False},
+        field_mappings=[
+            FieldMapping(
+                field_name="is_active", value=True,
+                source="custom_field", required=False, field_type="bool",
+                default=False,
+            ),
+        ],
+    )
+    md = _build_model_definition([entity])
+    field = md["student"]["custom_fields"][0]
+    assert field["default"] is False
+
+
+def test_build_model_definition_preserves_selection_multi_default():
+    """Selection (multi) default preserved verbatim alongside options/multiple."""
+    from app.api.finalize import _build_model_definition
+    from app.models.extraction import EntityResult, FieldMapping
+
+    entity = EntityResult(
+        entity_type="student",
+        entity={"subjects": ["math"]},
+        field_mappings=[
+            FieldMapping(
+                field_name="subjects", value=["math"],
+                source="custom_field", required=False, field_type="selection",
+                options=["math", "science", "history"], multiple=True,
+                default=["math"],
+            ),
+        ],
+    )
+    md = _build_model_definition([entity])
+    field = md["student"]["custom_fields"][0]
+    assert field == {
+        "name": "subjects",
+        "type": "selection",
+        "required": False,
+        "options": ["math", "science", "history"],
+        "multiple": True,
+        "default": ["math"],
+    }

--- a/papermite/frontend/src/api/client.ts
+++ b/papermite/frontend/src/api/client.ts
@@ -146,6 +146,7 @@ export function modelToExtraction(
         field_type: field.type,
         ...(field.options && { options: field.options }),
         ...(field.multiple !== undefined && { multiple: field.multiple }),
+        ...(field.default !== undefined && { default: field.default }),
       });
     }
 
@@ -160,6 +161,7 @@ export function modelToExtraction(
         field_type: field.type,
         ...(field.options && { options: field.options }),
         ...(field.multiple !== undefined && { multiple: field.multiple }),
+        ...(field.default !== undefined && { default: field.default }),
       });
     }
 

--- a/papermite/frontend/src/components/AddFieldForm.tsx
+++ b/papermite/frontend/src/components/AddFieldForm.tsx
@@ -1,20 +1,23 @@
 import { useState } from "react";
 
 interface Props {
-  onAdd: (fieldName: string, value: string) => void;
+  onAdd: (fieldName: string, value: string, defaultVal?: string) => void;
 }
 
 export default function AddFieldForm({ onAdd }: Props) {
   const [open, setOpen] = useState(false);
   const [name, setName] = useState("");
   const [value, setValue] = useState("");
+  const [defaultVal, setDefaultVal] = useState("");
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!name.trim()) return;
-    onAdd(name.trim(), value);
+    const trimmedDefault = defaultVal.trim();
+    onAdd(name.trim(), value, trimmedDefault === "" ? undefined : trimmedDefault);
     setName("");
     setValue("");
+    setDefaultVal("");
     setOpen(false);
   };
 
@@ -44,6 +47,12 @@ export default function AddFieldForm({ onAdd }: Props) {
         placeholder="value"
         value={value}
         onChange={(e) => setValue(e.target.value)}
+      />
+      <input
+        className="input"
+        placeholder="default (optional)"
+        value={defaultVal}
+        onChange={(e) => setDefaultVal(e.target.value)}
       />
       <button className="btn btn--primary btn--sm" type="submit">
         Add

--- a/papermite/frontend/src/components/EntityCard.test.tsx
+++ b/papermite/frontend/src/components/EntityCard.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import EntityCard from "./EntityCard";
+import type { EntityResult } from "../types/models";
+
+function makeEntity(): EntityResult {
+  return {
+    entity_type: "STUDENT",
+    entity: { grade_level: "9", subjects: ["math"] },
+    field_mappings: [
+      {
+        field_name: "grade_level",
+        value: "9",
+        source: "custom_field",
+        required: false,
+        field_type: "str",
+        default: "9",
+      },
+      {
+        field_name: "subjects",
+        value: ["math"],
+        source: "custom_field",
+        required: false,
+        field_type: "selection",
+        options: ["math", "science"],
+        multiple: true,
+        default: ["math"],
+      },
+    ],
+  };
+}
+
+describe("EntityCard", () => {
+  it("renders a Default column header between Value and Data Type", () => {
+    const entity = makeEntity();
+    render(<EntityCard entity={entity} index={0} onUpdate={() => {}} />);
+    const headers = screen.getAllByRole("columnheader").map((h) => h.textContent?.trim() ?? "");
+    const valueIdx = headers.indexOf("Value");
+    const defaultIdx = headers.indexOf("Default");
+    const dataTypeIdx = headers.indexOf("Data Type");
+    expect(valueIdx).toBeGreaterThanOrEqual(0);
+    expect(defaultIdx).toBe(valueIdx + 1);
+    expect(dataTypeIdx).toBe(defaultIdx + 1);
+  });
+
+  it("clears default when a field's type changes", () => {
+    const entity = makeEntity();
+    let latest: EntityResult | null = null;
+    render(
+      <EntityCard
+        entity={entity}
+        index={0}
+        onUpdate={(_, updated) => {
+          latest = updated;
+        }}
+      />
+    );
+    const typeSelects = screen.getAllByRole("combobox").filter(
+      (el) => el.classList.contains("field-row__type-select")
+    );
+    const gradeLevelType = typeSelects[0];
+    fireEvent.change(gradeLevelType, { target: { value: "number" } });
+    expect(latest).not.toBeNull();
+    const grade = latest!.field_mappings.find((m) => m.field_name === "grade_level")!;
+    expect(grade.field_type).toBe("number");
+    expect(grade.default).toBeUndefined();
+  });
+
+  it("clears default when multiple toggles on a selection field", () => {
+    const entity = makeEntity();
+    let latest: EntityResult | null = null;
+    const { container } = render(
+      <EntityCard
+        entity={entity}
+        index={0}
+        onUpdate={(_, updated) => {
+          latest = updated;
+        }}
+      />
+    );
+    const optionsButtons = container.querySelectorAll(".field-row__options-btn");
+    fireEvent.click(optionsButtons[0]);
+    const multipleCheckbox = container.querySelector(
+      ".options-editor__multiple input[type='checkbox']"
+    ) as HTMLInputElement;
+    fireEvent.click(multipleCheckbox);
+    expect(latest).not.toBeNull();
+    const subjects = latest!.field_mappings.find((m) => m.field_name === "subjects")!;
+    expect(subjects.multiple).toBe(false);
+    expect(subjects.default).toBeUndefined();
+  });
+
+  it("does NOT clear default when only options change (no multi toggle)", () => {
+    const entity = makeEntity();
+    let latest: EntityResult | null = null;
+    const { container } = render(
+      <EntityCard
+        entity={entity}
+        index={0}
+        onUpdate={(_, updated) => {
+          latest = updated;
+        }}
+      />
+    );
+    const optionsButtons = container.querySelectorAll(".field-row__options-btn");
+    fireEvent.click(optionsButtons[0]);
+    const addInput = container.querySelector(
+      ".options-editor__input"
+    ) as HTMLInputElement;
+    fireEvent.change(addInput, { target: { value: "history" } });
+    const addBtn = container.querySelector(
+      ".options-editor__add .btn"
+    ) as HTMLButtonElement;
+    fireEvent.click(addBtn);
+    expect(latest).not.toBeNull();
+    const subjects = latest!.field_mappings.find((m) => m.field_name === "subjects")!;
+    expect(subjects.options).toEqual(["math", "science", "history"]);
+    expect(subjects.multiple).toBe(true);
+    expect(subjects.default).toEqual(["math"]);
+  });
+});

--- a/papermite/frontend/src/components/EntityCard.tsx
+++ b/papermite/frontend/src/components/EntityCard.tsx
@@ -47,6 +47,7 @@ export default function EntityCard({ entity, index, onUpdate }: Props) {
         ? {
             ...m,
             field_type,
+            default: undefined,
             // Reset selection-specific fields when switching away
             ...(field_type !== "selection" ? { options: undefined, multiple: undefined } : {}),
             // Init selection defaults when switching to selection
@@ -59,8 +60,23 @@ export default function EntityCard({ entity, index, onUpdate }: Props) {
 
   const handleOptionsChange = (fieldName: string, options: string[], multiple: boolean) => {
     const updated = { ...entity };
+    updated.field_mappings = updated.field_mappings.map((m) => {
+      if (m.field_name !== fieldName) return m;
+      const multipleChanged = m.multiple !== multiple;
+      return {
+        ...m,
+        options,
+        multiple,
+        ...(multipleChanged ? { default: undefined } : {}),
+      };
+    });
+    onUpdate(index, updated);
+  };
+
+  const handleDefaultChange = (fieldName: string, value: unknown) => {
+    const updated = { ...entity };
     updated.field_mappings = updated.field_mappings.map((m) =>
-      m.field_name === fieldName ? { ...m, options, multiple } : m
+      m.field_name === fieldName ? { ...m, default: value } : m
     );
     onUpdate(index, updated);
   };
@@ -174,6 +190,7 @@ export default function EntityCard({ entity, index, onUpdate }: Props) {
             <tr>
               <th>Field</th>
               <th>Value</th>
+              <th>Default</th>
               <th>Data Type</th>
               <th>Source</th>
               <th>Required</th>
@@ -194,10 +211,12 @@ export default function EntityCard({ entity, index, onUpdate }: Props) {
                 fieldType={mapping.field_type}
                 options={mapping.options}
                 multiple={mapping.multiple}
+                defaultVal={mapping.default}
                 onUpdate={handleFieldUpdate}
                 onRequiredToggle={handleRequiredToggle}
                 onTypeChange={handleTypeChange}
                 onOptionsChange={handleOptionsChange}
+                onDefaultChange={handleDefaultChange}
                 onFieldNameChange={
                   mapping.source === "custom_field"
                     ? handleFieldNameChange

--- a/papermite/frontend/src/components/EntityCard.tsx
+++ b/papermite/frontend/src/components/EntityCard.tsx
@@ -151,7 +151,7 @@ export default function EntityCard({ entity, index, onUpdate }: Props) {
     onUpdate(index, updated);
   };
 
-  const handleAddField = (fieldName: string, value: string) => {
+  const handleAddField = (fieldName: string, value: string, defaultVal?: string) => {
     const updated = { ...entity };
     updated.entity = { ...updated.entity, [fieldName]: value };
     const cf = {
@@ -161,7 +161,14 @@ export default function EntityCard({ entity, index, onUpdate }: Props) {
     updated.entity.custom_fields = cf;
     updated.field_mappings = [
       ...updated.field_mappings,
-      { field_name: fieldName, value, source: "custom_field" as const, required: false, field_type: "str" as const },
+      {
+        field_name: fieldName,
+        value,
+        source: "custom_field" as const,
+        required: false,
+        field_type: "str" as const,
+        ...(defaultVal !== undefined ? { default: defaultVal } : {}),
+      },
     ];
     onUpdate(index, updated);
   };

--- a/papermite/frontend/src/components/FieldRow.test.tsx
+++ b/papermite/frontend/src/components/FieldRow.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, within } from "@testing-library/react";
 import FieldRow from "./FieldRow";
 import type { FieldType } from "../types/models";
 
@@ -11,6 +11,7 @@ interface FieldRowTestProps {
   fieldType?: FieldType;
   options?: string[];
   multiple?: boolean;
+  defaultVal?: unknown;
   onUpdate?: (fieldName: string, value: unknown) => void;
   onRequiredToggle?: (fieldName: string, required: boolean) => void;
   onTypeChange?: (fieldName: string, fieldType: FieldType) => void;
@@ -19,6 +20,7 @@ interface FieldRowTestProps {
     options: string[],
     multiple: boolean
   ) => void;
+  onDefaultChange?: (fieldName: string, value: unknown) => void;
   onDelete?: () => void;
 }
 
@@ -27,6 +29,7 @@ function renderRow(overrides: FieldRowTestProps = {}) {
   const onRequiredToggle = overrides.onRequiredToggle ?? vi.fn();
   const onTypeChange = overrides.onTypeChange ?? vi.fn();
   const onOptionsChange = overrides.onOptionsChange ?? vi.fn();
+  const onDefaultChange = overrides.onDefaultChange ?? vi.fn();
 
   const utils = render(
     <table>
@@ -39,17 +42,19 @@ function renderRow(overrides: FieldRowTestProps = {}) {
           fieldType={overrides.fieldType ?? "str"}
           options={overrides.options}
           multiple={overrides.multiple}
+          defaultVal={overrides.defaultVal}
           onUpdate={onUpdate}
           onRequiredToggle={onRequiredToggle}
           onTypeChange={onTypeChange}
           onOptionsChange={onOptionsChange}
+          onDefaultChange={onDefaultChange}
           onDelete={overrides.onDelete}
         />
       </tbody>
     </table>
   );
 
-  return { ...utils, onUpdate, onRequiredToggle, onTypeChange, onOptionsChange };
+  return { ...utils, onUpdate, onRequiredToggle, onTypeChange, onOptionsChange, onDefaultChange };
 }
 
 describe("FieldRow", () => {
@@ -69,8 +74,6 @@ describe("FieldRow", () => {
 
   it("renders a <select> inline for single-select with options (no click required)", () => {
     const { onUpdate } = renderRow({
-      // base_model so the data-type column renders a locked <span>, not a <select>;
-      // this keeps the Value cell's <select> the only combobox in the row.
       source: "base_model",
       required: true,
       value: "Active",
@@ -79,7 +82,9 @@ describe("FieldRow", () => {
       multiple: false,
     });
 
-    const select = screen.getByRole("combobox") as HTMLSelectElement;
+    // Scope to the Value cell so the Default cell's <select> doesn't interfere.
+    const valueCell = screen.getByTestId("field-row-value");
+    const select = within(valueCell).getByRole("combobox") as HTMLSelectElement;
     expect(select).toBeInTheDocument();
     expect(select.value).toBe("Active");
     const optionValues = Array.from(select.options).map((o) => o.value);
@@ -100,13 +105,9 @@ describe("FieldRow", () => {
       multiple: true,
     });
 
-    const checkboxes = screen.getAllByRole("checkbox");
-    // The Required column also has a checkbox, so we filter by accessible name.
-    const optionBoxes = checkboxes.filter((cb) =>
-      ["Mon", "Tue", "Wed"].some((label) =>
-        cb.closest("label")?.textContent?.includes(label)
-      )
-    );
+    // Scope to the Value cell so the Default cell's checkboxes don't interfere.
+    const valueCell = screen.getByTestId("field-row-value");
+    const optionBoxes = within(valueCell).getAllByRole("checkbox");
     expect(optionBoxes).toHaveLength(3);
     expect((optionBoxes[0] as HTMLInputElement).checked).toBe(true);
     expect((optionBoxes[1] as HTMLInputElement).checked).toBe(false);
@@ -128,5 +129,95 @@ describe("FieldRow", () => {
     expect(screen.getByText("seed")).toBeInTheDocument();
     fireEvent.click(screen.getByText("seed"));
     expect(screen.getByDisplayValue("seed")).toBeInTheDocument();
+  });
+
+  it("renders an empty Default cell click-to-edit input", () => {
+    const { onDefaultChange } = renderRow({ fieldType: "str" });
+    const cell = screen.getByTestId("field-row-default");
+    const display = cell.querySelector(".field-row__default-display") as HTMLElement;
+    expect(display).toBeInTheDocument();
+    fireEvent.click(display);
+    const input = cell.querySelector("input") as HTMLInputElement;
+    expect(input).toBeInTheDocument();
+    expect(input.value).toBe("");
+    fireEvent.change(input, { target: { value: "9" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onDefaultChange).toHaveBeenCalledWith("grade_level", "9");
+  });
+
+  it("Escape in the Default input cancels without firing onDefaultChange", () => {
+    const { onDefaultChange } = renderRow({ fieldType: "str", defaultVal: "9" });
+    const cell = screen.getByTestId("field-row-default");
+    const display = cell.querySelector(".field-row__default-display") as HTMLElement;
+    fireEvent.click(display);
+    const input = cell.querySelector("input") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "11" } });
+    fireEvent.keyDown(input, { key: "Escape" });
+    expect(onDefaultChange).not.toHaveBeenCalled();
+  });
+
+  it("clearing the Default input commits undefined (not the empty string)", () => {
+    const { onDefaultChange } = renderRow({ fieldType: "str", defaultVal: "9" });
+    const cell = screen.getByTestId("field-row-default");
+    const display = cell.querySelector(".field-row__default-display") as HTMLElement;
+    fireEvent.click(display);
+    const input = cell.querySelector("input") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onDefaultChange).toHaveBeenCalledWith("grade_level", undefined);
+  });
+
+  it("bool Default cell renders a checkbox bound to defaultVal", () => {
+    const { onDefaultChange } = renderRow({ fieldType: "bool", defaultVal: false });
+    const cell = screen.getByTestId("field-row-default");
+    const checkbox = cell.querySelector("input[type='checkbox']") as HTMLInputElement;
+    expect(checkbox.checked).toBe(false);
+    fireEvent.click(checkbox);
+    expect(onDefaultChange).toHaveBeenCalledWith("grade_level", true);
+  });
+
+  it("selection-single Default cell renders a <select> with — none — option", () => {
+    const { onDefaultChange } = renderRow({
+      fieldType: "selection",
+      options: ["9", "10", "11"],
+      multiple: false,
+      defaultVal: "10",
+    });
+    const cell = screen.getByTestId("field-row-default");
+    const select = cell.querySelector("select") as HTMLSelectElement;
+    expect(select.value).toBe("10");
+    const optionValues = Array.from(select.options).map((o) => o.value);
+    expect(optionValues).toEqual(["", "9", "10", "11"]);
+    fireEvent.change(select, { target: { value: "" } });
+    expect(onDefaultChange).toHaveBeenCalledWith("grade_level", undefined);
+  });
+
+  it("selection-multi Default cell renders checkboxes and commits arrays", () => {
+    const { onDefaultChange } = renderRow({
+      fieldType: "selection",
+      options: ["math", "science", "history"],
+      multiple: true,
+      defaultVal: ["math"],
+    });
+    const cell = screen.getByTestId("field-row-default");
+    const checkboxes = cell.querySelectorAll<HTMLInputElement>("input[type='checkbox']");
+    expect(checkboxes).toHaveLength(3);
+    expect(checkboxes[0].checked).toBe(true);
+    expect(checkboxes[1].checked).toBe(false);
+    fireEvent.click(checkboxes[1]);
+    expect(onDefaultChange).toHaveBeenCalledWith("grade_level", ["math", "science"]);
+  });
+
+  it("selection-multi clearing the last checked option commits undefined", () => {
+    const { onDefaultChange } = renderRow({
+      fieldType: "selection",
+      options: ["math", "science"],
+      multiple: true,
+      defaultVal: ["math"],
+    });
+    const cell = screen.getByTestId("field-row-default");
+    const checkboxes = cell.querySelectorAll<HTMLInputElement>("input[type='checkbox']");
+    fireEvent.click(checkboxes[0]);
+    expect(onDefaultChange).toHaveBeenCalledWith("grade_level", undefined);
   });
 });

--- a/papermite/frontend/src/components/FieldRow.tsx
+++ b/papermite/frontend/src/components/FieldRow.tsx
@@ -10,10 +10,12 @@ interface Props {
   fieldType: FieldType;
   options?: string[];
   multiple?: boolean;
+  defaultVal?: unknown;
   onUpdate: (fieldName: string, value: unknown) => void;
   onRequiredToggle: (fieldName: string, required: boolean) => void;
   onTypeChange: (fieldName: string, fieldType: FieldType) => void;
   onOptionsChange: (fieldName: string, options: string[], multiple: boolean) => void;
+  onDefaultChange?: (fieldName: string, value: unknown) => void;
   onFieldNameChange?: (
     oldName: string,
     newName: string
@@ -108,10 +110,12 @@ export default function FieldRow({
   fieldType,
   options,
   multiple,
+  defaultVal,
   onUpdate,
   onRequiredToggle,
   onTypeChange,
   onOptionsChange,
+  onDefaultChange,
   onFieldNameChange,
   onDelete,
 }: Props) {
@@ -121,6 +125,8 @@ export default function FieldRow({
   const [editingName, setEditingName] = useState(false);
   const [editName, setEditName] = useState(fieldName);
   const [nameError, setNameError] = useState<string | null>(null);
+  const [editingDefault, setEditingDefault] = useState(false);
+  const [editDefault, setEditDefault] = useState(toEditString(defaultVal));
 
   useEffect(() => {
     if (nameError === null) return;
@@ -171,6 +177,50 @@ export default function FieldRow({
     }
   };
 
+  const handleDefaultSave = () => {
+    if (!onDefaultChange) {
+      setEditingDefault(false);
+      setEditDefault(toEditString(defaultVal));
+      return;
+    }
+    const trimmed = editDefault.trim();
+    const next = trimmed === "" ? undefined : trimmed;
+    onDefaultChange(fieldName, next);
+    setEditingDefault(false);
+  };
+
+  const handleDefaultKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleDefaultSave();
+    }
+    if (e.key === "Escape") {
+      setEditingDefault(false);
+      setEditDefault(toEditString(defaultVal));
+    }
+  };
+
+  const handleDefaultSelectionSingle = (newValue: string) => {
+    if (!onDefaultChange) return;
+    onDefaultChange(fieldName, newValue === "" ? undefined : newValue);
+  };
+
+  const handleDefaultSelectionMulti = (option: string, checked: boolean) => {
+    if (!onDefaultChange) return;
+    const current = Array.isArray(defaultVal)
+      ? defaultVal.filter((s): s is string => typeof s === "string")
+      : [];
+    const next = checked
+      ? [...current, option]
+      : current.filter((s) => s !== option);
+    onDefaultChange(fieldName, next.length === 0 ? undefined : next);
+  };
+
+  const handleDefaultBool = (checked: boolean) => {
+    if (!onDefaultChange) return;
+    onDefaultChange(fieldName, checked);
+  };
+
   const displayValue = toEditString(value) || "—";
 
   const isBase = source === "base_model";
@@ -208,7 +258,7 @@ export default function FieldRow({
             </div>
           )}
         </td>
-        <td className="field-row__value">
+        <td className="field-row__value" data-testid="field-row-value">
           {fieldType === "selection" && (options?.length ?? 0) > 0 ? (
             multiple ? (
               (() => {
@@ -277,6 +327,64 @@ export default function FieldRow({
               title="Click to edit"
             >
               {displayValue}
+            </span>
+          )}
+        </td>
+        <td className="field-row__default" data-testid="field-row-default">
+          {fieldType === "selection" && (options?.length ?? 0) > 0 ? (
+            multiple ? (
+              (() => {
+                const selected = Array.isArray(defaultVal)
+                  ? defaultVal.filter((s): s is string => typeof s === "string")
+                  : [];
+                return (options ?? []).map((opt) => (
+                  <label key={opt} className="field-row__default-multi-label">
+                    <input
+                      type="checkbox"
+                      checked={selected.includes(opt)}
+                      onChange={(e) => handleDefaultSelectionMulti(opt, e.target.checked)}
+                    />
+                    {opt}
+                  </label>
+                ));
+              })()
+            ) : (
+              <select
+                className="input field-row__input"
+                value={typeof defaultVal === "string" ? defaultVal : ""}
+                onChange={(e) => handleDefaultSelectionSingle(e.target.value)}
+              >
+                <option value="">— none —</option>
+                {(options ?? []).map((opt) => (
+                  <option key={opt} value={opt}>{opt}</option>
+                ))}
+              </select>
+            )
+          ) : fieldType === "bool" ? (
+            <input
+              type="checkbox"
+              checked={Boolean(defaultVal)}
+              onChange={(e) => handleDefaultBool(e.target.checked)}
+            />
+          ) : editingDefault ? (
+            <input
+              className="input field-row__input"
+              value={editDefault}
+              onChange={(e) => setEditDefault(e.target.value)}
+              onBlur={handleDefaultSave}
+              onKeyDown={handleDefaultKeyDown}
+              autoFocus
+            />
+          ) : (
+            <span
+              className="field-row__default-display"
+              onClick={() => {
+                setEditDefault(toEditString(defaultVal));
+                setEditingDefault(true);
+              }}
+              title="Click to edit default"
+            >
+              {toEditString(defaultVal) || "—"}
             </span>
           )}
         </td>

--- a/papermite/frontend/src/components/FieldRow.tsx
+++ b/papermite/frontend/src/components/FieldRow.tsx
@@ -446,7 +446,7 @@ export default function FieldRow({
       </tr>
       {showOptions && fieldType === "selection" && (
         <tr className="field-row__options-row">
-          <td colSpan={6}>
+          <td colSpan={7}>
             <OptionsEditor
               options={options ?? []}
               multiple={multiple ?? false}

--- a/papermite/frontend/src/db/indexedDb.ts
+++ b/papermite/frontend/src/db/indexedDb.ts
@@ -39,3 +39,34 @@ export async function deleteDraft(extractionId: string): Promise<void> {
   const db = await getDb();
   await db.delete(STORE_NAME, extractionId);
 }
+
+// ── Edit-flow original snapshot (sessionStorage, per tab) ──────
+//
+// The Review page's "no changes detected" Finalize-disabled gate needs a
+// baseline that is durable across remounts. A useRef inside ReviewPage
+// resets every time the page unmounts (e.g., user navigates to the
+// Finalize/Confirm step and back), causing the post-back snapshot to equal
+// the already-edited draft and falsely report "no changes." Storing the
+// snapshot in sessionStorage when the edit flow starts (LandingPage)
+// survives remounts within the tab and gets cleared on
+// finalize-confirm or finalize-cancel.
+
+const EDIT_ORIGINAL_KEY_PREFIX = "papermite-edit-original-";
+
+export function saveEditOriginal(extraction: ExtractionResult): void {
+  sessionStorage.setItem(
+    EDIT_ORIGINAL_KEY_PREFIX + extraction.extraction_id,
+    JSON.stringify(extraction),
+  );
+}
+
+export function getEditOriginal(
+  extractionId: string,
+): ExtractionResult | null {
+  const raw = sessionStorage.getItem(EDIT_ORIGINAL_KEY_PREFIX + extractionId);
+  return raw ? (JSON.parse(raw) as ExtractionResult) : null;
+}
+
+export function clearEditOriginal(extractionId: string): void {
+  sessionStorage.removeItem(EDIT_ORIGINAL_KEY_PREFIX + extractionId);
+}

--- a/papermite/frontend/src/pages/FinalizedPage.tsx
+++ b/papermite/frontend/src/pages/FinalizedPage.tsx
@@ -6,7 +6,7 @@ import type {
   ModelDefinition,
   TestUser,
 } from "../types/models";
-import { getDraft, deleteDraft } from "../db/indexedDb";
+import { getDraft, deleteDraft, clearEditOriginal } from "../db/indexedDb";
 import { commitFinalize, getActiveModel } from "../api/client";
 import "./FinalizedPage.css";
 
@@ -266,7 +266,10 @@ export default function FinalizedPage({ user }: Props) {
     setStatus("committing");
     try {
       await commitFinalize(user.tenant_id, extraction);
-      if (id) deleteDraft(id);
+      if (id) {
+        deleteDraft(id);
+        clearEditOriginal(id);
+      }
       if (returnUrl) {
         window.location.href = returnUrl;
       } else {
@@ -279,7 +282,10 @@ export default function FinalizedPage({ user }: Props) {
   };
 
   const handleCancel = () => {
-    if (id) deleteDraft(id);
+    if (id) {
+      deleteDraft(id);
+      clearEditOriginal(id);
+    }
     if (returnUrl) {
       window.location.href = returnUrl;
     } else {

--- a/papermite/frontend/src/pages/FinalizedPage.tsx
+++ b/papermite/frontend/src/pages/FinalizedPage.tsx
@@ -186,6 +186,9 @@ export default function FinalizedPage({ user }: Props) {
               fieldDef.options = mapping.options || [];
               fieldDef.multiple = mapping.multiple || false;
             }
+            if (mapping.default !== undefined) {
+              fieldDef.default = mapping.default;
+            }
             if (mapping.source === "base_model") {
               baseFields.push(fieldDef);
             } else {

--- a/papermite/frontend/src/pages/LandingPage.tsx
+++ b/papermite/frontend/src/pages/LandingPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import type { TestUser, TenantModel } from "../types/models";
 import { getActiveModel, modelToExtraction } from "../api/client";
-import { saveDraft } from "../db/indexedDb";
+import { saveDraft, saveEditOriginal } from "../db/indexedDb";
 import TenantInfo from "../components/TenantInfo";
 import "../components/TenantInfo.css";
 import "./LandingPage.css";
@@ -31,6 +31,7 @@ export default function LandingPage({ user }: Props) {
     if (!model) return;
     const extraction = modelToExtraction(model);
     await saveDraft(extraction);
+    saveEditOriginal(extraction);
     navigate(`/review/${extraction.extraction_id}${forwardQs}`);
   };
 

--- a/papermite/frontend/src/pages/ReviewPage.tsx
+++ b/papermite/frontend/src/pages/ReviewPage.tsx
@@ -22,6 +22,7 @@ function hasChanges(original: ExtractionResult, current: ExtractionResult): bool
       if (om.field_type !== cm.field_type) return true;
       if (JSON.stringify(om.options ?? []) !== JSON.stringify(cm.options ?? [])) return true;
       if ((om.multiple ?? false) !== (cm.multiple ?? false)) return true;
+      if (JSON.stringify(om.default ?? null) !== JSON.stringify(cm.default ?? null)) return true;
     }
   }
   return false;

--- a/papermite/frontend/src/pages/ReviewPage.tsx
+++ b/papermite/frontend/src/pages/ReviewPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import type { EntityResult, ExtractionResult } from "../types/models";
-import { getDraft, saveDraft } from "../db/indexedDb";
+import { getDraft, getEditOriginal, saveDraft } from "../db/indexedDb";
 import EntityCard from "../components/EntityCard";
 import "./ReviewPage.css";
 
@@ -47,7 +47,8 @@ export default function ReviewPage() {
         if (draft) {
           setExtraction(draft);
           if (!originalRef.current) {
-            originalRef.current = JSON.parse(JSON.stringify(draft));
+            const saved = getEditOriginal(draft.extraction_id);
+            originalRef.current = saved ?? JSON.parse(JSON.stringify(draft));
           }
         } else {
           navigate("/");

--- a/papermite/frontend/src/types/models.ts
+++ b/papermite/frontend/src/types/models.ts
@@ -18,6 +18,7 @@ export interface FieldMapping {
   field_type: FieldType;
   options?: string[];
   multiple?: boolean;
+  default?: unknown;
 }
 
 export interface EntityResult {
@@ -54,6 +55,7 @@ export interface FieldDefinition {
   required: boolean;
   options?: string[];
   multiple?: boolean;
+  default?: unknown;
 }
 
 export interface EntityModelDefinition {


### PR DESCRIPTION
## Summary

Implements OpenSpec change [`field-default-values`](openspec/changes/field-default-values/). Tenant admins can now set a per-field default in Papermite's form builder; AdminDash's Add Entity form prefills those defaults (still editable).

- Papermite Review page gains a **Default** column between Value and Data Type, with per-type editors (text click-to-edit / checkbox / select / checkbox group).
- `FieldMapping` and stored `FieldDefinition` carry an optional `default`. The key is **omitted** (not `null`) when unset, preserving byte-equality with pre-feature models in DataCore's `normalize`-then-compare.
- AdminDash `DynamicForm.buildValues` prefills from `field.default` (`overrides ?? default ?? empty`); `number` defaults are coerced via `Number(...)` to avoid submitting strings on untouched fields.
- Changing a field's type or toggling `multiple` clears the default (avoids stale shapes; per design decisions D8/D9).
- Closes #70.

## Implementation

13 commits on this branch. Backend (`papermite/backend/`), Papermite frontend (`papermite/frontend/`), AdminDash frontend (`admindash/frontend/`). DataCore unchanged.

3 follow-on fixes surfaced during manual verification:
- `fix(papermite): include default in Review page change detection` — `hasChanges` was missing `default`, so the Finalize button stayed disabled after editing a default.
- `fix(papermite): preserve edit-flow original snapshot across ReviewPage remounts` — `useRef` original reset on remount, so navigating Finalize → back lost the change-detected state. Moved to sessionStorage; cleared on finalize-confirm/cancel.
- `fix(papermite): include default in FinalizedPage client-side preview model` — duplicate client-side model builder didn't include `default`, causing "no changes detected" on the preview page when only a default was edited.

These point at a structural duplication (`_build_model_definition` in Python and the FinalizedPage preview builder in TS both produce a model_definition from the draft). Worth a future consolidation but out of scope here.

## Spec

See [`openspec/changes/field-default-values/`](openspec/changes/field-default-values/) for proposal, design (11 decisions), specs (6 requirements / 33 scenarios), and tasks.

## Test plan

- [x] `uv run pytest -v` in `papermite/backend/tests/test_finalize_helpers.py` + `test_finalize_api.py` (28 passed)
- [x] `npx vitest run` in `papermite/frontend/` (16 passed: 12 FieldRow + 4 EntityCard)
- [x] `npm run build` in `papermite/frontend/` and `admindash/frontend/`
- [x] Manual end-to-end:
  - Set default in Papermite → finalize → confirm `default` key in stored model
  - Reopen for edit → defaults shown; type change clears default
  - AdminDash Add Student prefilled from defaults; user-edits and untouched values both persist correctly
  - Edit existing entity → saved value wins over default (initialValues precedence)
  - Re-finalize with no changes → response status `"unchanged"` (no version bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)