### PR TITLE
feat(papermite): multi-file upload & append-to-existing-model (#53)

### DIFF
--- a/papermite/backend/app/api/upload.py
+++ b/papermite/backend/app/api/upload.py
@@ -8,7 +8,7 @@ from app.api.auth import require_admin
 from app.config import settings
 from app.models.registry import UserRecord
 from app.models.extraction import ExtractionResult
-from app.services.mapper import map_extraction
+from app.services.mapper import map_extraction, merge_raw_extractions
 from app.services.extraction_pipeline import extract_for_discovery
 
 router = APIRouter()
@@ -20,34 +20,47 @@ ALLOWED_EXTENSIONS = {".pdf", ".docx", ".txt"}
 def upload_document(
     tenant_id: str,
     response: Response,
-    file: UploadFile = File(...),
+    files: list[UploadFile] = File(...),
     model_id: str = Form(default=settings.default_model),
     user: UserRecord = Depends(require_admin),
 ):
-    """Upload a document, extract entities, and return the mapped result."""
+    """Upload one or more documents, extract entities from each, and return the
+    merged mapped result. Multiple files are extracted independently and their
+    entities merged into a single field union per entity type."""
     if user.tenant_id != tenant_id:
         raise HTTPException(status_code=403, detail="Tenant mismatch")
 
-    # Validate file type
-    suffix = Path(file.filename or "").suffix.lower()
-    if suffix not in ALLOWED_EXTENSIONS:
-        raise HTTPException(
-            status_code=400,
-            detail=f"Unsupported file type: {suffix}. Allowed: {ALLOWED_EXTENSIONS}",
-        )
+    if not files:
+        raise HTTPException(status_code=400, detail="No files provided")
 
-    # Save uploaded file
+    # Validate all file types up front
+    for f in files:
+        suffix = Path(f.filename or "").suffix.lower()
+        if suffix not in ALLOWED_EXTENSIONS:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Unsupported file type: {suffix}. Allowed: {ALLOWED_EXTENSIONS}",
+            )
+
     upload_dir = settings.upload_dir / tenant_id
     upload_dir.mkdir(parents=True, exist_ok=True)
-    file_path = upload_dir / file.filename
-    with file_path.open("wb") as f:
-        shutil.copyfileobj(file.file, f)
 
     try:
-        # Run discovery extraction → map to ExtractionResult
-        raw_extraction = extract_for_discovery(file_path, model_id)
-        result = map_extraction(raw_extraction, tenant_id, file.filename)
+        raw_extractions = []
+        filenames = []
+        for f in files:
+            file_path = upload_dir / f.filename
+            with file_path.open("wb") as out:
+                shutil.copyfileobj(f.file, out)
+            raw_extractions.append(extract_for_discovery(file_path, model_id))
+            filenames.append(f.filename)
+
+        merged_raw = merge_raw_extractions(raw_extractions)
+        combined_name = filenames[0] if len(filenames) == 1 else ", ".join(filenames)
+        result = map_extraction(merged_raw, tenant_id, combined_name)
         response.headers["X-Papermite-Parser-Backend"] = settings.parser_backend
         return result
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/papermite/backend/app/services/mapper.py
+++ b/papermite/backend/app/services/mapper.py
@@ -264,6 +264,31 @@ def _consolidate_entities(entities: list[EntityResult]) -> list[EntityResult]:
     return list(by_type.values())
 
 
