### PR TITLE
feat(papermite): hide tenant from model-setup flow; extras → note (#76)

### DIFF
--- a/papermite/backend/app/api/finalize.py
+++ b/papermite/backend/app/api/finalize.py
@@ -268,16 +268,23 @@ async def finalize_commit(
     )
     if tenant_entity is not None:
         extracted_base, extracted_custom = _split_extracted_tenant(tenant_entity)
-        if extracted_base or extracted_custom:
+        # The tenant schema is pre-determined and takes no custom fields
+        # (issue #76): fold any extra extracted fields into the `note` field so
+        # the information is preserved rather than stored as custom columns.
+        if extracted_custom:
+            extra = "; ".join(f"{k}: {v}" for k, v in extracted_custom.items())
+            base_note = str(extracted_base.get("note", "")).strip()
+            extracted_base["note"] = f"{base_note}\n{extra}".strip() if base_note else extra
+        if extracted_base:
             cleaned = _fetch_existing_tenant_row(tenant_id)
             existing_base, existing_custom = _split_existing_tenant_row(cleaned)
             merged_base = _merge_fields(existing_base, extracted_base)
-            merged_custom = _merge_fields(existing_custom, extracted_custom)
-
+            # Do not introduce new custom fields for the tenant; preserve any
+            # that already exist on the row unchanged.
             try:
                 tenant_resp = httpx.put(
                     f"{settings.datacore_api_url}/tenants/{tenant_id}",
-                    json={"base_data": merged_base, "custom_fields": merged_custom},
+                    json={"base_data": merged_base, "custom_fields": existing_custom},
                     timeout=30.0,
                 )
             except httpx.HTTPError:

--- a/papermite/backend/app/models/domain.py
+++ b/papermite/backend/app/models/domain.py
@@ -159,6 +159,10 @@ class Tenant(BaseEntity):
     capacity: Optional[int] = None
     accreditation: Optional[str] = None
     insurance_provider: Optional[str] = None
+    # Free-text note holding any extra information extracted from documents.
+    # The tenant schema is pre-determined and takes no custom fields (issue #76);
+    # anything the AI extracts beyond these fields is folded into `note`.
+    note: str = ""
 
 
 # All entity classes that can be extracted from documents

--- a/papermite/backend/tests/test_finalize_api.py
+++ b/papermite/backend/tests/test_finalize_api.py
@@ -211,9 +211,11 @@ def test_finalize_persists_extracted_tenant_when_row_empty():
     assert len(put_calls) == 2, put_calls
     assert "/models/t1" in put_calls[0]["url"]
     assert put_calls[1]["url"].endswith("/tenants/t1")
+    # Tenant takes no custom fields (issue #76): the extracted custom value is
+    # folded into `note`, and no custom fields are written for an empty row.
     assert put_calls[1]["json"] == {
-        "base_data": {"name": "Acme"},
-        "custom_fields": {"school_district_code": "DC-100"},
+        "base_data": {"name": "Acme", "note": "school_district_code: DC-100"},
+        "custom_fields": {},
     }
 
     # And we read existing first
@@ -287,9 +289,10 @@ def test_finalize_merges_with_existing_tenant_row():
     assert body["base_data"]["name"] == "User Typed Name"
     # contact_email was None in existing -> filled
     assert body["base_data"]["contact_email"] == "a@x.com"
-    # school_district_code was "" in existing -> filled
-    assert body["custom_fields"]["school_district_code"] == "DC-100"
-    # legacy_marker was non-empty and absent from extraction -> preserved
+    # Extracted custom (school_district_code) is folded into note, not custom
+    # fields (issue #76).
+    assert body["base_data"]["note"] == "school_district_code: DC-100"
+    # legacy_marker was non-empty and absent from extraction -> preserved as-is
     assert body["custom_fields"]["legacy_marker"] == "keep-me"
 
 

--- a/papermite/frontend/src/pages/ReviewPage.tsx
+++ b/papermite/frontend/src/pages/ReviewPage.tsx
@@ -83,11 +83,18 @@ export default function ReviewPage() {
     );
   }
 
-  const baseCount = extraction.entities.reduce(
+  // The Tenant entity is not exposed in the model-setup UI (issue #76): its
+  // schema is pre-determined and its data is managed on the LaunchPad tenant
+  // settings page. It remains in `extraction` so finalize still persists it.
+  const visibleEntities = extraction.entities.filter(
+    (e) => e.entity_type !== "TENANT"
+  );
+
+  const baseCount = visibleEntities.reduce(
     (sum, e) => sum + e.field_mappings.filter((m) => m.source === "base_model").length,
     0
   );
-  const customCount = extraction.entities.reduce(
+  const customCount = visibleEntities.reduce(
     (sum, e) => sum + e.field_mappings.filter((m) => m.source === "custom_field").length,
     0
   );
@@ -112,7 +119,7 @@ export default function ReviewPage() {
         <div className="review__stats">
           <div className="review__stat">
             <span className="review__stat-value">
-              {extraction.entities.length}
+              {visibleEntities.length}
             </span>
             <span className="review__stat-label">Entities</span>
           </div>
@@ -154,14 +161,16 @@ export default function ReviewPage() {
         )}
 
         <div className="review__entities">
-          {extraction.entities.map((entity, idx) => (
-            <EntityCard
-              key={`${entity.entity_type}-${idx}`}
-              entity={entity}
-              index={idx}
-              onUpdate={handleEntityUpdate}
-            />
-          ))}
+          {extraction.entities.map((entity, idx) =>
+            entity.entity_type === "TENANT" ? null : (
+              <EntityCard
+                key={`${entity.entity_type}-${idx}`}
+                entity={entity}
+                index={idx}
+                onUpdate={handleEntityUpdate}
+              />
+            )
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
Part 1 of issue #76 (tenant information handling). **Papermite: Tenant Model should be hidden.**

## Changes
- The **TENANT** entity is no longer shown as an editable card in the Review / model-setup UI (its schema is pre-determined; its data is managed on the LaunchPad tenant settings page). TENANT stays in the extraction payload, so `finalize` still persists its values to DataCore (the #69 flow). Entity/base/custom counts exclude it.
- Added a `note` field to the Tenant model. On finalize, any **extra** extracted tenant fields (beyond the fixed schema) are folded into `note` instead of being written as custom columns — the tenant takes **no custom fields**. Existing custom columns on the row are preserved unchanged.

## Test plan
- [x] Backend `pytest` finalize suite — 28 passed (updated the 2 tenant-persistence tests to the new "extras → note, no new custom" contract)
- [x] Frontend `npm run build` + `vitest` (22) pass

Refs #76. Companion PRs: LaunchPad tenant model + AdminDash display name.