### PR TITLE
fix(admindash): use self-hosted logo (CSP blocked external placeholder)

### DIFF
--- a/admindash/frontend/src/components/Navbar.tsx
+++ b/admindash/frontend/src/components/Navbar.tsx
@@ -59,8 +59,8 @@ export default function Navbar() {
       <div className="navbar-inner">
         <a className="navbar-brand" href="/">
           <img
-            src="https://www.acmeschool.com/uploads/2/7/1/4/27147223/1418317113.png"
-            alt="Logo"
+            src="/favicon.svg"
+            alt="Floatify"
           />
           <span className="navbar-brand-text" style={{ color: '#378ADD' }}>{t('nav.systemName')}</span>
         </a>

--- a/admindash/frontend/src/pages/LoginPage.tsx
+++ b/admindash/frontend/src/pages/LoginPage.tsx
@@ -33,8 +33,8 @@ export default function LoginPage() {
         <div className="login-card-body">
           <div className="login-logo">
             <img
-              src="https://www.acmeschool.com/uploads/2/7/1/4/27147223/1418317113.png"
-              alt="Logo"
+              src="/favicon.svg"
+              alt="Floatify"
             />
           </div>
           <h1 className="login-title">{t('login.title')}</h1>


### PR DESCRIPTION
## Problem

The logo is missing on https://admin.floatify.com/home (and the login page).

**Cause:** The Navbar and LoginPage `<img>` logos were hardcoded to an external placeholder URL (`https://www.acmeschool.com/.../1418317113.png`). The production CSP in `public/_headers` is:

```
img-src 'self' data:
```

That blocks the external `acmeschool.com` origin, so the browser refuses to load the logo in prod. It only appeared in local dev because no CSP is applied there — and the placeholder URL is a dead external dependency regardless.

## Fix

Point both logos at the self-hosted **`/favicon.svg`** (the Floatify brand mark already shipped in `public/`), served from `'self'` and allowed by the CSP. No CSP change needed.

## Test plan
- [x] `npm run build` passes; `favicon.svg` present in `dist/`
- [x] No remaining external logo references in `src/`
- [ ] Prod: after deploy, logo renders in the navbar + login page

Only AdminDash had this placeholder — papermite/launchpad frontends are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)