+def merge_raw_extractions(raws: list[RawExtraction]) -> RawExtraction:
+    """Merge several per-file RawExtractions into one before mapping.
+
+    Entity lists are concatenated — `map_extraction`'s `_consolidate_entities`
+    then merges same-type entities into a single field union. The tenant dict is
+    shallow-merged, with the first non-empty value for each key winning so an
+    earlier document's data is not clobbered by a later blank.
+    """
+    merged = RawExtraction()
+    tenant: dict[str, Any] = {}
+    for raw in raws:
+        if raw.tenant:
+            for key, value in raw.tenant.items():
+                if key not in tenant or tenant[key] in (None, "", [], {}):
+                    tenant[key] = value
+        merged.programs.extend(raw.programs)
+        merged.students.extend(raw.students)
+        merged.families.extend(raw.families)
+        merged.contacts.extend(raw.contacts)
+        merged.enrollments.extend(raw.enrollments)
+        merged.registration_applications.extend(raw.registration_applications)
+    merged.tenant = tenant or None
+    return merged
+
+
 def map_extraction(raw: RawExtraction, tenant_id: str, filename: str) -> ExtractionResult:
     """Map a RawExtraction into an ExtractionResult with field provenance."""
     entities: list[EntityResult] = []

--- a/papermite/backend/tests/test_mapper.py
+++ b/papermite/backend/tests/test_mapper.py
@@ -325,3 +325,37 @@ def test_placeholder_attendance_is_added_despite_no_raw_field():
 
     # tenant_id is the caller-provided value
     assert att.entity["tenant_id"] == "t1"
+
+
+# --- merge_raw_extractions (multi-file upload, issue #53) ---
+from app.services.mapper import merge_raw_extractions  # noqa: E402
+
+
+def test_merge_raw_extractions_unions_fields_across_files():
+    """Two files each contributing different student fields merge into one
+    student with the union of fields."""
+    file_a = RawExtraction(students=[{"first_name": "Ada", "grade_level": "3"}])
+    file_b = RawExtraction(students=[{"last_name": "Lovelace", "dob": "2015-01-01"}])
+
+    merged = merge_raw_extractions([file_a, file_b])
+    result = map_extraction(merged, "t1", "a.pdf, b.pdf")
+
+    students = [e for e in result.entities if e.entity_type == "STUDENT"]
+    assert len(students) == 1
+    names = {m.field_name for m in students[0].field_mappings}
+    assert {"first_name", "last_name", "grade_level", "dob"} <= names
+
+
+def test_merge_raw_extractions_merges_tenant_first_nonempty_wins():
+    file_a = RawExtraction(tenant={"tenant_name": "Acme", "address": ""})
+    file_b = RawExtraction(tenant={"tenant_name": "Ignored", "address": "123 Main St"})
+
+    merged = merge_raw_extractions([file_a, file_b])
+    assert merged.tenant["tenant_name"] == "Acme"  # first non-empty wins
+    assert merged.tenant["address"] == "123 Main St"  # blank filled by later file
+
+
+def test_merge_raw_extractions_empty_list_is_safe():
+    merged = merge_raw_extractions([])
+    assert merged.tenant is None
+    assert merged.students == []

--- a/papermite/frontend/src/api/client.ts
+++ b/papermite/frontend/src/api/client.ts
@@ -101,13 +101,15 @@ export async function getActiveModel(
   return data;
 }
 
