### PR TITLE
fix(admindash): bring program page into spec compliance

### DIFF
--- a/admindash/frontend/src/components/ProgramWeekView.tsx
+++ b/admindash/frontend/src/components/ProgramWeekView.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from 'react';
+import { useState, useMemo } from 'react';
 import { useTranslation } from '../hooks/useTranslation.ts';
 import type { ModelDefinition, ModelFieldDefinition } from '../types/models.ts';
 import CalendarChip from './CalendarChip.tsx';
@@ -96,11 +96,16 @@ export default function ProgramWeekView({
     getWeekStart(weekStart ?? new Date()),
   );
 
-  // Sync external weekStart prop to internal state
-  const externalWeekStart = weekStart;
-  useEffect(() => {
-    if (externalWeekStart) setCurrentWeekStart(getWeekStart(externalWeekStart));
-  }, [externalWeekStart]);
+  // Sync external weekStart prop to internal state by adjusting state during
+  // render when the prop changes — the React-recommended alternative to a
+  // setState-in-effect (see react.dev "You Might Not Need an Effect"). The
+  // parent passes a stable Date reference that only changes on navigation, so
+  // a referential comparison is sufficient.
+  const [prevWeekStart, setPrevWeekStart] = useState<Date | undefined>(weekStart);
+  if (weekStart !== prevWeekStart) {
+    setPrevWeekStart(weekStart);
+    if (weekStart) setCurrentWeekStart(getWeekStart(weekStart));
+  }
 
   // The 7 days of the current week (Mon–Sun)
   const weekDays = useMemo<Date[]>(() => {

--- a/admindash/frontend/src/hooks/useTablePreferences.ts
+++ b/admindash/frontend/src/hooks/useTablePreferences.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef } from 'react';
+import { useState, useCallback } from 'react';
 
 const VALID_PAGE_SIZES = [10, 20, 30, 40, 50] as const;
 type ValidPageSize = (typeof VALID_PAGE_SIZES)[number];
@@ -10,15 +10,33 @@ export interface TablePreferences {
   sortDir: 'asc' | 'desc';
 }
 
-const DEFAULT_PREFS: TablePreferences = {
-  hiddenColumns: [],
-  pageSize: 20,
-  sortBy: 'last_name',
-  sortDir: 'asc',
-};
+/**
+ * Options that scope a preferences slot to a particular table.
+ *
+ * `namespace` partitions storage per entity type so that, e.g., the Programs
+ * table and the Students table do not clobber each other's sort/page-size/hidden
+ * columns. `defaultSortBy` is the fallback sort column when nothing is persisted
+ * yet (e.g. 'last_name' for students, 'name' for programs).
+ */
+export interface UseTablePreferencesOptions {
+  namespace?: string;
+  defaultSortBy?: string;
+}
 
-function buildStorageKey(userId: string, tenantId: string): string {
-  return `admindash_table_prefs_${userId}_${tenantId}`;
+const DEFAULT_NAMESPACE = 'student';
+const DEFAULT_SORT_BY = 'last_name';
+
+function baseDefaults(defaultSortBy: string): TablePreferences {
+  return {
+    hiddenColumns: [],
+    pageSize: 20,
+    sortBy: defaultSortBy,
+    sortDir: 'asc',
+  };
+}
+
+function buildStorageKey(namespace: string, userId: string, tenantId: string): string {
+  return `admindash_table_prefs_${namespace}_${userId}_${tenantId}`;
 }
 
 function validatePageSize(size: number): ValidPageSize {
@@ -28,13 +46,15 @@ function validatePageSize(size: number): ValidPageSize {
 }
 
 function loadPreferences(
+  namespace: string,
   userId: string,
   tenantId: string,
   currentColumns: string[],
+  defaultSortBy: string,
 ): TablePreferences {
-  const key = buildStorageKey(userId, tenantId);
+  const key = buildStorageKey(namespace, userId, tenantId);
   const raw = localStorage.getItem(key);
-  if (!raw) return { ...DEFAULT_PREFS };
+  if (!raw) return baseDefaults(defaultSortBy);
 
   try {
     const parsed = JSON.parse(raw) as Partial<TablePreferences>;
@@ -42,20 +62,21 @@ function loadPreferences(
     return {
       hiddenColumns: (parsed.hiddenColumns ?? []).filter((c) => colSet.has(c)),
       pageSize: validatePageSize(parsed.pageSize ?? 20),
-      sortBy: (parsed.sortBy && colSet.has(parsed.sortBy)) ? parsed.sortBy : DEFAULT_PREFS.sortBy,
+      sortBy: (parsed.sortBy && colSet.has(parsed.sortBy)) ? parsed.sortBy : defaultSortBy,
       sortDir: parsed.sortDir === 'desc' ? 'desc' : 'asc',
     };
   } catch {
-    return { ...DEFAULT_PREFS };
+    return baseDefaults(defaultSortBy);
   }
 }
 
 function savePreferences(
+  namespace: string,
   userId: string,
   tenantId: string,
   prefs: TablePreferences,
 ): void {
-  const key = buildStorageKey(userId, tenantId);
+  const key = buildStorageKey(namespace, userId, tenantId);
   localStorage.setItem(key, JSON.stringify(prefs));
 }
 
@@ -63,30 +84,33 @@ export function useTablePreferences(
   userId: string,
   tenantId: string,
   currentColumns: string[],
+  options: UseTablePreferencesOptions = {},
 ) {
+  const { namespace = DEFAULT_NAMESPACE, defaultSortBy = DEFAULT_SORT_BY } = options;
+
   const [prefs, setPrefs] = useState<TablePreferences>(() =>
-    loadPreferences(userId, tenantId, currentColumns),
+    loadPreferences(namespace, userId, tenantId, currentColumns, defaultSortBy),
   );
 
-  // Re-load preferences when columns, user, or tenant change
-  const prevKey = useRef(`${userId}_${tenantId}_${currentColumns.join(',')}`);
-  useEffect(() => {
-    const key = `${userId}_${tenantId}_${currentColumns.join(',')}`;
-    if (key !== prevKey.current && currentColumns.length > 0) {
-      prevKey.current = key;
-      setPrefs(loadPreferences(userId, tenantId, currentColumns));
-    }
-  }, [userId, tenantId, currentColumns]);
+  // Re-load preferences when namespace, columns, user, or tenant change by
+  // adjusting state during render (the React-recommended alternative to a
+  // setState-in-effect; see react.dev "You Might Not Need an Effect").
+  const key = `${namespace}_${userId}_${tenantId}_${currentColumns.join(',')}`;
+  const [prevKey, setPrevKey] = useState(key);
+  if (key !== prevKey && currentColumns.length > 0) {
+    setPrevKey(key);
+    setPrefs(loadPreferences(namespace, userId, tenantId, currentColumns, defaultSortBy));
+  }
 
   const updatePrefs = useCallback(
     (updates: Partial<TablePreferences>) => {
       setPrefs((prev) => {
         const next = { ...prev, ...updates };
-        savePreferences(userId, tenantId, next);
+        savePreferences(namespace, userId, tenantId, next);
         return next;
       });
     },
-    [userId, tenantId],
+    [namespace, userId, tenantId],
   );
 
   const toggleColumn = useCallback(
@@ -96,11 +120,11 @@ export function useTablePreferences(
           ? prev.hiddenColumns.filter((c) => c !== columnKey)
           : [...prev.hiddenColumns, columnKey];
         const next = { ...prev, hiddenColumns: hidden };
-        savePreferences(userId, tenantId, next);
+        savePreferences(namespace, userId, tenantId, next);
         return next;
       });
     },
-    [userId, tenantId],
+    [namespace, userId, tenantId],
   );
 
   return { prefs, updatePrefs, toggleColumn };

--- a/admindash/frontend/src/i18n/translations.ts
+++ b/admindash/frontend/src/i18n/translations.ts
@@ -148,6 +148,15 @@ export const translations: Record<Locale, Record<string, string>> = {
     'program.calendarTooltipWhere': 'Where',
     'program.calendarTooltipStatus': 'Status',
     'program.calendarTooltipDays': 'Days',
+    'program.editTitle': 'Edit Program',
+    'program.selectedSuffix': 'selected',
+    'program.moreActions': 'More actions',
+    'program.actionsLabel': 'Actions',
+    'program.columnsLabel': 'Columns',
+    'program.editSelected': 'Edit Selected',
+    'program.deleteSelected': 'Delete Selected',
+    'program.exportSelected': 'Export Selected',
+    'program.filterAll': 'All',
 
     // Lead
     'lead.title': 'Lead Management',
@@ -417,6 +426,15 @@ export const translations: Record<Locale, Record<string, string>> = {
     'program.calendarTooltipWhere': '\u5730\u70b9',
     'program.calendarTooltipStatus': '\u72b6\u6001',
     'program.calendarTooltipDays': '\u661f\u671f',
+    'program.editTitle': '\u7f16\u8f91\u8bfe\u7a0b',
+    'program.selectedSuffix': '\u9879\u5df2\u9009',
+    'program.moreActions': '\u66f4\u591a\u64cd\u4f5c',
+    'program.actionsLabel': '\u64cd\u4f5c',
+    'program.columnsLabel': '\u5217',
+    'program.editSelected': '\u7f16\u8f91\u6240\u9009',
+    'program.deleteSelected': '\u5220\u9664\u6240\u9009',
+    'program.exportSelected': '\u5bfc\u51fa\u6240\u9009',
+    'program.filterAll': '\u5168\u90e8',
 
     // Lead
     'lead.title': '\u5ba2\u6237\u7ba1\u7406',

--- a/admindash/frontend/src/pages/ProgramPage.tsx
+++ b/admindash/frontend/src/pages/ProgramPage.tsx
@@ -204,9 +204,6 @@ export default function ProgramPage({ tenant }: ProgramPageProps) {
   const [addSubmitting, setAddSubmitting] = useState(false);
   const [addError, setAddError] = useState<string | null>(null);
 
-  // View-only detail modal (from calendar click)
-  const [viewingEntity, setViewingEntity] = useState<DataRow | null>(null);
-
   // View toggle
   const [activeView, setActiveView] = useState<'list' | 'week' | 'month'>('list');
   const [weekStartDate, setWeekStartDate] = useState<Date | undefined>(undefined);
@@ -228,7 +225,10 @@ export default function ProgramPage({ tenant }: ProgramPageProps) {
 
   // Table preferences
   const userId = user?.user_id ?? 'anonymous';
-  const { prefs, updatePrefs, toggleColumn } = useTablePreferences(userId, tenant, columnKeys);
+  const { prefs, updatePrefs, toggleColumn } = useTablePreferences(userId, tenant, columnKeys, {
+    namespace: 'program',
+    defaultSortBy: 'name',
+  });
 
   // Adaptive page size on mount
   const containerRef = useRef<HTMLDivElement>(null);
@@ -459,7 +459,7 @@ export default function ProgramPage({ tenant }: ProgramPageProps) {
         <div className="programs-edit-overlay">
           <div className="programs-edit-dialog">
             <div className="programs-edit-dialog-header">
-              <h3>Edit Program</h3>
+              <h3>{t('program.editTitle')}</h3>
               <span className="programs-edit-dialog-subtitle">
                 {String(editingEntity.name ?? editingEntity.program_id ?? '')}
               </span>
@@ -474,46 +474,6 @@ export default function ProgramPage({ tenant }: ProgramPageProps) {
                 submitting={editSubmitting}
                 error={editError}
               />
-            </div>
-          </div>
-        </div>
-      )}
-
-      {/* View-only program detail (from calendar click) */}
-      {viewingEntity && model && (
-        <div className="programs-edit-overlay" onClick={() => setViewingEntity(null)}>
-          <div className="programs-edit-dialog" onClick={(e) => e.stopPropagation()}>
-            <div className="programs-edit-dialog-header">
-              <h3>{String(viewingEntity.name ?? viewingEntity.program_id ?? 'Program')}</h3>
-              <span className="programs-edit-dialog-subtitle">
-                {String(viewingEntity.program_id ?? '')}
-              </span>
-            </div>
-            <div className="programs-edit-dialog-body">
-              <div className="programs-detail-grid">
-                {[...model.base_fields, ...model.custom_fields].map((field) => {
-                  const raw = viewingEntity[field.name];
-                  let display = '-';
-                  if (raw != null && raw !== '') {
-                    if (field.type === 'bool') {
-                      display = raw ? 'Yes' : 'No';
-                    } else if (field.type === 'selection') {
-                      display = formatSelectionValue(raw);
-                    } else {
-                      display = String(raw);
-                    }
-                  }
-                  return (
-                    <div className="programs-detail-field" key={field.name}>
-                      <div className="programs-detail-label">{formatFieldLabel(field.name)}</div>
-                      <div className="programs-detail-value">{display}</div>
-                    </div>
-                  );
-                })}
-              </div>
-              <div className="programs-confirm-actions" style={{ marginTop: '1rem' }}>
-                <button onClick={() => setViewingEntity(null)}>{t('common.close')}</button>
-              </div>
             </div>
           </div>
         </div>
@@ -565,7 +525,7 @@ export default function ProgramPage({ tenant }: ProgramPageProps) {
                     value={filters[field.name] ?? ''}
                     onChange={(e) => updateFilter(field.name, e.target.value)}
                   >
-                    <option value="">All</option>
+                    <option value="">{t('program.filterAll')}</option>
                     {field.options.map((opt) => (
                       <option key={opt} value={opt}>{opt}</option>
                     ))}
@@ -573,7 +533,7 @@ export default function ProgramPage({ tenant }: ProgramPageProps) {
                 ) : (
                   <input
                     type="text"
-                    placeholder={`Search ${formatFieldLabel(field.name).toLowerCase()}`}
+                    placeholder={`${t('program.search')} ${formatFieldLabel(field.name).toLowerCase()}`}
                     value={filters[field.name] ?? ''}
                     onChange={(e) => updateFilter(field.name, e.target.value)}
                   />
@@ -591,7 +551,7 @@ export default function ProgramPage({ tenant }: ProgramPageProps) {
 
             {selectedIds.size > 0 && (
               <span className="programs-selected-count">
-                {selectedIds.size} selected
+                {selectedIds.size} {t('program.selectedSuffix')}
               </span>
             )}
 
@@ -600,13 +560,13 @@ export default function ProgramPage({ tenant }: ProgramPageProps) {
               <button
                 className="programs-menu-btn"
                 onClick={() => setShowMenu((prev) => !prev)}
-                aria-label="More actions"
+                aria-label={t('program.moreActions')}
               >
                 ⋮
               </button>
               {showMenu && (
                 <div className="programs-menu-popover">
-                  <div className="programs-menu-section-label">Actions</div>
+                  <div className="programs-menu-section-label">{t('program.actionsLabel')}</div>
                   <button
                     className="programs-menu-item"
                     disabled={selectedIds.size === 0}
@@ -621,24 +581,24 @@ export default function ProgramPage({ tenant }: ProgramPageProps) {
                       }
                     }}
                   >
-                    Edit Selected
+                    {t('program.editSelected')}
                   </button>
                   <button
                     className="programs-menu-item programs-menu-item-danger"
                     disabled={selectedIds.size === 0}
                     onClick={() => { setShowMenu(false); setShowArchiveConfirm(true); }}
                   >
-                    Delete Selected
+                    {t('program.deleteSelected')}
                   </button>
                   <button
                     className="programs-menu-item"
                     disabled={selectedIds.size === 0}
                     onClick={() => { setShowMenu(false); setShowComingSoon(true); }}
                   >
-                    Export Selected
+                    {t('program.exportSelected')}
                   </button>
                   <div className="programs-menu-divider" />
-                  <div className="programs-menu-section-label">Columns</div>
+                  <div className="programs-menu-section-label">{t('program.columnsLabel')}</div>
                   {columns.map((col) => (
                     <label key={col.key} className="programs-menu-column-option">
                       <input
@@ -683,7 +643,7 @@ export default function ProgramPage({ tenant }: ProgramPageProps) {
         <ProgramWeekView
           programs={data}
           model={model}
-          onEditProgram={setViewingEntity}
+          onEditProgram={setEditingEntity}
           weekStart={weekStartDate}
         />
       )}
@@ -692,7 +652,7 @@ export default function ProgramPage({ tenant }: ProgramPageProps) {
         <ProgramMonthView
           programs={data}
           model={model}
-          onEditProgram={setViewingEntity}
+          onEditProgram={setEditingEntity}
           onSwitchToWeek={(date: Date) => {
             setActiveView('week');
             setWeekStartDate(date);

--- a/admindash/frontend/src/pages/StudentsPage.tsx
+++ b/admindash/frontend/src/pages/StudentsPage.tsx
@@ -273,7 +273,10 @@ export default function StudentsPage({ tenant }: StudentsPageProps) {
 
   // Table preferences
   const userId = user?.user_id ?? 'anonymous';
-  const { prefs, updatePrefs, toggleColumn } = useTablePreferences(userId, tenant, columnKeys);
+  const { prefs, updatePrefs, toggleColumn } = useTablePreferences(userId, tenant, columnKeys, {
+    namespace: 'student',
+    defaultSortBy: 'last_name',
+  });
 
   // Adaptive page size on mount
   const containerRef = useRef<HTMLDivElement>(null);

--- a/openspec/changes/admindash-program-page/tasks.md
+++ b/openspec/changes/admindash-program-page/tasks.md
@@ -4,52 +4,61 @@ Already done: `createStudent`, `updateStudent`, `fetchNextStudentId` consolidate
 
 ## 2. UI Tokens Integration
 
-- [ ] 2.1 Add `@neoapex/ui-tokens` dependency to `admindash/frontend/package.json` and import in `index.css` (replacing duplicated token definitions)
-- [ ] 2.2 Add `--warning` and `--warning-muted` tokens to `ui-tokens/tokens.css` (currently only in admindash locally)
-- [ ] 2.3 Ensure all program page CSS uses ui-tokens variables — no hardcoded colors, radii, or shadows. Use tinted pairs for program chips, accent tokens for today highlight, shadow/border tokens for popovers.
+- [x] 2.1 Add `@neoapex/ui-tokens` dependency to `admindash/frontend/package.json` and import in `index.css` (replacing duplicated token definitions)
+- [x] 2.2 Add `--warning` and `--warning-muted` tokens to `ui-tokens/tokens.css` (currently only in admindash locally)
+- [x] 2.3 Ensure all program page CSS uses ui-tokens variables — no hardcoded colors, radii, or shadows. Use tinted pairs for program chips, accent tokens for today highlight, shadow/border tokens for popovers.
 
 ## 3. I18n Translation Keys
 
-- [ ] 2.1 Add program-related translation keys for en-US and zh-CN in `translations.ts`
+- [x] 2.1 Add program-related translation keys for en-US and zh-CN in `translations.ts` (includes menu/toolbar keys added for full M9 compliance: `editTitle`, `selectedSuffix`, `moreActions`, `actionsLabel`, `columnsLabel`, `editSelected`, `deleteSelected`, `exportSelected`, `filterAll`)
 
 ## 4. Dashboard Context
 
-- [ ] 4.1 Add `getProgramCount()` and `invalidateProgramCount()` to DashboardContext
+- [x] 4.1 Add `getProgramCount()` and `invalidateProgramCount()` to DashboardContext
 
 ## 5. Program List View
 
-- [ ] 5.1 Implement ProgramPage with model loading, dynamic column building, data querying, FilterForm, DataTable, sorting, pagination, and row selection
-- [ ] 5.2 Add action menu with disabled states (Edit Selected, Delete Selected, Export Selected) and Columns toggle
-- [ ] 5.3 Add `useTablePreferences('program')` for persistence of sort, page size, hidden columns
-- [ ] 5.4 Add ProgramPage.css with styles for toolbar, filters, menu, and layout
+- [x] 5.1 Implement ProgramPage with model loading, dynamic column building, data querying, FilterForm, DataTable, sorting, pagination, and row selection
+- [x] 5.2 Add action menu with disabled states (Edit Selected, Delete Selected, Export Selected) and Columns toggle
+- [x] 5.3 Add `useTablePreferences` for program with `namespace: 'program'` + `defaultSortBy: 'name'` — persists sort, page size, hidden columns in a program-scoped slot (no longer collides with the Students table)
+- [x] 5.4 Add ProgramPage.css with styles for toolbar, filters, menu, and layout
 
 ## 6. Program CRUD Modals
 
-- [ ] 6.1 Add "Add Program" modal with DynamicForm, auto-generated program ID, and create flow
-- [ ] 6.2 Add "Edit Program" modal with DynamicForm pre-populated from selected row
-- [ ] 6.3 Add archive confirmation dialog with multi-select support
+- [x] 6.1 Add "Add Program" modal with DynamicForm, auto-generated program ID, and create flow
+- [x] 6.2 Add "Edit Program" modal with DynamicForm pre-populated from selected row
+- [x] 6.3 Add archive confirmation dialog with multi-select support
 
 ## 7. Week View
 
-- [ ] 7.1 Build ProgramWeekView component with 7-column CSS Grid, day headers, program chips per day
-- [ ] 7.2 Add week navigation (prev/next week, "Today" button)
-- [ ] 7.3 Add program chip rendering based on date-type fields from model, with click-to-edit
-- [ ] 7.4 Add today column highlight
-- [ ] 7.5 Add empty state for when model has no date fields
+- [x] 7.1 Build ProgramWeekView component with 7-column CSS Grid, day headers, program chips per day
+- [x] 7.2 Add week navigation (prev/next week, "Today" button)
+- [x] 7.3 Add program chip rendering based on date-type fields from model, with click-to-edit (opens the edit modal per spec C11)
+- [x] 7.4 Add today column highlight
+- [x] 7.5 Add empty state for when model has no date fields
 
 ## 8. Month View
 
-- [ ] 8.1 Build ProgramMonthView component with month CSS Grid, day cells, month navigation
-- [ ] 8.2 Add program chip rendering with 2-3 chip cap per cell and "+N more" link
-- [ ] 8.3 Add "+N more" popover listing all programs for a day, with click navigating to week view
-- [ ] 8.4 Add today cell highlight
-- [ ] 8.5 Add ProgramCalendar.css with shared calendar styles (week + month)
+- [x] 8.1 Build ProgramMonthView component with month CSS Grid, day cells, month navigation
+- [x] 8.2 Add program chip rendering with 2-3 chip cap per cell and "+N more" link
+- [x] 8.3 Add "+N more" popover listing all programs for a day, with click navigating to week view
+- [x] 8.4 Add today cell highlight
+- [x] 8.5 Add ProgramCalendar.css with shared calendar styles (week + month)
 
 ## 9. View Toggle
 
-- [ ] 9.1 Add List/Week/Month view toggle buttons in toolbar, persisted via useTablePreferences
+- [x] 9.1 Add List/Week/Month view toggle buttons in toolbar, persisted via useTablePreferences
 
 ## 10. Verification
 
-- [ ] 10.1 Run `npm run build` in admindash/frontend to confirm no TypeScript errors
-- [ ] 10.2 Run `npm run lint` in admindash/frontend to confirm no lint errors
+- [x] 10.1 Run `npm run build` in admindash/frontend to confirm no TypeScript errors — PASSES clean.
+- [~] 10.2 Run `npm run lint` in admindash/frontend. The 2 lint errors touching this change's files (`ProgramWeekView.tsx`, `useTablePreferences.ts`) were fixed by converting setState-in-effect to the React-recommended adjust-state-during-render pattern. 5 pre-existing systemic errors remain in shared infra (`AuthContext`, `ModelContext`, `DashboardContext`, `DynamicForm`) — `react-refresh/only-export-components` on every context file and two older `set-state-in-effect` cases. These are blame-confirmed to predate this change (authored 2026-03-22 → 2026-04-07) and require a codebase-wide refactor (splitting hooks out of context files); tracked as a separate follow-up.
+
+## Post-implementation spec-compliance fixes (2026-07-15)
+
+Verification against the delta specs surfaced three deviations, all now fixed:
+- **C11**: calendar chip click now opens the **edit** modal (was a read-only detail modal). The dead view-only modal + `viewingEntity` state were removed.
+- **L8**: `useTablePreferences` is now namespaced per entity type — Programs and Students no longer clobber each other's persisted table state.
+- **M9**: hardcoded English menu/toolbar strings replaced with i18n keys (en-US + zh-CN).
+
+Note: StudentsPage shares the same M9 hardcoded-string gap for its own menu/toolbar (pre-existing pattern); bringing it to full i18n parity is tracked as a separate follow-up.


### PR DESCRIPTION
## Summary

The `admindash-program-page` OpenSpec change was implemented and shipped (it's live in the admindash-v0.3.0 deploy), but its `tasks.md` was never checked off and it was never archived. A verification pass against the four delta specs found the implementation **nearly complete** with **three deviations** from spec intent. This PR closes all three and completes the change's bookkeeping.

## Deviations fixed

1. **C11 — calendar chip opens the edit modal.** Clicking a program chip in the week/month calendar previously opened a *read-only detail* modal. Spec C11 requires it to open the **edit** modal (the prop was even named `onEditProgram`). Rewired both calendar views to `setEditingEntity`, and removed the now-dead view-only modal + `viewingEntity` state.
2. **L8 — per-entity table preferences.** `useTablePreferences` was keyed only by `(userId, tenant)`, so the Programs and Students tables **shared one localStorage slot** and clobbered each other's sort / page size / hidden columns. Added a `{ namespace, defaultSortBy }` option; Programs use `namespace: 'program'` / `defaultSortBy: 'name'`, Students use `namespace: 'student'` / `defaultSortBy: 'last_name'`.
3. **M9 — i18n.** Hardcoded English menu/toolbar strings (Edit/Delete/Export Selected, Actions, Columns, "N selected", More actions, filter "All", search placeholder) now use translation keys, added for both en-US and zh-CN.

## Also

- Converted two `setState`-in-effect patterns (ProgramWeekView week-sync, useTablePreferences reload) to React's recommended *adjust-state-during-render* pattern — clears the lint errors in this change's own files.

## ⚠️ Reviewer note

Deviation #1 is a **behavioral change**: calendar chips now open the editable form instead of a read-only detail view, and the read-only detail modal is deleted. This matches the written spec, but if the view-first UX was intentional, say so and I'll instead amend the spec to document the read-only behavior.

## Test plan

- [x] `npm run build` (admindash/frontend) — passes clean
- [x] `npm run lint` — the 2 errors in this change's files fixed; 5 pre-existing systemic errors remain in shared context/form files (blame-confirmed to predate this change; tracked as a follow-up)
- [ ] Manual: calendar chip → edit modal; program vs student table prefs no longer collide; zh-CN menu labels

## Follow-ups

- StudentsPage shares the same M9 hardcoded-string gap for its own menu/toolbar — bring to full i18n parity separately.
- 5 pre-existing lint errors (`react-refresh/only-export-components` on every context file; `set-state-in-effect` in AuthContext/DynamicForm) need a codebase-wide refactor.
- After merge: archive the `admindash-program-page` OpenSpec change and sync its delta specs into `openspec/specs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)