### PR TITLE
chore(deploy): scale Fly machines to zero when idle for beta

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,7 @@ NeoApex deploys to Fly.io (Python backends) and Cloudflare Workers with Static A
 - [`docs/deployment/provisioning.md`](docs/deployment/provisioning.md) — one-time setup runbook (Fly.io account, Cloudflare Workers, DNS, secrets, first deploy)
 - [`docs/deployment/release-runbook.md`](docs/deployment/release-runbook.md) — cutting releases, approving deploys, rolling back
 - [`docs/deployment/follow-ups.md`](docs/deployment/follow-ups.md) — deferred hardening and nice-to-haves
+- [`docs/deployment/cost-control.md`](docs/deployment/cost-control.md) — scale-to-zero config for beta idle, cold-start expectations, wake/sleep commands
 
 ## Conventions
 

--- a/datacore/fly.toml
+++ b/datacore/fly.toml
@@ -21,9 +21,17 @@ primary_region = "sjc"
 
 # Internal service on Fly's private network. No [http_service] means the app
 # is NOT reachable from the public internet.
+#
+# auto_stop_machines / min_machines_running are set so the machine suspends
+# when idle. Sibling apps calling `datacore.flycast:5800` will auto-wake it
+# (~3–5s cold start + LanceDB load). Set to "off" / 1 if cold starts become
+# disruptive to beta testers.
 [[services]]
   protocol = "tcp"
   internal_port = 5800
+  auto_stop_machines = "suspend"
+  auto_start_machines = true
+  min_machines_running = 0
 
   [[services.ports]]
     port = 5800

--- a/docs/deployment/cost-control.md
+++ b/docs/deployment/cost-control.md
@@ -1,0 +1,142 @@
+# Cost Control — Beta Idle Mode
+
+NeoApex on Fly.io was originally tuned for "always-warm" production traffic.
+For beta testing — where the platform sits idle for days at a time — we
+want every machine to scale to zero when no one is using it.
+
+This doc explains what we changed, how to verify it, and how to bring the
+fleet back online when you want to test.
+
+## Summary of changes
+
+| App | Before | After | Effect |
+|---|---|---|---|
+| `papermite-api` | `min_machines_running = 1` on `[http_service]`; no auto-stop on internal `[[services]]` | `min_machines_running = 0` on both; `auto_stop_machines` on the internal service | 4gb / 2-CPU machine suspends when idle (~$31/mo → ~$0) |
+| `launchpad-api` | `min_machines_running = 1` | `min_machines_running = 0` | 512mb machine suspends when idle |
+| `datacore` | No auto-stop on its TCP `[[services]]` block (ran 24/7) | `auto_stop_machines = "suspend"` + `min_machines_running = 0` | Suspends when no sibling app is calling it; wakes on next `datacore.flycast:5800` request |
+| `admindash-api` | Already `min_machines_running = 0` | unchanged | No change needed — already scaled to zero |
+
+Estimated idle savings: **~$35–40/month** in compute. See "Residual idle costs"
+below for what we did not eliminate.
+
+## How auto-stop works on Fly
+
+- `auto_stop_machines = "suspend"` — machine RAM is checkpointed to disk;
+  wake is fast (~hundreds of ms). Costs a small amount of disk while suspended.
+- `auto_stop_machines = "stop"` — full shutdown. No suspend-disk cost but
+  cold start is several seconds longer.
+- `auto_start_machines = true` — Fly's proxy will boot the machine on the
+  next incoming request. This works for `[http_service]` AND `[[services]]`
+  blocks reached via `<app>.flycast`.
+- `min_machines_running = 0` — Fly is allowed to stop the last machine.
+  With `1`, at least one machine stays warm regardless.
+
+We chose `suspend` because beta testing flows are interactive and a couple
+of seconds of cold start is more disruptive than the tiny suspend-disk fee.
+
+## Cold start expectations
+
+| App | First request after idle |
+|---|---|
+| `launchpad-api` | ~2–3s |
+| `admindash-api` | ~2–3s (FastAPI cold start) |
+| `papermite-api` | ~5–8s (4gb machine + docling/libmagic warmup) |
+| `datacore` | ~3–5s + LanceDB load (depends on table count) |
+
+Cold-start chains compound. A user clicking "Upload" in admindash from
+fully-cold cold may trigger: admindash wake → datacore wake → papermite wake
+in sequence. Worst-case first request after a week of idle: ~15–20s.
+Subsequent requests are normal latency until idle again.
+
+## Bringing the fleet back online for a testing session
+
+You generally do not need to. The next user request will wake everything via
+`auto_start_machines`. If you want to pre-warm to avoid making testers see
+cold-start latency:
+
+```bash
+# Wake every public app (a single curl is enough — Fly's proxy starts the machine on the first request)
+curl -sI https://api.launchpad.floatify.com/api/health
+curl -sI https://api.papermite.floatify.com/api/health
+curl -sI https://api.admin.floatify.com/api/health
+
+# datacore is private — wake it by calling it from a sibling app, or:
+fly machine start -a datacore <machine-id>   # find the id with `fly machine list -a datacore`
+```
+
+Status check:
+
+```bash
+fly status -a datacore
+fly status -a launchpad-api
+fly status -a papermite-api
+fly status -a admindash-api
+```
+
+A machine in `state: started` is warm. `stopped` or `suspended` is idle.
+
+## If you want to force everything OFF (deepest idle)
+
+```bash
+fly scale count 0 -a datacore
+fly scale count 0 -a launchpad-api
+fly scale count 0 -a papermite-api
+fly scale count 0 -a admindash-api
+```
+
+This guarantees zero compute charges and disables `auto_start_machines` —
+the next request will 503 until you scale back up:
+
+```bash
+fly scale count 1 -a datacore
+fly scale count 1 -a launchpad-api
+fly scale count 1 -a papermite-api
+fly scale count 1 -a admindash-api
+```
+
+Use this only if you are going weeks without testing and want to avoid
+even the (small) suspend-disk fee. Auto-stop covers the normal case.
+
+## Deploying the changes
+
+These config edits are picked up on the next `fly deploy`. The repo's release
+pipeline (see `release-runbook.md`) handles deploys, but you can also deploy
+the config-only changes directly:
+
+```bash
+fly deploy -a datacore       --config datacore/fly.toml      --remote-only
+fly deploy -a launchpad-api  --config launchpad/fly.toml     --remote-only
+fly deploy -a papermite-api  --config papermite/fly.toml     --remote-only
+```
+
+(`admindash-api` was not changed, so no deploy needed.)
+
+## Residual idle costs we did not eliminate
+
+Even with everything suspended, the following keep accruing:
+
+- **`datacore_data` volume (3gb)** — ~$0.45/mo. Required to preserve LanceDB
+  data between sessions. Snapshot retention is 7 daily snapshots, small.
+- **Dedicated IPv4 addresses on the 3 public apps** — Fly charges ~$2/mo
+  for each *dedicated* IPv4. As of 2026-05-27 our fleet uses **shared
+  IPv4 + dedicated IPv6** on `launchpad-api`, `papermite-api`, and
+  `admindash-api`. Dedicated IPv6 is free, so we are not paying for IPs.
+
+  If a future change moves an app to dedicated IPv4 (e.g. allocated via
+  `fly ips allocate-v4 -a <app>`), release it with:
+
+  ```bash
+  fly ips list -a <app>                    # confirm `public ingress (dedicated)` on a v4 entry
+  fly ips release <address> -a <app>       # only safe with Cloudflare in front
+  ```
+
+Total residual idle cost after all changes: **~$0.50–1/month** (volume +
+snapshots only).
+
+## Reverting
+
+If beta load picks up and cold starts become unacceptable, restore warm
+machines per app by changing `min_machines_running = 0` back to `1` in the
+relevant `fly.toml` and redeploying. The `auto_stop_machines` settings can
+stay — they only kick in when there is no traffic, so warming `min_machines_running`
+back up is sufficient.