-export async function uploadDocument(
+export async function uploadDocuments(
   tenantId: string,
-  file: File,
+  files: File[],
   modelId: string
 ): Promise<ExtractionResult> {
   const formData = new FormData();
-  formData.append("file", file);
+  for (const file of files) {
+    formData.append("files", file);
+  }
   formData.append("model_id", modelId);
 
   const res = await authFetch(`${BASE_URL}/tenants/${tenantId}/upload`, {
@@ -119,6 +121,63 @@ export async function uploadDocument(
     throw new Error(detail.detail || "Upload failed");
   }
   return res.json();
+}
+
+/**
+ * Merge a freshly-extracted ExtractionResult into an existing one (used when
+ * appending additional documents to an already-finalized model). For each
+ * entity type, the base's fields are kept and any newly-discovered fields from
+ * `incoming` are added; selection options present in both are unioned. Base
+ * field definitions (types, defaults, required) always win — appending adds
+ * coverage, it never rewrites the existing schema.
+ */
+export function mergeExtractionResults(
+  base: ExtractionResult,
+  incoming: ExtractionResult
+): ExtractionResult {
+  const byType = new Map<string, EntityResult>();
+  for (const entity of base.entities) {
+    byType.set(entity.entity_type, {
+      ...entity,
+      entity: { ...entity.entity },
+      field_mappings: entity.field_mappings.map((m) => ({ ...m })),
+    });
+  }
+
+  for (const incomingEntity of incoming.entities) {
+    const existing = byType.get(incomingEntity.entity_type);
+    if (!existing) {
+      byType.set(incomingEntity.entity_type, {
+        ...incomingEntity,
+        entity: { ...incomingEntity.entity },
+        field_mappings: incomingEntity.field_mappings.map((m) => ({ ...m })),
+      });
+      continue;
+    }
+    const indexByName = new Map(
+      existing.field_mappings.map((m, i) => [m.field_name, i] as const)
+    );
+    for (const mapping of incomingEntity.field_mappings) {
+      const idx = indexByName.get(mapping.field_name);
+      if (idx === undefined) {
+        indexByName.set(mapping.field_name, existing.field_mappings.length);
+        existing.field_mappings.push({ ...mapping });
+        existing.entity[mapping.field_name] = mapping.value;
+      } else if (mapping.field_type === "selection" && mapping.options?.length) {
+        const current = existing.field_mappings[idx];
+        const merged = [...(current.options ?? [])];
+        for (const opt of mapping.options) {
+          if (!merged.includes(opt)) merged.push(opt);
+        }
+        existing.field_mappings[idx] = { ...current, options: merged };
+      }
+    }
+  }
+
+  return {
+    ...base,
+    entities: Array.from(byType.values()),
+  };
 }
 
 /**

--- a/papermite/frontend/src/api/mergeExtractionResults.test.ts
+++ b/papermite/frontend/src/api/mergeExtractionResults.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { mergeExtractionResults } from "./client";
+import type { ExtractionResult, EntityResult } from "../types/models";
+
+function result(entities: EntityResult[]): ExtractionResult {
+  return {
+    extraction_id: "edit-1",
+    tenant_id: "t1",
+    filename: "base",
+    entities,
+    status: "pending_review",
+  };
+}
+
+describe("mergeExtractionResults (append additional documents, #53)", () => {
+  it("adds newly-discovered fields from the incoming extraction", () => {
+    const base = result([
+      {
+        entity_type: "STUDENT",
+        entity: { first_name: "" },
+        field_mappings: [
+          { field_name: "first_name", value: "", source: "base_model", required: true, field_type: "str" },
+        ],
+      },
+    ]);
+    const incoming = result([
+      {
+        entity_type: "STUDENT",
+        entity: { allergies: "peanuts" },
+        field_mappings: [
+          { field_name: "allergies", value: "peanuts", source: "custom_field", required: false, field_type: "str" },
+        ],
+      },
+    ]);
+
+    const merged = mergeExtractionResults(base, incoming);
+    const student = merged.entities.find((e) => e.entity_type === "STUDENT")!;
+    const names = student.field_mappings.map((m) => m.field_name);
+    expect(names).toContain("first_name");
+    expect(names).toContain("allergies");
+    expect(student.entity.allergies).toBe("peanuts");
+  });
+
+  it("keeps the base field definition and does not duplicate existing fields", () => {
+    const base = result([
+      {
+        entity_type: "STUDENT",
+        entity: {},
+        field_mappings: [
+          { field_name: "status", value: "", source: "base_model", required: true, field_type: "selection", options: ["active"], default: "active" },
+        ],
+      },
+    ]);
+    const incoming = result([
+      {
+        entity_type: "STUDENT",
+        entity: {},
+        field_mappings: [
+          { field_name: "status", value: "inactive", source: "custom_field", required: false, field_type: "selection", options: ["inactive"] },
+        ],
+      },
+    ]);
+
+    const merged = mergeExtractionResults(base, incoming);
+    const student = merged.entities.find((e) => e.entity_type === "STUDENT")!;
+    const statusFields = student.field_mappings.filter((m) => m.field_name === "status");
+    expect(statusFields).toHaveLength(1);
+    // Base definition wins (required, default) but options are unioned.
+    expect(statusFields[0].required).toBe(true);
+    expect(statusFields[0].default).toBe("active");
+    expect(statusFields[0].options).toEqual(["active", "inactive"]);
+  });
+
+  it("adds an entity type present only in the incoming extraction", () => {
+    const base = result([
+      { entity_type: "STUDENT", entity: {}, field_mappings: [] },
+    ]);
+    const incoming = result([
+      {
+        entity_type: "PROGRAM",
+        entity: { name: "Chess Club" },
+        field_mappings: [
+          { field_name: "name", value: "Chess Club", source: "base_model", required: true, field_type: "str" },
+        ],
+      },
+    ]);
+
+    const merged = mergeExtractionResults(base, incoming);
+    expect(merged.entities.map((e) => e.entity_type).sort()).toEqual(["PROGRAM", "STUDENT"]);
+  });
+});

--- a/papermite/frontend/src/components/FileUploader.css
+++ b/papermite/frontend/src/components/FileUploader.css
@@ -62,21 +62,65 @@
   margin-top: 8px;
 }
 
-.file-uploader__selected {
+.file-uploader__list {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 6px;
+  width: 100%;
+  max-width: 420px;
+}
+
+.file-uploader__selected {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  background: var(--bg-tertiary);
+  border-radius: var(--radius-sm);
 }
 
 .file-uploader__filename {
   font-family: var(--font-sans);
-  font-size: 15px;
+  font-size: 14px;
   color: var(--accent);
   font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .file-uploader__size {
   font-family: var(--font-sans);
-  font-size: 13px;
+  font-size: 12px;
   color: var(--text-tertiary);
+  margin-left: auto;
+  white-space: nowrap;
+}
+
+.file-uploader__remove {
+  background: none;
+  border: none;
+  color: var(--text-tertiary);
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+  padding: 0 2px;
+}
+
+.file-uploader__remove:hover {
+  color: var(--accent-danger, #d4537e);
+}
+
+.file-uploader__add-more {
+  font-family: var(--font-sans);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--accent);
+  cursor: pointer;
+  padding: 4px 0;
+  align-self: flex-start;
+}
+
+.file-uploader__add-more:hover {
+  text-decoration: underline;
 }

--- a/papermite/frontend/src/components/FileUploader.tsx
+++ b/papermite/frontend/src/components/FileUploader.tsx
@@ -2,22 +2,46 @@ import { useCallback, useState } from "react";
 import "./FileUploader.css";
 
 interface Props {
-  onFileSelect: (file: File) => void;
+  /** Called whenever the selected file set changes. */
+  onFilesChange: (files: File[]) => void;
   disabled?: boolean;
 }
 
 const ACCEPTED = ".pdf,.docx,.txt";
 
-export default function FileUploader({ onFileSelect, disabled }: Props) {
+export default function FileUploader({ onFilesChange, disabled }: Props) {
   const [dragOver, setDragOver] = useState(false);
-  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [files, setFiles] = useState<File[]>([]);
 
-  const handleFile = useCallback(
-    (file: File) => {
-      setSelectedFile(file);
-      onFileSelect(file);
+  const addFiles = useCallback(
+    (incoming: File[]) => {
+      setFiles((prev) => {
+        // De-dupe by name + size so re-dropping the same file is a no-op.
+        const seen = new Set(prev.map((f) => `${f.name}:${f.size}`));
+        const next = [...prev];
+        for (const f of incoming) {
+          const key = `${f.name}:${f.size}`;
+          if (!seen.has(key)) {
+            seen.add(key);
+            next.push(f);
+          }
+        }
+        onFilesChange(next);
+        return next;
+      });
     },
-    [onFileSelect]
+    [onFilesChange]
+  );
+
+  const removeFile = useCallback(
+    (index: number) => {
+      setFiles((prev) => {
+        const next = prev.filter((_, i) => i !== index);
+        onFilesChange(next);
+        return next;
+      });
+    },
+    [onFilesChange]
   );
 
   const handleDrop = useCallback(
@@ -25,18 +49,20 @@ export default function FileUploader({ onFileSelect, disabled }: Props) {
       e.preventDefault();
       setDragOver(false);
       if (disabled) return;
-      const file = e.dataTransfer.files[0];
-      if (file) handleFile(file);
+      const dropped = Array.from(e.dataTransfer.files);
+      if (dropped.length) addFiles(dropped);
     },
-    [disabled, handleFile]
+    [disabled, addFiles]
   );
 
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
-      const file = e.target.files?.[0];
-      if (file) handleFile(file);
+      const picked = Array.from(e.target.files ?? []);
+      if (picked.length) addFiles(picked);
+      // Reset so selecting the same file again still fires change.
+      e.target.value = "";
     },
-    [handleFile]
+    [addFiles]
   );
 
   return (
@@ -65,31 +91,60 @@ export default function FileUploader({ onFileSelect, disabled }: Props) {
             <polyline points="9 15 12 12 15 15" />
           </svg>
         </div>
-        {selectedFile ? (
-          <div className="file-uploader__selected">
-            <span className="file-uploader__filename">
-              {selectedFile.name}
-            </span>
-            <span className="file-uploader__size">
-              {(selectedFile.size / 1024).toFixed(1)} KB
-            </span>
+        {files.length > 0 ? (
+          <div className="file-uploader__list">
+            {files.map((file, i) => (
+              <div key={`${file.name}:${file.size}`} className="file-uploader__selected">
+                <span className="file-uploader__filename">{file.name}</span>
+                <span className="file-uploader__size">
+                  {(file.size / 1024).toFixed(1)} KB
+                </span>
+                {!disabled && (
+                  <button
+                    type="button"
+                    className="file-uploader__remove"
+                    onClick={() => removeFile(i)}
+                    title="Remove file"
+                    aria-label={`Remove ${file.name}`}
+                  >
+                    &times;
+                  </button>
+                )}
+              </div>
+            ))}
+            {!disabled && (
+              <label className="file-uploader__add-more">
+                + Add more files
+                <input
+                  type="file"
+                  accept={ACCEPTED}
+                  multiple
+                  onChange={handleChange}
+                  hidden
+                  disabled={disabled}
+                />
+              </label>
+            )}
           </div>
         ) : (
           <>
             <p className="file-uploader__text">
-              Drop your document here or{" "}
+              Drop your documents here or{" "}
               <label className="file-uploader__browse">
                 browse
                 <input
                   type="file"
                   accept={ACCEPTED}
+                  multiple
                   onChange={handleChange}
                   hidden
                   disabled={disabled}
                 />
               </label>
             </p>
-            <p className="file-uploader__hint">PDF, DOCX, or TXT</p>
+            <p className="file-uploader__hint">
+              PDF, DOCX, or TXT — one or more files
+            </p>
           </>
         )}
       </div>

--- a/papermite/frontend/src/pages/LandingPage.tsx
+++ b/papermite/frontend/src/pages/LandingPage.tsx
@@ -26,6 +26,7 @@ export default function LandingPage({ user }: Props) {
   }, [user.tenant_id]);
 
   const forwardQs = returnUrl ? `?return_url=${encodeURIComponent(returnUrl)}` : "";
+  const appendQs = forwardQs ? `${forwardQs}&mode=append` : "?mode=append";
 
   const handleEditModel = async () => {
     if (!model) return;
@@ -157,6 +158,38 @@ export default function LandingPage({ user }: Props) {
 
             <div
               className="landing__action-card card"
+              onClick={() => navigate(`/upload${appendQs}`)}
+              role="button"
+              tabIndex={0}
+              onKeyDown={(e) => e.key === "Enter" && navigate(`/upload${appendQs}`)}
+            >
+              <div className="landing__action-icon">
+                <svg
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                >
+                  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+                  <polyline points="14 2 14 8 20 8" />
+                  <line x1="12" y1="12" x2="12" y2="18" />
+                  <line x1="9" y1="15" x2="15" y2="15" />
+                </svg>
+              </div>
+              <div className="landing__action-content">
+                <h3 className="landing__action-title">Add Documents to Model</h3>
+                <p className="landing__action-desc">
+                  Upload additional documents. Newly-discovered fields are merged
+                  into the current model for review before saving a new version.
+                </p>
+              </div>
+              <div className="landing__action-arrow">&rarr;</div>
+            </div>
+
+            <div
+              className="landing__action-card card"
               onClick={() => navigate(`/upload${forwardQs}`)}
               role="button"
               tabIndex={0}
@@ -180,7 +213,7 @@ export default function LandingPage({ user }: Props) {
               <div className="landing__action-content">
                 <h3 className="landing__action-title">Upload New Document</h3>
                 <p className="landing__action-desc">
-                  Upload a revised document to re-extract and update the model.
+                  Upload a revised document to re-extract and replace the model.
                   The current version will be archived.
                 </p>
               </div>

--- a/papermite/frontend/src/pages/UploadPage.tsx
+++ b/papermite/frontend/src/pages/UploadPage.tsx
@@ -4,7 +4,9 @@ import type { TestUser, TenantModel } from "../types/models";
 import {
   getAvailableModels,
   getActiveModel,
-  uploadDocument,
+  uploadDocuments,
+  mergeExtractionResults,
+  modelToExtraction,
 } from "../api/client";
 import { saveDraft } from "../db/indexedDb";
 import TenantInfo from "../components/TenantInfo";
@@ -23,9 +25,10 @@ export default function UploadPage({ user }: Props) {
   const [searchParams] = useSearchParams();
   const returnUrl = searchParams.get("return_url");
   const tenantIdParam = searchParams.get("tenant_id");
+  const isAppend = searchParams.get("mode") === "append";
   const [models, setModels] = useState<string[]>([]);
   const [selectedModel, setSelectedModel] = useState("");
-  const [file, setFile] = useState<File | null>(null);
+  const [files, setFiles] = useState<File[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [existingModel, setExistingModel] = useState<TenantModel | null>(null);
@@ -40,12 +43,22 @@ export default function UploadPage({ user }: Props) {
   }, [user.tenant_id]);
 
   const doUpload = async () => {
-    if (!file) return;
+    if (files.length === 0) return;
     setLoading(true);
     setError(null);
     setShowConfirm(false);
     try {
-      const result = await uploadDocument(tenantIdParam || user.tenant_id, file, selectedModel);
+      const extracted = await uploadDocuments(
+        tenantIdParam || user.tenant_id,
+        files,
+        selectedModel
+      );
+      // Append mode merges the new extraction into the existing model so the
+      // review reflects existing fields ∪ newly-discovered ones.
+      const result =
+        isAppend && existingModel
+          ? mergeExtractionResults(modelToExtraction(existingModel), extracted)
+          : extracted;
       await saveDraft(result);
       const forwardParams = new URLSearchParams();
       if (returnUrl) forwardParams.set("return_url", returnUrl);
@@ -59,8 +72,10 @@ export default function UploadPage({ user }: Props) {
   };
 
   const handleUpload = () => {
-    if (!file) return;
-    if (existingModel) {
+    if (files.length === 0) return;
+    // Append merges into the existing model (no replace prompt). A plain upload
+    // over an existing model still confirms the replace.
+    if (existingModel && !isAppend) {
       setShowConfirm(true);
     } else {
       doUpload();
@@ -71,10 +86,13 @@ export default function UploadPage({ user }: Props) {
     <div className="upload-page">
       <div className="page-header">
         <div className="page-header__eyebrow">Step 1 of 3</div>
-        <h1 className="page-header__title">Upload Document</h1>
+        <h1 className="page-header__title">
+          {isAppend ? "Add Documents to Model" : "Upload Documents"}
+        </h1>
         <p className="page-header__desc">
-          Upload your afterschool policy or application template. The AI will
-          extract entities and map them to the data model.
+          {isAppend
+            ? "Upload one or more additional documents. The AI extracts them and merges any newly-discovered fields into your existing model for review."
+            : "Upload one or more afterschool policy or application templates. The AI will extract entities and map them to the data model."}
         </p>
       </div>
 
@@ -98,7 +116,7 @@ export default function UploadPage({ user }: Props) {
           </div>
           <div className="upload-page__existing-model-text">
             <span className="upload-page__existing-model-label">
-              Active model exists
+              {isAppend ? "Merging into active model" : "Active model exists"}
             </span>
             <span className="upload-page__existing-model-detail">
               Source: <code>{existingModel.source_filename}</code> &middot;
@@ -110,7 +128,7 @@ export default function UploadPage({ user }: Props) {
       )}
 
       <div className="upload-page__form">
-        <FileUploader onFileSelect={setFile} disabled={loading} />
+        <FileUploader onFilesChange={setFiles} disabled={loading} />
 
         <div className="upload-page__options">
           <ModelSelector
@@ -130,7 +148,7 @@ export default function UploadPage({ user }: Props) {
             <button
               className="btn btn--primary"
               onClick={handleUpload}
-              disabled={!file || loading}
+              disabled={files.length === 0 || loading}
             >
               {loading ? (
                 <>


### PR DESCRIPTION
Closes #53.

Implements both asks from the issue: **(1) multi-file uploads** and **(2) uploading additional files to update an existing model**.

## 1. Multi-file upload
- **Backend**: `POST /tenants/{id}/upload` now accepts `files: list[UploadFile]`. Each file is extracted independently; new `merge_raw_extractions()` concatenates the per-file extractions (tenant dict shallow-merged, first non-empty value wins) and the existing `_consolidate_entities` unions same-type entities into one field set. `/extract` is untouched.
- **Frontend**: `FileUploader` accepts multiple files (drag/drop or browse), shows a removable list with an "add more" affordance; `uploadDocuments(files[])` posts them under `files`.

## 2. Append documents to an existing model
- New **"Add Documents to Model"** action on the Landing page (between Edit Model and Upload New Document) → upload flow in `?mode=append`.
- On upload, the fresh extraction is merged into `modelToExtraction(activeModel)` via new `mergeExtractionResults()`: existing field definitions win, **newly-discovered fields are added**, and selection options present in both are unioned. The merged result opens in Review to finalize a **new version** — no replace/archive prompt in append mode.

## Design notes
- Append merges on the client by reusing the proven `modelToExtraction` converter, mirroring the backend's `_consolidate_entities` semantics (union, not overwrite) — so appending only *adds coverage*, never rewrites the schema.
- Single-file upload still works (list of one).

## Test plan
- [x] Backend: `pytest` — 101 passed (excl. a **pre-existing** unrelated `test_auth.py` import error on `app.storage`). 3 new tests for `merge_raw_extractions` (field union across files, tenant first-non-empty-wins, empty-safe).
- [x] Frontend: `vitest` — 19 passed, incl. 3 new `mergeExtractionResults` tests (adds new fields, dedups existing + unions options, adds incoming-only entity type).
- [x] `npm run build` passes; no new lint errors (7 remaining are pre-existing in App/ReviewPage/FinalizedPage).
- [ ] Manual end-to-end (multi-file drag/drop; Landing → Add Documents → merged review → finalize new version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)