### PR TITLE
feat(launchpad): pre-determined tenant model with full attributes (#76)

### DIFF
--- a/launchpad/backend/app/data/base_model.json
+++ b/launchpad/backend/app/data/base_model.json
@@ -2,10 +2,16 @@
   "tenant": {
     "base_fields": [
       {"name": "name", "type": "str", "required": true},
-      {"name": "address", "type": "str", "required": false},
-      {"name": "phone", "type": "phone", "required": false},
-      {"name": "email", "type": "email", "required": false},
-      {"name": "website", "type": "str", "required": false}
+      {"name": "display_name", "type": "str", "required": false},
+      {"name": "contact_email", "type": "email", "required": false},
+      {"name": "contact_phone", "type": "phone", "required": false},
+      {"name": "primary_address", "type": "str", "required": false},
+      {"name": "mailing_address", "type": "str", "required": false},
+      {"name": "license_number", "type": "str", "required": false},
+      {"name": "capacity", "type": "number", "required": false},
+      {"name": "accreditation", "type": "str", "required": false},
+      {"name": "insurance_provider", "type": "str", "required": false},
+      {"name": "note", "type": "str", "required": false}
     ],
     "custom_fields": []
   },


### PR DESCRIPTION
Part 2 of issue #76. **Tenant model used in the tenant info/settings page, populated with extracted info.**

## Change
Expanded the default tenant model in `base_model.json` from 5 fields (name/address/phone/email/website) to the canonical pre-determined tenant schema: `name` (legal), `display_name`, `contact_email`, `contact_phone`, `primary_address`, `mailing_address`, `license_number`, `capacity`, `accreditation`, `insurance_provider`, `note`. No custom fields.

## Why this is (mostly) just data
The tenant settings page (`TenantSettingsPage`) is already model-driven and already:
- renders all model fields editable **except `name` (legal name) and `tenant_id`** (`immutableFields`),
- populates values from the DataCore tenant row (which Papermite's finalize persists), and
- `getTenantModel` extracts the tenant slice from the stored definition.

So expanding the schema flows straight through — the extracted attributes now appear and are editable on the tenant page.

Refs #76. Companion PRs: Papermite hide-tenant + AdminDash display name.