--- a/launchpad/fly.toml
+++ b/launchpad/fly.toml
@@ -25,7 +25,7 @@ primary_region = "sjc"
   force_https = true
   auto_stop_machines = true
   auto_start_machines = true
-  min_machines_running = 1
+  min_machines_running = 0
   processes = ["app"]
 
   [[http_service.checks]]

--- a/papermite/fly.toml
+++ b/papermite/fly.toml
@@ -28,7 +28,7 @@ primary_region = "sjc"
   force_https = true
   auto_stop_machines = true
   auto_start_machines = true
-  min_machines_running = 1
+  min_machines_running = 0
   processes = ["app"]
 
   [[http_service.checks]]
@@ -42,9 +42,15 @@ primary_region = "sjc"
 # reach papermite via `http://papermite-api.flycast:5710` without going
 # through the public http_service TLS pipeline. admindash-api uses this
 # path for document extraction.
+#
+# Auto-stop is set here too — without it, this service would keep the
+# machine warm even when [http_service] above asks for scale-to-zero.
 [[services]]
   protocol = "tcp"
   internal_port = 5710
+  auto_stop_machines = "suspend"
+  auto_start_machines = true
+  min_machines_running = 0
 
   [[services.ports]]
     port = 5710


### PR DESCRIPTION
## Summary
- Lets every Fly machine suspend/stop when no traffic hits it, cutting ~\$35/mo of idle compute during beta testing.
- `launchpad-api` and `papermite-api`: `min_machines_running 1 → 0`. Papermite needed auto-stop on its internal `[[services]]` block too — otherwise the 4gb machine stays warm regardless of `[http_service]` settings.
- `datacore`: `auto_stop_machines = "suspend"` + `min_machines_running = 0` on its TCP `[[services]]` block; sibling apps auto-wake it via `datacore.flycast:5800` (~3–5s cold start + LanceDB load).
- `admindash-api` unchanged — already correctly configured.
- New `docs/deployment/cost-control.md` documents the change, cold-start expectations, wake/sleep commands, and residual idle costs.

## Already deployed
These config changes were applied directly via `fly deploy --config <path> --remote-only` for datacore / launchpad-api / papermite-api before opening this PR — this PR exists to bring git in sync with what is already running. Post-deploy `fly status` confirmed `suspended` / `stopped` states.

## Test plan
- [ ] Verify CI passes (config-only changes, no app code touched)
- [ ] Manually wake one app via `curl -sI https://api.launchpad.floatify.com/api/health` and confirm it returns 200 within ~3s
- [ ] After ~15min idle, `fly status -a launchpad-api` shows `stopped`
- [ ] After ~15min idle, `fly status -a datacore` shows `suspended`
- [ ] End-to-end smoke: log in via launchpad → navigate to admindash → upload a document via papermite → confirm everything wakes from cold and completes
- [ ] Cold-start chain (worst case: all 4 apps cold) completes within ~20s

🤖 Generated with [Claude Code](https://claude.com/claude-code)