### PR TITLE
feat(admindash): lead management module

### DIFF
--- a/admindash/backend/app/api/leads.py
+++ b/admindash/backend/app/api/leads.py
@@ -190,7 +190,8 @@ def public_lead_model(tenant_id: str):
     if model is None:
         fields = _default_prospect_fields()
     else:
-        fields = [f for f in model.get("base_fields", []) if f.get("name") not in RESERVED_LEAD_FIELDS]
+        all_fields = model.get("base_fields", []) + model.get("custom_fields", [])
+        fields = [f for f in all_fields if f.get("name") not in RESERVED_LEAD_FIELDS]
         if not fields:
             fields = _default_prospect_fields()
     return {"fields": fields}
@@ -310,12 +311,13 @@ def list_activities(tenant_id: str, lead_id: str, user=Depends(require_authentic
 @router.patch("/leads/{tenant_id}/{lead_id}/stage")
 def update_stage(tenant_id: str, lead_id: str, body: StageUpdate,
                  user=Depends(require_authenticated_user)):
-    if body.stage not in _stage_options(tenant_id, user["_token"]):
+    opts = _stage_options(tenant_id, user["_token"])
+    if body.stage not in opts:
         raise HTTPException(400, f"Unknown stage: {body.stage}")
     lead = _get_lead(tenant_id, lead_id, user["_token"])
     if not lead:
         raise HTTPException(404, "Lead not found")
-    current = lead.get("stage", "New")
+    current = lead.get("stage") or opts[0]
     base = _lead_base_data(lead)
     base["stage"] = body.stage
     updated = _dc_update(tenant_id, "lead", lead_id, base, user["_token"])

--- a/admindash/backend/app/api/leads.py
+++ b/admindash/backend/app/api/leads.py
@@ -169,6 +169,46 @@ def add_activity(tenant_id: str, lead_id: str, body: ActivityCreate,
     }, user["_token"])
 
 
+@router.post("/leads/{tenant_id}/{lead_id}/convert", status_code=201)
+def convert_lead(tenant_id: str, lead_id: str, body: ConvertRequest,
+                 user=Depends(require_authenticated_user)):
+    token = user["_token"]
+    lead = _get_lead(tenant_id, lead_id, token)
+    if not lead:
+        raise HTTPException(404, "Lead not found")
+    if lead.get("converted_family_id"):
+        raise HTTPException(409, f"Lead already converted to family {lead['converted_family_id']}")
+
+    family = _dc_create(tenant_id, "family", {
+        "family_name": body.family_name,
+        "primary_address": body.primary_address,
+        "primary_email": body.primary_email or lead.get("email"),
+        "primary_phone": body.primary_phone or lead.get("phone"),
+    }, token)
+    family_id = family["entity_id"]
+
+    student_base = {
+        "first_name": body.student_first_name,
+        "last_name": body.student_last_name,
+        "family_id": family_id,
+        "primary_address": body.primary_address,
+        "status": "Enrolled",
+    }
+    if body.grade_level:
+        student_base["grade_level"] = body.grade_level
+    student = _dc_create(tenant_id, "student", student_base, token)
+
+    base = _lead_base_data(lead)
+    base["converted_family_id"] = family_id
+    prev_stage = base.get("stage", "New")
+    base["stage"] = "Enrolled"
+    _dc_update(tenant_id, "lead", lead_id, base, token)
+    if prev_stage != "Enrolled":
+        _log_stage_change(tenant_id, lead_id, prev_stage, "Enrolled", token)
+
+    return {"family_id": family_id, "student_id": student["entity_id"], "lead_id": lead_id}
+
+
 @router.get("/leads/{tenant_id}/{lead_id}/activities")
 def list_activities(tenant_id: str, lead_id: str, user=Depends(require_authenticated_user)):
     rows = _dc_query(

--- a/admindash/backend/app/api/leads.py
+++ b/admindash/backend/app/api/leads.py
@@ -12,6 +12,7 @@ router = APIRouter()
 
 DEFAULT_STAGES = ["New", "Contacted", "Tour Scheduled", "Toured", "Enrolled", "Lost"]
 ACTIVITY_TYPES = {"call", "email", "note"}
+RESERVED_LEAD_FIELDS = {"stage", "source", "converted_family_id", "lead_id"}
 
 
 # ── DataCore client helpers (sync httpx so respx intercepts) ──────────────
@@ -83,6 +84,19 @@ def _stage_options(tenant: str, token: str | None) -> list[str]:
             if f.get("name") == "stage" and f.get("options"):
                 return f["options"]
     return DEFAULT_STAGES
+
+
+def _default_prospect_fields() -> list[dict]:
+    """Default prospect field definitions used when a tenant has no lead model."""
+    return [
+        {"name": "guardian_name", "type": "str", "required": True},
+        {"name": "email", "type": "email", "required": False},
+        {"name": "phone", "type": "phone", "required": False},
+        {"name": "student_first_name", "type": "str", "required": False},
+        {"name": "student_last_name", "type": "str", "required": False},
+        {"name": "grade_of_interest", "type": "str", "required": False},
+        {"name": "message", "type": "str", "required": False},
+    ]
 
 
 def _get_lead(tenant: str, lead_id: str, token: str | None) -> dict | None:
@@ -166,6 +180,20 @@ def public_intake(tenant_id: str, body: PublicLeadCreate):
         base.pop(k, None)
     base.update({"source": "web_form", "stage": _stage_options(tenant_id, None)[0]})
     return _dc_create(tenant_id, "lead", base, None)
+
+
+@router.get("/public/leads/{tenant_id}/model")
+def public_lead_model(tenant_id: str):
+    if not re.fullmatch(r"[A-Za-z0-9_-]+", tenant_id):
+        raise HTTPException(404, "Unknown tenant")
+    model = _lead_model(tenant_id, None)
+    if model is None:
+        fields = _default_prospect_fields()
+    else:
+        fields = [f for f in model.get("base_fields", []) if f.get("name") not in RESERVED_LEAD_FIELDS]
+        if not fields:
+            fields = _default_prospect_fields()
+    return {"fields": fields}
 
 
 @router.post("/leads/{tenant_id}", status_code=201)

--- a/admindash/backend/app/api/leads.py
+++ b/admindash/backend/app/api/leads.py
@@ -158,6 +158,27 @@ def _log_stage_change(tenant: str, lead_id: str, frm: str, to: str, token: str |
     }, token)
 
 
+@router.post("/leads/{tenant_id}/{lead_id}/activities", status_code=201)
+def add_activity(tenant_id: str, lead_id: str, body: ActivityCreate,
+                 user=Depends(require_authenticated_user)):
+    if body.type not in ACTIVITY_TYPES:
+        raise HTTPException(400, f"Unknown activity type: {body.type}")
+    return _dc_create(tenant_id, "lead_activity", {
+        "lead_id": lead_id, "type": body.type, "body": body.body,
+        "created_by": user.get("id", "unknown"),
+    }, user["_token"])
+
+
+@router.get("/leads/{tenant_id}/{lead_id}/activities")
+def list_activities(tenant_id: str, lead_id: str, user=Depends(require_authenticated_user)):
+    rows = _dc_query(
+        tenant_id,
+        f"SELECT * FROM data WHERE entity_type = 'lead_activity' "
+        f"AND lead_id = '{lead_id}' AND _status = 'active' ORDER BY _created_at DESC",
+        user["_token"])
+    return {"activities": rows}
+
+
 @router.patch("/leads/{tenant_id}/{lead_id}/stage")
 def update_stage(tenant_id: str, lead_id: str, body: StageUpdate,
                  user=Depends(require_authenticated_user)):

--- a/admindash/backend/app/api/leads.py
+++ b/admindash/backend/app/api/leads.py
@@ -167,6 +167,8 @@ def get_lead(tenant_id: str, lead_id: str, user=Depends(require_authenticated_us
     return lead
 
 
+# Keep in sync with LeadCreate schema fields + internal fields (source, stage,
+# lead_id, converted_family_id) — stage/convert PUTs will silently drop new fields otherwise.
 _LEAD_FIELDS = ["guardian_name", "email", "phone", "student_first_name",
                 "student_last_name", "grade_of_interest", "message", "source",
                 "stage", "lead_id", "converted_family_id"]

--- a/admindash/backend/app/api/leads.py
+++ b/admindash/backend/app/api/leads.py
@@ -1,4 +1,5 @@
 """Lead-management routes — proxy to DataCore with lead-specific business rules."""
+import re
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, model_validator
@@ -130,6 +131,8 @@ class ConvertRequest(BaseModel):
 
 @router.post("/public/leads/{tenant_id}", status_code=201)
 def public_intake(tenant_id: str, body: PublicLeadCreate):
+    if not re.fullmatch(r"[A-Za-z0-9_-]+", tenant_id):
+        raise HTTPException(404, "Unknown tenant")
     if not _tenant_exists(tenant_id):
         raise HTTPException(404, "Unknown tenant")
     base = body.model_dump(exclude_none=True)

--- a/admindash/backend/app/api/leads.py
+++ b/admindash/backend/app/api/leads.py
@@ -140,3 +140,36 @@ def get_lead(tenant_id: str, lead_id: str, user=Depends(require_authenticated_us
     if not lead:
         raise HTTPException(404, "Lead not found")
     return lead
+
+
+_LEAD_FIELDS = ["guardian_name", "email", "phone", "student_first_name",
+                "student_last_name", "grade_of_interest", "message", "source",
+                "stage", "lead_id", "converted_family_id"]
+
+
+def _lead_base_data(row: dict) -> dict:
+    return {k: row[k] for k in _LEAD_FIELDS if row.get(k) is not None}
+
+
+def _log_stage_change(tenant: str, lead_id: str, frm: str, to: str, token: str | None):
+    _dc_create(tenant, "lead_activity", {
+        "lead_id": lead_id, "type": "stage_change", "body": f"{frm} → {to}",
+        "stage_from": frm, "stage_to": to, "created_by": "system",
+    }, token)
+
+
+@router.patch("/leads/{tenant_id}/{lead_id}/stage")
+def update_stage(tenant_id: str, lead_id: str, body: StageUpdate,
+                 user=Depends(require_authenticated_user)):
+    if body.stage not in STAGES:
+        raise HTTPException(400, f"Unknown stage: {body.stage}")
+    lead = _get_lead(tenant_id, lead_id, user["_token"])
+    if not lead:
+        raise HTTPException(404, "Lead not found")
+    current = lead.get("stage", "New")
+    base = _lead_base_data(lead)
+    base["stage"] = body.stage
+    updated = _dc_update(tenant_id, "lead", lead_id, base, user["_token"])
+    if body.stage != current:
+        _log_stage_change(tenant_id, lead_id, current, body.stage, user["_token"])
+    return updated

--- a/admindash/backend/app/api/leads.py
+++ b/admindash/backend/app/api/leads.py
@@ -81,6 +81,7 @@ class LeadCreate(BaseModel):
     student_last_name: str | None = None
     grade_of_interest: str | None = None
     message: str | None = None
+    source: str | None = None
 
     @model_validator(mode="after")
     def _contact_required(self):
@@ -110,3 +111,32 @@ class ConvertRequest(BaseModel):
     student_first_name: str
     student_last_name: str
     grade_level: str | None = None
+
+
+# ── Routes ────────────────────────────────────────────────────────────────
+
+@router.post("/leads/{tenant_id}", status_code=201)
+def create_lead(tenant_id: str, body: LeadCreate, user=Depends(require_authenticated_user)):
+    src = body.source if body.source in ("manual", "email_import") else "manual"
+    base = body.model_dump(exclude_none=True, exclude={"source"})
+    base.update({"source": src, "stage": "New"})
+    return _dc_create(tenant_id, "lead", base, user["_token"])
+
+
+@router.get("/leads/{tenant_id}")
+def list_leads(tenant_id: str, stage: str | None = None, user=Depends(require_authenticated_user)):
+    where = "entity_type = 'lead' AND _status = 'active'"
+    if stage:
+        if stage not in STAGES:
+            raise HTTPException(400, f"Unknown stage: {stage}")
+        where += f" AND stage = '{stage}'"
+    rows = _dc_query(tenant_id, f"SELECT * FROM data WHERE {where}", user["_token"])
+    return {"leads": rows}
+
+
+@router.get("/leads/{tenant_id}/{lead_id}")
+def get_lead(tenant_id: str, lead_id: str, user=Depends(require_authenticated_user)):
+    lead = _get_lead(tenant_id, lead_id, user["_token"])
+    if not lead:
+        raise HTTPException(404, "Lead not found")
+    return lead

--- a/admindash/backend/app/api/leads.py
+++ b/admindash/backend/app/api/leads.py
@@ -90,8 +90,21 @@ class LeadCreate(BaseModel):
         return self
 
 
-class PublicLeadCreate(LeadCreate):
-    """Same prospect fields; internal fields (stage/source/converted_family_id) are never accepted."""
+class PublicLeadCreate(BaseModel):
+    """Prospect-facing fields only — source/stage/converted_family_id are never accepted."""
+    guardian_name: str
+    email: str | None = None
+    phone: str | None = None
+    student_first_name: str | None = None
+    student_last_name: str | None = None
+    grade_of_interest: str | None = None
+    message: str | None = None
+
+    @model_validator(mode="after")
+    def _contact_required(self):
+        if not (self.email or self.phone):
+            raise ValueError("At least one of email or phone is required")
+        return self
 
 
 class StageUpdate(BaseModel):
@@ -114,6 +127,15 @@ class ConvertRequest(BaseModel):
 
 
 # ── Routes ────────────────────────────────────────────────────────────────
+
+@router.post("/public/leads/{tenant_id}", status_code=201)
+def public_intake(tenant_id: str, body: PublicLeadCreate):
+    if not _tenant_exists(tenant_id):
+        raise HTTPException(404, "Unknown tenant")
+    base = body.model_dump(exclude_none=True)
+    base.update({"source": "web_form", "stage": "New"})  # force; internal fields never in schema
+    return _dc_create(tenant_id, "lead", base, None)
+
 
 @router.post("/leads/{tenant_id}", status_code=201)
 def create_lead(tenant_id: str, body: LeadCreate, user=Depends(require_authenticated_user)):

--- a/admindash/backend/app/api/leads.py
+++ b/admindash/backend/app/api/leads.py
@@ -1,16 +1,16 @@
 """Lead-management routes — proxy to DataCore with lead-specific business rules."""
+import json
 import re
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, ConfigDict
 
 from app.auth import require_authenticated_user
 from app.config import settings
 
 router = APIRouter()
 
-STAGES = ["New", "Contacted", "Tour Scheduled", "Toured", "Enrolled", "Lost"]
-TERMINAL_STAGES = {"Enrolled", "Lost"}
+DEFAULT_STAGES = ["New", "Contacted", "Tour Scheduled", "Toured", "Enrolled", "Lost"]
 ACTIVITY_TYPES = {"call", "email", "note"}
 
 
@@ -45,12 +45,44 @@ def _dc_update(tenant: str, entity_type: str, entity_id: str, base_data: dict, t
     return resp.json()
 
 
-def _dc_query(tenant: str, sql: str, token: str | None) -> list[dict]:
+def _dc_query(tenant: str, sql: str, token: str | None, table: str = "entities") -> list[dict]:
     resp = _dc("POST", "/api/query", token,
-               {"tenant_id": tenant, "table": "entities", "sql": sql})
+               {"tenant_id": tenant, "table": table, "sql": sql})
     if resp.status_code != 200:
         raise HTTPException(resp.status_code, f"DataCore query failed: {resp.text}")
     return resp.json().get("data", [])
+
+
+# ── Model-driven stage helpers ────────────────────────────────────────────
+def _lead_model(tenant: str, token: str | None) -> dict | None:
+    """Return the lead entity's model definition {base_fields, custom_fields} or None."""
+    rows = _dc_query(
+        tenant,
+        "SELECT * FROM data WHERE entity_type = 'lead' AND _status = 'active'",
+        token, table="models",
+    )
+    if not rows:
+        return None
+    try:
+        md = rows[0]["model_definition"]
+        if isinstance(md, str):
+            md = json.loads(md)
+        if isinstance(md, dict) and "lead" in md:
+            return md["lead"]
+        return md
+    except Exception:
+        return None
+
+
+def _stage_options(tenant: str, token: str | None) -> list[str]:
+    """Stage options from the lead model's `stage` selection field, else DEFAULT_STAGES."""
+    model = _lead_model(tenant, token)
+    if model:
+        fields = model.get("base_fields", []) + model.get("custom_fields", [])
+        for f in fields:
+            if f.get("name") == "stage" and f.get("options"):
+                return f["options"]
+    return DEFAULT_STAGES
 
 
 def _get_lead(tenant: str, lead_id: str, token: str | None) -> dict | None:
@@ -75,7 +107,9 @@ def _tenant_exists(tenant: str) -> bool:
 
 # ── Schemas ───────────────────────────────────────────────────────────────
 class LeadCreate(BaseModel):
-    guardian_name: str
+    model_config = ConfigDict(extra="allow")
+
+    guardian_name: str | None = None
     email: str | None = None
     phone: str | None = None
     student_first_name: str | None = None
@@ -84,28 +118,18 @@ class LeadCreate(BaseModel):
     message: str | None = None
     source: str | None = None
 
-    @model_validator(mode="after")
-    def _contact_required(self):
-        if not (self.email or self.phone):
-            raise ValueError("At least one of email or phone is required")
-        return self
-
 
 class PublicLeadCreate(BaseModel):
-    """Prospect-facing fields only — source/stage/converted_family_id are never accepted."""
-    guardian_name: str
+    """Prospect-facing fields — reserved internal keys are stripped in the route."""
+    model_config = ConfigDict(extra="allow")
+
+    guardian_name: str | None = None
     email: str | None = None
     phone: str | None = None
     student_first_name: str | None = None
     student_last_name: str | None = None
     grade_of_interest: str | None = None
     message: str | None = None
-
-    @model_validator(mode="after")
-    def _contact_required(self):
-        if not (self.email or self.phone):
-            raise ValueError("At least one of email or phone is required")
-        return self
 
 
 class StageUpdate(BaseModel):
@@ -125,6 +149,7 @@ class ConvertRequest(BaseModel):
     student_first_name: str
     student_last_name: str
     grade_level: str | None = None
+    target_stage: str | None = None
 
 
 # ── Routes ────────────────────────────────────────────────────────────────
@@ -136,15 +161,19 @@ def public_intake(tenant_id: str, body: PublicLeadCreate):
     if not _tenant_exists(tenant_id):
         raise HTTPException(404, "Unknown tenant")
     base = body.model_dump(exclude_none=True)
-    base.update({"source": "web_form", "stage": "New"})  # force; internal fields never in schema
+    # Strip reserved internal keys — a prospect must not set these.
+    for k in ("stage", "source", "converted_family_id", "lead_id"):
+        base.pop(k, None)
+    base.update({"source": "web_form", "stage": _stage_options(tenant_id, None)[0]})
     return _dc_create(tenant_id, "lead", base, None)
 
 
 @router.post("/leads/{tenant_id}", status_code=201)
 def create_lead(tenant_id: str, body: LeadCreate, user=Depends(require_authenticated_user)):
-    src = body.source if body.source in ("manual", "email_import") else "manual"
     base = body.model_dump(exclude_none=True, exclude={"source"})
-    base.update({"source": src, "stage": "New"})
+    src = body.source if body.source in ("manual", "email_import") else "manual"
+    base["source"] = src
+    base["stage"] = _stage_options(tenant_id, user["_token"])[0]
     return _dc_create(tenant_id, "lead", base, user["_token"])
 
 
@@ -152,7 +181,7 @@ def create_lead(tenant_id: str, body: LeadCreate, user=Depends(require_authentic
 def list_leads(tenant_id: str, stage: str | None = None, user=Depends(require_authenticated_user)):
     where = "entity_type = 'lead' AND _status = 'active'"
     if stage:
-        if stage not in STAGES:
+        if stage not in _stage_options(tenant_id, user["_token"]):
             raise HTTPException(400, f"Unknown stage: {stage}")
         where += f" AND stage = '{stage}'"
     rows = _dc_query(tenant_id, f"SELECT * FROM data WHERE {where}", user["_token"])
@@ -167,15 +196,15 @@ def get_lead(tenant_id: str, lead_id: str, user=Depends(require_authenticated_us
     return lead
 
 
-# Keep in sync with LeadCreate schema fields + internal fields (source, stage,
-# lead_id, converted_family_id) — stage/convert PUTs will silently drop new fields otherwise.
-_LEAD_FIELDS = ["guardian_name", "email", "phone", "student_first_name",
-                "student_last_name", "grade_of_interest", "message", "source",
-                "stage", "lead_id", "converted_family_id"]
+# Preserve ALL lead fields (base + custom) from a flattened entity row, dropping
+# only system/metadata columns — stage/convert PUTs REPLACE base_data, so anything
+# omitted here is lost.
+_SYSTEM_COLS = {"entity_id", "entity_type", "base_data", "custom_fields", "vector"}
 
 
 def _lead_base_data(row: dict) -> dict:
-    return {k: row[k] for k in _LEAD_FIELDS if row.get(k) is not None}
+    return {k: v for k, v in row.items()
+            if k not in _SYSTEM_COLS and not k.startswith("_") and v is not None}
 
 
 def _log_stage_change(tenant: str, lead_id: str, frm: str, to: str, token: str | None):
@@ -227,11 +256,15 @@ def convert_lead(tenant_id: str, lead_id: str, body: ConvertRequest,
 
     base = _lead_base_data(lead)
     base["converted_family_id"] = family_id
-    prev_stage = base.get("stage", "New")
-    base["stage"] = "Enrolled"
+    opts = _stage_options(tenant_id, token)
+    if body.target_stage is not None and body.target_stage not in opts:
+        raise HTTPException(400, f"Unknown target stage: {body.target_stage}")
+    target = body.target_stage or opts[-1]
+    prev_stage = base.get("stage")
+    base["stage"] = target
     _dc_update(tenant_id, "lead", lead_id, base, token)
-    if prev_stage != "Enrolled":
-        _log_stage_change(tenant_id, lead_id, prev_stage, "Enrolled", token)
+    if prev_stage != target:
+        _log_stage_change(tenant_id, lead_id, prev_stage, target, token)
 
     return {"family_id": family_id, "student_id": student["entity_id"], "lead_id": lead_id}
 
@@ -249,7 +282,7 @@ def list_activities(tenant_id: str, lead_id: str, user=Depends(require_authentic
 @router.patch("/leads/{tenant_id}/{lead_id}/stage")
 def update_stage(tenant_id: str, lead_id: str, body: StageUpdate,
                  user=Depends(require_authenticated_user)):
-    if body.stage not in STAGES:
+    if body.stage not in _stage_options(tenant_id, user["_token"]):
         raise HTTPException(400, f"Unknown stage: {body.stage}")
     lead = _get_lead(tenant_id, lead_id, user["_token"])
     if not lead:

--- a/admindash/backend/app/api/leads.py
+++ b/admindash/backend/app/api/leads.py
@@ -260,7 +260,7 @@ def convert_lead(tenant_id: str, lead_id: str, body: ConvertRequest,
     if body.target_stage is not None and body.target_stage not in opts:
         raise HTTPException(400, f"Unknown target stage: {body.target_stage}")
     target = body.target_stage or opts[-1]
-    prev_stage = base.get("stage")
+    prev_stage = base.get("stage") or opts[0]
     base["stage"] = target
     _dc_update(tenant_id, "lead", lead_id, base, token)
     if prev_stage != target:

--- a/admindash/backend/app/api/leads.py
+++ b/admindash/backend/app/api/leads.py
@@ -1,0 +1,112 @@
+"""Lead-management routes — proxy to DataCore with lead-specific business rules."""
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, model_validator
+
+from app.auth import require_authenticated_user
+from app.config import settings
+
+router = APIRouter()
+
+STAGES = ["New", "Contacted", "Tour Scheduled", "Toured", "Enrolled", "Lost"]
+TERMINAL_STAGES = {"Enrolled", "Lost"}
+ACTIVITY_TYPES = {"call", "email", "note"}
+
+
+# ── DataCore client helpers (sync httpx so respx intercepts) ──────────────
+def _dc(method: str, path: str, token: str | None, json_body: dict | None = None):
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = token
+    try:
+        resp = httpx.request(
+            method, f"{settings.datacore_url}{path}",
+            json=json_body, headers=headers, timeout=30.0,
+        )
+    except httpx.RequestError:
+        raise HTTPException(status.HTTP_502_BAD_GATEWAY, "DataCore is unreachable")
+    return resp
+
+
+def _dc_create(tenant: str, entity_type: str, base_data: dict, token: str | None) -> dict:
+    resp = _dc("POST", f"/api/entities/{tenant}/{entity_type}", token,
+               {"base_data": base_data, "custom_fields": {}})
+    if resp.status_code not in (200, 201):
+        raise HTTPException(resp.status_code, f"DataCore create failed: {resp.text}")
+    return resp.json()
+
+
+def _dc_update(tenant: str, entity_type: str, entity_id: str, base_data: dict, token: str | None) -> dict:
+    resp = _dc("PUT", f"/api/entities/{tenant}/{entity_type}/{entity_id}", token,
+               {"base_data": base_data, "custom_fields": {}})
+    if resp.status_code not in (200, 201):
+        raise HTTPException(resp.status_code, f"DataCore update failed: {resp.text}")
+    return resp.json()
+
+
+def _dc_query(tenant: str, sql: str, token: str | None) -> list[dict]:
+    resp = _dc("POST", "/api/query", token,
+               {"tenant_id": tenant, "table": "entities", "sql": sql})
+    if resp.status_code != 200:
+        raise HTTPException(resp.status_code, f"DataCore query failed: {resp.text}")
+    return resp.json().get("data", [])
+
+
+def _get_lead(tenant: str, lead_id: str, token: str | None) -> dict | None:
+    rows = _dc_query(
+        tenant,
+        f"SELECT * FROM data WHERE entity_type = 'lead' "
+        f"AND entity_id = '{lead_id}' AND _status = 'active'",
+        token,
+    )
+    return rows[0] if rows else None
+
+
+def _tenant_exists(tenant: str) -> bool:
+    rows = _dc_query(
+        tenant,
+        f"SELECT entity_id FROM data WHERE entity_type = 'tenant' "
+        f"AND entity_id = '{tenant}' AND _status = 'active'",
+        None,
+    )
+    return bool(rows)
+
+
+# ── Schemas ───────────────────────────────────────────────────────────────
+class LeadCreate(BaseModel):
+    guardian_name: str
+    email: str | None = None
+    phone: str | None = None
+    student_first_name: str | None = None
+    student_last_name: str | None = None
+    grade_of_interest: str | None = None
+    message: str | None = None
+
+    @model_validator(mode="after")
+    def _contact_required(self):
+        if not (self.email or self.phone):
+            raise ValueError("At least one of email or phone is required")
+        return self
+
+
+class PublicLeadCreate(LeadCreate):
+    """Same prospect fields; internal fields (stage/source/converted_family_id) are never accepted."""
+
+
+class StageUpdate(BaseModel):
+    stage: str
+
+
+class ActivityCreate(BaseModel):
+    type: str
+    body: str
+
+
+class ConvertRequest(BaseModel):
+    family_name: str
+    primary_address: str
+    primary_email: str | None = None
+    primary_phone: str | None = None
+    student_first_name: str
+    student_last_name: str
+    grade_level: str | None = None

--- a/admindash/backend/app/main.py
+++ b/admindash/backend/app/main.py
@@ -4,7 +4,7 @@ import os
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from app.api import auth, entities, extract, health, query
+from app.api import auth, entities, extract, health, leads, query
 from app.config import settings
 from app.middleware.cloudflare_ip import CloudflareIPMiddleware
 
@@ -38,3 +38,4 @@ app.include_router(health.router, prefix="/api", tags=["health"])
 app.include_router(query.router, prefix="/api", tags=["query"])
 app.include_router(entities.router, prefix="/api", tags=["entities"])
 app.include_router(extract.router, prefix="/api", tags=["extract"])
+app.include_router(leads.router, prefix="/api", tags=["leads"])

--- a/admindash/backend/tests/test_leads.py
+++ b/admindash/backend/tests/test_leads.py
@@ -272,6 +272,17 @@ def test_public_intake_unknown_tenant_404(client):
     assert resp.status_code == 404
 
 
+@respx.mock
+def test_public_intake_rejects_malformed_tenant_id(client):
+    """tenant_id with characters outside [A-Za-z0-9_-] must be rejected before DataCore is called."""
+    # No DataCore routes registered — if the code reaches _tenant_exists/_dc_query it will error
+    resp = client.post(
+        "/api/public/leads/t1'%20OR%201=1",
+        json={"guardian_name": "Probe", "email": "p@e.com"},
+    )
+    assert resp.status_code in (400, 404)
+
+
 def test_public_intake_needs_no_jwt(client):
     # No Authorization header at all — must not 401 on auth (tenant check will run)
     import respx as _r

--- a/admindash/backend/tests/test_leads.py
+++ b/admindash/backend/tests/test_leads.py
@@ -197,3 +197,49 @@ def test_list_activities_desc(client):
     assert resp.status_code == 200
     sql = _j.loads(route.calls.last.request.content)["sql"]
     assert "lead_activity" in sql and "lead_id = 'ld1'" in sql and "ORDER BY _created_at DESC" in sql
+
+
+# ── convert lead routes ───────────────────────────────────────────────────
+
+
+@respx.mock
+def test_convert_creates_family_student_and_links(client):
+    _stub_auth(respx)
+    respx.post("http://localhost:5800/api/query").mock(
+        return_value=httpx.Response(200, json={"data": [
+            {"entity_id": "ld1", "guardian_name": "Sam", "email": "s@e.com",
+             "stage": "Toured", "source": "manual"}], "total": 1}))
+    fam = respx.post("http://localhost:5800/api/entities/t1/family").mock(
+        return_value=httpx.Response(201, json={"entity_id": "fam1", "base_data": {"family_id": "F-1"}}))
+    stu = respx.post("http://localhost:5800/api/entities/t1/student").mock(
+        return_value=httpx.Response(201, json={"entity_id": "stu1"}))
+    upd = respx.put("http://localhost:5800/api/entities/t1/lead/ld1").mock(
+        return_value=httpx.Response(200, json={"entity_id": "ld1"}))
+    act = respx.post("http://localhost:5800/api/entities/t1/lead_activity").mock(
+        return_value=httpx.Response(201, json={}))
+    resp = client.post("/api/leads/t1/ld1/convert",
+        json={"family_name": "Rivera Family", "primary_address": "1 Main St",
+              "student_first_name": "Ada", "student_last_name": "Rivera"},
+        headers={"Authorization": "Bearer good"})
+    assert resp.status_code == 201
+    assert fam.called and stu.called and upd.called and act.called
+    import json as _j
+    stu_body = _j.loads(stu.calls.last.request.content)["base_data"]
+    assert stu_body["family_id"] == "fam1" and stu_body["status"] == "Enrolled"
+    lead_body = _j.loads(upd.calls.last.request.content)["base_data"]
+    assert lead_body["converted_family_id"] == "fam1" and lead_body["stage"] == "Enrolled"
+
+
+@respx.mock
+def test_convert_guards_double_conversion(client):
+    _stub_auth(respx)
+    respx.post("http://localhost:5800/api/query").mock(
+        return_value=httpx.Response(200, json={"data": [
+            {"entity_id": "ld1", "guardian_name": "Sam", "email": "s@e.com",
+             "stage": "Enrolled", "converted_family_id": "famX"}], "total": 1}))
+    resp = client.post("/api/leads/t1/ld1/convert",
+        json={"family_name": "X", "primary_address": "Y",
+              "student_first_name": "A", "student_last_name": "B"},
+        headers={"Authorization": "Bearer good"})
+    assert resp.status_code == 409
+    assert "famX" in resp.json()["detail"]

--- a/admindash/backend/tests/test_leads.py
+++ b/admindash/backend/tests/test_leads.py
@@ -1,4 +1,7 @@
+import json as _j
+
 import httpx
+import pytest
 import respx
 
 
@@ -11,3 +14,100 @@ def _stub_auth(mock):
 def test_stages_constant_is_ordered():
     from app.api.leads import STAGES
     assert STAGES == ["New", "Contacted", "Tour Scheduled", "Toured", "Enrolled", "Lost"]
+
+
+# ── create / list / get routes ────────────────────────────────────────────
+
+
+@respx.mock
+def test_create_lead_manual(client):
+    _stub_auth(respx)
+    route = respx.post("http://localhost:5800/api/entities/t1/lead").mock(
+        return_value=httpx.Response(201, json={
+            "entity_id": "ld1", "base_data": {
+                "guardian_name": "Sam Rivera", "email": "sam@example.com",
+                "source": "manual", "stage": "New"}})
+    )
+    resp = client.post("/api/leads/t1",
+        json={"guardian_name": "Sam Rivera", "email": "sam@example.com"},
+        headers={"Authorization": "Bearer good"})
+    assert resp.status_code == 201
+    sent = route.calls.last.request
+    body = _j.loads(sent.content)
+    assert body["base_data"]["source"] == "manual"
+    assert body["base_data"]["stage"] == "New"
+
+
+@respx.mock
+def test_create_lead_requires_contact(client):
+    _stub_auth(respx)
+    resp = client.post("/api/leads/t1", json={"guardian_name": "No Contact"},
+        headers={"Authorization": "Bearer good"})
+    assert resp.status_code == 422
+
+
+@respx.mock
+def test_list_leads_filters_by_stage(client):
+    _stub_auth(respx)
+    route = respx.post("http://localhost:5800/api/query").mock(
+        return_value=httpx.Response(200, json={"data": [{"entity_id": "ld1", "stage": "Toured"}], "total": 1}))
+    resp = client.get("/api/leads/t1?stage=Toured", headers={"Authorization": "Bearer good"})
+    assert resp.status_code == 200
+    sql = _j.loads(route.calls.last.request.content)["sql"]
+    assert "entity_type = 'lead'" in sql and "stage = 'Toured'" in sql
+
+
+def test_list_leads_requires_auth(client):
+    resp = client.get("/api/leads/t1")
+    assert resp.status_code == 401
+
+
+@respx.mock
+def test_get_lead_returns_lead(client):
+    _stub_auth(respx)
+    respx.post("http://localhost:5800/api/query").mock(
+        return_value=httpx.Response(200, json={"data": [{"entity_id": "ld1", "stage": "New"}], "total": 1}))
+    resp = client.get("/api/leads/t1/ld1", headers={"Authorization": "Bearer good"})
+    assert resp.status_code == 200
+    assert resp.json()["entity_id"] == "ld1"
+
+
+@respx.mock
+def test_get_lead_not_found(client):
+    _stub_auth(respx)
+    respx.post("http://localhost:5800/api/query").mock(
+        return_value=httpx.Response(200, json={"data": [], "total": 0}))
+    resp = client.get("/api/leads/t1/missing", headers={"Authorization": "Bearer good"})
+    assert resp.status_code == 404
+
+
+@respx.mock
+def test_create_lead_honors_email_import_source(client):
+    _stub_auth(respx)
+    # Case 1: email_import source is preserved
+    route = respx.post("http://localhost:5800/api/entities/t1/lead").mock(
+        return_value=httpx.Response(201, json={
+            "entity_id": "ld2", "base_data": {
+                "guardian_name": "X", "email": "x@e.com",
+                "source": "email_import", "stage": "New"}})
+    )
+    resp = client.post("/api/leads/t1",
+        json={"guardian_name": "X", "email": "x@e.com", "source": "email_import"},
+        headers={"Authorization": "Bearer good"})
+    assert resp.status_code == 201
+    body = _j.loads(route.calls.last.request.content)
+    assert body["base_data"]["source"] == "email_import"
+
+    # Case 2: unknown source falls back to manual
+    route2 = respx.post("http://localhost:5800/api/entities/t1/lead").mock(
+        return_value=httpx.Response(201, json={
+            "entity_id": "ld3", "base_data": {
+                "guardian_name": "X", "email": "x@e.com",
+                "source": "manual", "stage": "New"}})
+    )
+    resp2 = client.post("/api/leads/t1",
+        json={"guardian_name": "X", "email": "x@e.com", "source": "unknown_value"},
+        headers={"Authorization": "Bearer good"})
+    assert resp2.status_code == 201
+    body2 = _j.loads(route2.calls.last.request.content)
+    assert body2["base_data"]["source"] == "manual"

--- a/admindash/backend/tests/test_leads.py
+++ b/admindash/backend/tests/test_leads.py
@@ -243,3 +243,58 @@ def test_convert_guards_double_conversion(client):
         headers={"Authorization": "Bearer good"})
     assert resp.status_code == 409
     assert "famX" in resp.json()["detail"]
+
+
+# ── public intake route ───────────────────────────────────────────────────────
+
+
+@respx.mock
+def test_public_intake_creates_web_form_lead(client):
+    respx.post("http://localhost:5800/api/query").mock(  # tenant existence check
+        return_value=httpx.Response(200, json={"data": [{"entity_id": "t1"}], "total": 1}))
+    create = respx.post("http://localhost:5800/api/entities/t1/lead").mock(
+        return_value=httpx.Response(201, json={"entity_id": "ld1"}))
+    resp = client.post("/api/public/leads/t1",
+        json={"guardian_name": "Prospect", "email": "p@e.com", "stage": "Enrolled",
+              "converted_family_id": "hack"})  # internal fields must be ignored
+    assert resp.status_code == 201
+    b = _j.loads(create.calls.last.request.content)["base_data"]
+    assert b["source"] == "web_form" and b["stage"] == "New"
+    assert "converted_family_id" not in b
+
+
+@respx.mock
+def test_public_intake_unknown_tenant_404(client):
+    respx.post("http://localhost:5800/api/query").mock(
+        return_value=httpx.Response(200, json={"data": [], "total": 0}))
+    resp = client.post("/api/public/leads/ghost",
+        json={"guardian_name": "P", "email": "p@e.com"})
+    assert resp.status_code == 404
+
+
+def test_public_intake_needs_no_jwt(client):
+    # No Authorization header at all — must not 401 on auth (tenant check will run)
+    import respx as _r
+    with _r.mock:
+        _r.post("http://localhost:5800/api/query").mock(
+            return_value=httpx.Response(200, json={"data": [], "total": 0}))
+        resp = client.post("/api/public/leads/t1", json={"guardian_name": "P", "phone": "555"})
+    assert resp.status_code != 401
+
+
+@respx.mock
+def test_public_intake_source_field_overridden(client):
+    """Prospect-supplied source/stage/converted_family_id must never reach DataCore."""
+    respx.post("http://localhost:5800/api/query").mock(
+        return_value=httpx.Response(200, json={"data": [{"entity_id": "t1"}], "total": 1}))
+    create = respx.post("http://localhost:5800/api/entities/t1/lead").mock(
+        return_value=httpx.Response(201, json={"entity_id": "ld1"}))
+    resp = client.post("/api/public/leads/t1",
+        json={"guardian_name": "Prospect", "email": "p@e.com",
+              "source": "email_import", "stage": "Enrolled",
+              "converted_family_id": "fam-hack"})
+    assert resp.status_code == 201
+    b = _j.loads(create.calls.last.request.content)["base_data"]
+    assert b["source"] == "web_form"
+    assert b["stage"] == "New"
+    assert "converted_family_id" not in b

--- a/admindash/backend/tests/test_leads.py
+++ b/admindash/backend/tests/test_leads.py
@@ -11,9 +11,28 @@ def _stub_auth(mock):
     )
 
 
+def _stub_query(mock, *, lead_model=None, entity_rows=None):
+    """Route /api/query by request body's `table`.
+
+    lead_model: list[str] of stage options to expose as the lead model's
+        `stage` selection field. None → models query returns empty (no model).
+    entity_rows: list[dict] returned for entities-table queries.
+    """
+    def responder(request):
+        body = _j.loads(request.content)
+        if body.get("table") == "models":
+            data = [{"model_definition": {"base_fields": [
+                {"name": "stage", "type": "selection", "options": lead_model}]}}] if lead_model else []
+            return httpx.Response(200, json={"data": data, "total": len(data)})
+        rows = entity_rows or []
+        return httpx.Response(200, json={"data": rows, "total": len(rows)})
+
+    mock.post("http://localhost:5800/api/query").mock(side_effect=responder)
+
+
 def test_stages_constant_is_ordered():
-    from app.api.leads import STAGES
-    assert STAGES == ["New", "Contacted", "Tour Scheduled", "Toured", "Enrolled", "Lost"]
+    from app.api.leads import DEFAULT_STAGES
+    assert DEFAULT_STAGES == ["New", "Contacted", "Tour Scheduled", "Toured", "Enrolled", "Lost"]
 
 
 # ── create / list / get routes ────────────────────────────────────────────
@@ -22,6 +41,7 @@ def test_stages_constant_is_ordered():
 @respx.mock
 def test_create_lead_manual(client):
     _stub_auth(respx)
+    _stub_query(respx)  # no lead model → DEFAULT_STAGES, first = "New"
     route = respx.post("http://localhost:5800/api/entities/t1/lead").mock(
         return_value=httpx.Response(201, json={
             "entity_id": "ld1", "base_data": {
@@ -39,21 +59,47 @@ def test_create_lead_manual(client):
 
 
 @respx.mock
-def test_create_lead_requires_contact(client):
+def test_create_lead_permissive_forwards_extra_field(client):
     _stub_auth(respx)
-    resp = client.post("/api/leads/t1", json={"guardian_name": "No Contact"},
+    _stub_query(respx)  # no model → DEFAULT_STAGES
+    route = respx.post("http://localhost:5800/api/entities/t1/lead").mock(
+        return_value=httpx.Response(201, json={"entity_id": "ld1"}))
+    # No email/phone (no longer required) + an extra custom field
+    resp = client.post("/api/leads/t1",
+        json={"guardian_name": "No Contact", "referral_source": "Friend"},
         headers={"Authorization": "Bearer good"})
-    assert resp.status_code == 422
+    assert resp.status_code == 201
+    body = _j.loads(route.calls.last.request.content)["base_data"]
+    assert body["referral_source"] == "Friend"
+    assert body["source"] == "manual"
+    assert body["stage"] == "New"  # first DEFAULT_STAGE
+
+
+@respx.mock
+def test_create_lead_first_stage_from_model(client):
+    _stub_auth(respx)
+    _stub_query(respx, lead_model=["Inquiry", "Applied", "Enrolled"])
+    route = respx.post("http://localhost:5800/api/entities/t1/lead").mock(
+        return_value=httpx.Response(201, json={"entity_id": "ld1"}))
+    resp = client.post("/api/leads/t1",
+        json={"guardian_name": "Sam", "email": "s@e.com"},
+        headers={"Authorization": "Bearer good"})
+    assert resp.status_code == 201
+    body = _j.loads(route.calls.last.request.content)["base_data"]
+    assert body["stage"] == "Inquiry"  # first model stage option
 
 
 @respx.mock
 def test_list_leads_filters_by_stage(client):
     _stub_auth(respx)
-    route = respx.post("http://localhost:5800/api/query").mock(
-        return_value=httpx.Response(200, json={"data": [{"entity_id": "ld1", "stage": "Toured"}], "total": 1}))
+    _stub_query(respx, entity_rows=[{"entity_id": "ld1", "stage": "Toured"}])
     resp = client.get("/api/leads/t1?stage=Toured", headers={"Authorization": "Bearer good"})
     assert resp.status_code == 200
-    sql = _j.loads(route.calls.last.request.content)["sql"]
+    # Find the entities query (last call may be either; grab the entities one)
+    entity_calls = [c for c in respx.calls
+                    if c.request.url.path == "/api/query"
+                    and _j.loads(c.request.content).get("table") != "models"]
+    sql = _j.loads(entity_calls[-1].request.content)["sql"]
     assert "entity_type = 'lead'" in sql and "stage = 'Toured'" in sql
 
 
@@ -65,8 +111,7 @@ def test_list_leads_requires_auth(client):
 @respx.mock
 def test_get_lead_returns_lead(client):
     _stub_auth(respx)
-    respx.post("http://localhost:5800/api/query").mock(
-        return_value=httpx.Response(200, json={"data": [{"entity_id": "ld1", "stage": "New"}], "total": 1}))
+    _stub_query(respx, entity_rows=[{"entity_id": "ld1", "stage": "New"}])
     resp = client.get("/api/leads/t1/ld1", headers={"Authorization": "Bearer good"})
     assert resp.status_code == 200
     assert resp.json()["entity_id"] == "ld1"
@@ -75,8 +120,7 @@ def test_get_lead_returns_lead(client):
 @respx.mock
 def test_get_lead_not_found(client):
     _stub_auth(respx)
-    respx.post("http://localhost:5800/api/query").mock(
-        return_value=httpx.Response(200, json={"data": [], "total": 0}))
+    _stub_query(respx, entity_rows=[])
     resp = client.get("/api/leads/t1/missing", headers={"Authorization": "Bearer good"})
     assert resp.status_code == 404
 
@@ -84,6 +128,7 @@ def test_get_lead_not_found(client):
 @respx.mock
 def test_create_lead_honors_email_import_source(client):
     _stub_auth(respx)
+    _stub_query(respx)
     # Case 1: email_import source is preserved
     route = respx.post("http://localhost:5800/api/entities/t1/lead").mock(
         return_value=httpx.Response(201, json={
@@ -116,17 +161,12 @@ def test_create_lead_honors_email_import_source(client):
 # ── stage transition routes ───────────────────────────────────────────────
 
 
-def _stub_lead(mock, lead_id="ld1", stage="New"):
-    mock.post("http://localhost:5800/api/query").mock(
-        return_value=httpx.Response(200, json={"data": [
-            {"entity_id": lead_id, "guardian_name": "Sam", "email": "s@e.com",
-             "stage": stage, "source": "manual"}], "total": 1}))
-
-
 @respx.mock
 def test_stage_change_updates_and_logs(client):
     _stub_auth(respx)
-    _stub_lead(respx, stage="New")
+    _stub_query(respx, lead_model=["New", "Contacted", "Tour Scheduled", "Toured", "Enrolled", "Lost"],
+                entity_rows=[{"entity_id": "ld1", "guardian_name": "Sam", "email": "s@e.com",
+                              "stage": "New", "source": "manual"}])
     upd = respx.put("http://localhost:5800/api/entities/t1/lead/ld1").mock(
         return_value=httpx.Response(200, json={"entity_id": "ld1", "base_data": {"stage": "Contacted"}}))
     act = respx.post("http://localhost:5800/api/entities/t1/lead_activity").mock(
@@ -142,9 +182,57 @@ def test_stage_change_updates_and_logs(client):
 
 
 @respx.mock
+def test_stage_change_no_model_falls_back_to_default(client):
+    """When the models query returns empty, DEFAULT_STAGES is used for validation."""
+    _stub_auth(respx)
+    _stub_query(respx, lead_model=None,  # no model
+                entity_rows=[{"entity_id": "ld1", "stage": "New", "source": "manual"}])
+    upd = respx.put("http://localhost:5800/api/entities/t1/lead/ld1").mock(
+        return_value=httpx.Response(200, json={"entity_id": "ld1"}))
+    act = respx.post("http://localhost:5800/api/entities/t1/lead_activity").mock(
+        return_value=httpx.Response(201, json={"entity_id": "la1"}))
+    resp = client.patch("/api/leads/t1/ld1/stage", json={"stage": "Contacted"},
+        headers={"Authorization": "Bearer good"})
+    assert resp.status_code == 200  # "Contacted" is in DEFAULT_STAGES
+    assert upd.called and act.called
+
+
+@respx.mock
+def test_stage_change_preserves_custom_field(client):
+    """_lead_base_data must carry custom fields and drop system/metadata columns."""
+    _stub_auth(respx)
+    _stub_query(respx, lead_model=None,
+                entity_rows=[{
+                    "entity_id": "ld1", "entity_type": "lead",
+                    "guardian_name": "Sam", "email": "s@e.com",
+                    "stage": "New", "source": "manual",
+                    "referral_source": "Friend",  # custom field
+                    "base_data": {"guardian_name": "Sam"},  # system col → dropped
+                    "custom_fields": {}, "vector": [0.1],
+                    "_status": "active", "_version": 3, "_created_at": "x",
+                    "_updated_at": "y", "_change_id": "c1"}])
+    upd = respx.put("http://localhost:5800/api/entities/t1/lead/ld1").mock(
+        return_value=httpx.Response(200, json={"entity_id": "ld1"}))
+    respx.post("http://localhost:5800/api/entities/t1/lead_activity").mock(
+        return_value=httpx.Response(201, json={"entity_id": "la1"}))
+    resp = client.patch("/api/leads/t1/ld1/stage", json={"stage": "Contacted"},
+        headers={"Authorization": "Bearer good"})
+    assert resp.status_code == 200
+    put_body = _j.loads(upd.calls.last.request.content)["base_data"]
+    assert put_body["referral_source"] == "Friend"  # custom field preserved
+    assert put_body["stage"] == "Contacted"
+    # system + metadata columns dropped
+    for k in ("entity_id", "entity_type", "base_data", "custom_fields", "vector",
+              "_status", "_version", "_created_at", "_updated_at", "_change_id"):
+        assert k not in put_body
+
+
+@respx.mock
 def test_stage_change_same_stage_no_activity(client):
     _stub_auth(respx)
-    _stub_lead(respx, stage="Contacted")
+    _stub_query(respx, lead_model=None,
+                entity_rows=[{"entity_id": "ld1", "guardian_name": "Sam",
+                              "stage": "Contacted", "source": "manual"}])
     upd = respx.put("http://localhost:5800/api/entities/t1/lead/ld1").mock(
         return_value=httpx.Response(200, json={"entity_id": "ld1"}))
     act = respx.post("http://localhost:5800/api/entities/t1/lead_activity").mock(
@@ -158,6 +246,7 @@ def test_stage_change_same_stage_no_activity(client):
 @respx.mock
 def test_stage_change_rejects_unknown_stage(client):
     _stub_auth(respx)
+    _stub_query(respx, lead_model=None)  # DEFAULT_STAGES, "Nope" not in it
     resp = client.patch("/api/leads/t1/ld1/stage", json={"stage": "Nope"},
         headers={"Authorization": "Bearer good"})
     assert resp.status_code == 400
@@ -191,11 +280,10 @@ def test_add_activity_rejects_bad_type(client):
 @respx.mock
 def test_list_activities_desc(client):
     _stub_auth(respx)
-    route = respx.post("http://localhost:5800/api/query").mock(
-        return_value=httpx.Response(200, json={"data": [{"entity_id": "la2"}, {"entity_id": "la1"}], "total": 2}))
+    _stub_query(respx, entity_rows=[{"entity_id": "la2"}, {"entity_id": "la1"}])
     resp = client.get("/api/leads/t1/ld1/activities", headers={"Authorization": "Bearer good"})
     assert resp.status_code == 200
-    sql = _j.loads(route.calls.last.request.content)["sql"]
+    sql = _j.loads(respx.calls.last.request.content)["sql"]
     assert "lead_activity" in sql and "lead_id = 'ld1'" in sql and "ORDER BY _created_at DESC" in sql
 
 
@@ -205,10 +293,9 @@ def test_list_activities_desc(client):
 @respx.mock
 def test_convert_creates_family_student_and_links(client):
     _stub_auth(respx)
-    respx.post("http://localhost:5800/api/query").mock(
-        return_value=httpx.Response(200, json={"data": [
-            {"entity_id": "ld1", "guardian_name": "Sam", "email": "s@e.com",
-             "stage": "Toured", "source": "manual"}], "total": 1}))
+    _stub_query(respx, lead_model=["Inquiry", "Applied", "Enrolled"],
+                entity_rows=[{"entity_id": "ld1", "guardian_name": "Sam", "email": "s@e.com",
+                              "stage": "Applied", "source": "manual"}])
     fam = respx.post("http://localhost:5800/api/entities/t1/family").mock(
         return_value=httpx.Response(201, json={"entity_id": "fam1", "base_data": {"family_id": "F-1"}}))
     stu = respx.post("http://localhost:5800/api/entities/t1/student").mock(
@@ -223,20 +310,92 @@ def test_convert_creates_family_student_and_links(client):
         headers={"Authorization": "Bearer good"})
     assert resp.status_code == 201
     assert fam.called and stu.called and upd.called and act.called
-    import json as _j
     stu_body = _j.loads(stu.calls.last.request.content)["base_data"]
     assert stu_body["family_id"] == "fam1" and stu_body["status"] == "Enrolled"
     lead_body = _j.loads(upd.calls.last.request.content)["base_data"]
+    # default target = LAST model stage option
     assert lead_body["converted_family_id"] == "fam1" and lead_body["stage"] == "Enrolled"
+
+
+@respx.mock
+def test_convert_honors_explicit_target_stage(client):
+    _stub_auth(respx)
+    _stub_query(respx, lead_model=["Inquiry", "Applied", "Accepted", "Enrolled"],
+                entity_rows=[{"entity_id": "ld1", "guardian_name": "Sam",
+                              "stage": "Applied", "source": "manual"}])
+    respx.post("http://localhost:5800/api/entities/t1/family").mock(
+        return_value=httpx.Response(201, json={"entity_id": "fam1"}))
+    respx.post("http://localhost:5800/api/entities/t1/student").mock(
+        return_value=httpx.Response(201, json={"entity_id": "stu1"}))
+    upd = respx.put("http://localhost:5800/api/entities/t1/lead/ld1").mock(
+        return_value=httpx.Response(200, json={"entity_id": "ld1"}))
+    respx.post("http://localhost:5800/api/entities/t1/lead_activity").mock(
+        return_value=httpx.Response(201, json={}))
+    resp = client.post("/api/leads/t1/ld1/convert",
+        json={"family_name": "X", "primary_address": "Y",
+              "student_first_name": "A", "student_last_name": "B",
+              "target_stage": "Accepted"},
+        headers={"Authorization": "Bearer good"})
+    assert resp.status_code == 201
+    lead_body = _j.loads(upd.calls.last.request.content)["base_data"]
+    assert lead_body["stage"] == "Accepted"
+
+
+@respx.mock
+def test_convert_rejects_target_stage_not_in_options(client):
+    _stub_auth(respx)
+    _stub_query(respx, lead_model=["Inquiry", "Applied", "Enrolled"],
+                entity_rows=[{"entity_id": "ld1", "guardian_name": "Sam",
+                              "stage": "Applied", "source": "manual"}])
+    respx.post("http://localhost:5800/api/entities/t1/family").mock(
+        return_value=httpx.Response(201, json={"entity_id": "fam1"}))
+    respx.post("http://localhost:5800/api/entities/t1/student").mock(
+        return_value=httpx.Response(201, json={"entity_id": "stu1"}))
+    respx.put("http://localhost:5800/api/entities/t1/lead/ld1").mock(
+        return_value=httpx.Response(200, json={"entity_id": "ld1"}))
+    resp = client.post("/api/leads/t1/ld1/convert",
+        json={"family_name": "X", "primary_address": "Y",
+              "student_first_name": "A", "student_last_name": "B",
+              "target_stage": "Bogus"},
+        headers={"Authorization": "Bearer good"})
+    assert resp.status_code == 400
+
+
+@respx.mock
+def test_convert_preserves_custom_field(client):
+    _stub_auth(respx)
+    _stub_query(respx, lead_model=None,
+                entity_rows=[{"entity_id": "ld1", "guardian_name": "Sam", "email": "s@e.com",
+                              "stage": "Toured", "source": "manual",
+                              "referral_source": "Friend",
+                              "base_data": {}, "custom_fields": {}, "vector": [0.1],
+                              "_status": "active", "_version": 1}])
+    respx.post("http://localhost:5800/api/entities/t1/family").mock(
+        return_value=httpx.Response(201, json={"entity_id": "fam1"}))
+    respx.post("http://localhost:5800/api/entities/t1/student").mock(
+        return_value=httpx.Response(201, json={"entity_id": "stu1"}))
+    upd = respx.put("http://localhost:5800/api/entities/t1/lead/ld1").mock(
+        return_value=httpx.Response(200, json={"entity_id": "ld1"}))
+    respx.post("http://localhost:5800/api/entities/t1/lead_activity").mock(
+        return_value=httpx.Response(201, json={}))
+    resp = client.post("/api/leads/t1/ld1/convert",
+        json={"family_name": "X", "primary_address": "Y",
+              "student_first_name": "A", "student_last_name": "B"},
+        headers={"Authorization": "Bearer good"})
+    assert resp.status_code == 201
+    lead_body = _j.loads(upd.calls.last.request.content)["base_data"]
+    assert lead_body["referral_source"] == "Friend"
+    assert lead_body["converted_family_id"] == "fam1"
+    assert lead_body["stage"] == "Lost"  # last DEFAULT_STAGE
+    assert "vector" not in lead_body and "_status" not in lead_body
 
 
 @respx.mock
 def test_convert_guards_double_conversion(client):
     _stub_auth(respx)
-    respx.post("http://localhost:5800/api/query").mock(
-        return_value=httpx.Response(200, json={"data": [
-            {"entity_id": "ld1", "guardian_name": "Sam", "email": "s@e.com",
-             "stage": "Enrolled", "converted_family_id": "famX"}], "total": 1}))
+    _stub_query(respx, lead_model=None,
+                entity_rows=[{"entity_id": "ld1", "guardian_name": "Sam", "email": "s@e.com",
+                              "stage": "Enrolled", "converted_family_id": "famX"}])
     resp = client.post("/api/leads/t1/ld1/convert",
         json={"family_name": "X", "primary_address": "Y",
               "student_first_name": "A", "student_last_name": "B"},
@@ -250,8 +409,8 @@ def test_convert_guards_double_conversion(client):
 
 @respx.mock
 def test_public_intake_creates_web_form_lead(client):
-    respx.post("http://localhost:5800/api/query").mock(  # tenant existence check
-        return_value=httpx.Response(200, json={"data": [{"entity_id": "t1"}], "total": 1}))
+    # tenant existence check (entities) + model query both route through _stub_query
+    _stub_query(respx, lead_model=None, entity_rows=[{"entity_id": "t1"}])
     create = respx.post("http://localhost:5800/api/entities/t1/lead").mock(
         return_value=httpx.Response(201, json={"entity_id": "ld1"}))
     resp = client.post("/api/public/leads/t1",
@@ -265,8 +424,7 @@ def test_public_intake_creates_web_form_lead(client):
 
 @respx.mock
 def test_public_intake_unknown_tenant_404(client):
-    respx.post("http://localhost:5800/api/query").mock(
-        return_value=httpx.Response(200, json={"data": [], "total": 0}))
+    _stub_query(respx, lead_model=None, entity_rows=[])  # tenant not found
     resp = client.post("/api/public/leads/ghost",
         json={"guardian_name": "P", "email": "p@e.com"})
     assert resp.status_code == 404
@@ -287,8 +445,7 @@ def test_public_intake_needs_no_jwt(client):
     # No Authorization header at all — must not 401 on auth (tenant check will run)
     import respx as _r
     with _r.mock:
-        _r.post("http://localhost:5800/api/query").mock(
-            return_value=httpx.Response(200, json={"data": [], "total": 0}))
+        _stub_query(_r, lead_model=None, entity_rows=[])  # tenant not found → 404, not 401
         resp = client.post("/api/public/leads/t1", json={"guardian_name": "P", "phone": "555"})
     assert resp.status_code != 401
 
@@ -296,8 +453,7 @@ def test_public_intake_needs_no_jwt(client):
 @respx.mock
 def test_public_intake_source_field_overridden(client):
     """Prospect-supplied source/stage/converted_family_id must never reach DataCore."""
-    respx.post("http://localhost:5800/api/query").mock(
-        return_value=httpx.Response(200, json={"data": [{"entity_id": "t1"}], "total": 1}))
+    _stub_query(respx, lead_model=None, entity_rows=[{"entity_id": "t1"}])
     create = respx.post("http://localhost:5800/api/entities/t1/lead").mock(
         return_value=httpx.Response(201, json={"entity_id": "ld1"}))
     resp = client.post("/api/public/leads/t1",

--- a/admindash/backend/tests/test_leads.py
+++ b/admindash/backend/tests/test_leads.py
@@ -465,3 +465,62 @@ def test_public_intake_source_field_overridden(client):
     assert b["source"] == "web_form"
     assert b["stage"] == "New"
     assert "converted_family_id" not in b
+
+
+# ── public lead model route ───────────────────────────────────────────────────
+
+
+def _stub_query_with_base_fields(mock, *, base_fields=None):
+    """Stub /api/query so models table returns a lead model with given base_fields list."""
+    def responder(request):
+        body = _j.loads(request.content)
+        if body.get("table") == "models":
+            data = [{"model_definition": {"lead": {"base_fields": base_fields, "custom_fields": []}}}] if base_fields is not None else []
+            return httpx.Response(200, json={"data": data, "total": len(data)})
+        return httpx.Response(200, json={"data": [], "total": 0})
+    mock.post("http://localhost:5800/api/query").mock(side_effect=responder)
+
+
+@respx.mock
+def test_public_model_returns_prospect_fields_from_model(client):
+    """Model's base_fields are returned minus all four reserved fields."""
+    _stub_query_with_base_fields(respx, base_fields=[
+        {"name": "guardian_name", "type": "str", "required": True},
+        {"name": "hear_about_us", "type": "str", "required": False},
+        {"name": "stage", "type": "selection", "required": False},
+        {"name": "source", "type": "str", "required": False},
+        {"name": "lead_id", "type": "str", "required": False},
+        {"name": "converted_family_id", "type": "str", "required": False},
+    ])
+    resp = client.get("/api/public/leads/t1/model")
+    assert resp.status_code == 200
+    names = [f["name"] for f in resp.json()["fields"]]
+    assert "guardian_name" in names
+    assert "hear_about_us" in names
+    for reserved in ("stage", "source", "lead_id", "converted_family_id"):
+        assert reserved not in names
+
+
+@respx.mock
+def test_public_model_falls_back_to_defaults(client):
+    """When models query returns empty, default prospect fields are returned."""
+    _stub_query_with_base_fields(respx, base_fields=None)
+    resp = client.get("/api/public/leads/t1/model")
+    assert resp.status_code == 200
+    names = [f["name"] for f in resp.json()["fields"]]
+    assert "guardian_name" in names
+    assert "stage" not in names
+
+
+@respx.mock
+def test_public_model_no_jwt_required(client):
+    """Endpoint must not 401 when no Authorization header is sent."""
+    _stub_query_with_base_fields(respx, base_fields=None)
+    resp = client.get("/api/public/leads/t1/model")
+    assert resp.status_code != 401
+
+
+def test_public_model_malformed_tenant_404(client):
+    """tenant_id with illegal chars returns 404 without calling DataCore."""
+    resp = client.get("/api/public/leads/t1'%20OR%201=1/model")
+    assert resp.status_code == 404

--- a/admindash/backend/tests/test_leads.py
+++ b/admindash/backend/tests/test_leads.py
@@ -111,3 +111,53 @@ def test_create_lead_honors_email_import_source(client):
     assert resp2.status_code == 201
     body2 = _j.loads(route2.calls.last.request.content)
     assert body2["base_data"]["source"] == "manual"
+
+
+# ── stage transition routes ───────────────────────────────────────────────
+
+
+def _stub_lead(mock, lead_id="ld1", stage="New"):
+    mock.post("http://localhost:5800/api/query").mock(
+        return_value=httpx.Response(200, json={"data": [
+            {"entity_id": lead_id, "guardian_name": "Sam", "email": "s@e.com",
+             "stage": stage, "source": "manual"}], "total": 1}))
+
+
+@respx.mock
+def test_stage_change_updates_and_logs(client):
+    _stub_auth(respx)
+    _stub_lead(respx, stage="New")
+    upd = respx.put("http://localhost:5800/api/entities/t1/lead/ld1").mock(
+        return_value=httpx.Response(200, json={"entity_id": "ld1", "base_data": {"stage": "Contacted"}}))
+    act = respx.post("http://localhost:5800/api/entities/t1/lead_activity").mock(
+        return_value=httpx.Response(201, json={"entity_id": "la1"}))
+    resp = client.patch("/api/leads/t1/ld1/stage", json={"stage": "Contacted"},
+        headers={"Authorization": "Bearer good"})
+    assert resp.status_code == 200
+    assert upd.called and act.called
+    act_body = _j.loads(act.calls.last.request.content)["base_data"]
+    assert act_body["type"] == "stage_change"
+    assert act_body["stage_from"] == "New" and act_body["stage_to"] == "Contacted"
+    assert act_body["created_by"] == "system"
+
+
+@respx.mock
+def test_stage_change_same_stage_no_activity(client):
+    _stub_auth(respx)
+    _stub_lead(respx, stage="Contacted")
+    upd = respx.put("http://localhost:5800/api/entities/t1/lead/ld1").mock(
+        return_value=httpx.Response(200, json={"entity_id": "ld1"}))
+    act = respx.post("http://localhost:5800/api/entities/t1/lead_activity").mock(
+        return_value=httpx.Response(201, json={}))
+    resp = client.patch("/api/leads/t1/ld1/stage", json={"stage": "Contacted"},
+        headers={"Authorization": "Bearer good"})
+    assert resp.status_code == 200
+    assert not act.called
+
+
+@respx.mock
+def test_stage_change_rejects_unknown_stage(client):
+    _stub_auth(respx)
+    resp = client.patch("/api/leads/t1/ld1/stage", json={"stage": "Nope"},
+        headers={"Authorization": "Bearer good"})
+    assert resp.status_code == 400

--- a/admindash/backend/tests/test_leads.py
+++ b/admindash/backend/tests/test_leads.py
@@ -1,0 +1,13 @@
+import httpx
+import respx
+
+
+def _stub_auth(mock):
+    mock.get("http://localhost:5800/auth/me").mock(
+        return_value=httpx.Response(200, json={"id": "u1", "tenant_id": "t1"})
+    )
+
+
+def test_stages_constant_is_ordered():
+    from app.api.leads import STAGES
+    assert STAGES == ["New", "Contacted", "Tour Scheduled", "Toured", "Enrolled", "Lost"]

--- a/admindash/backend/tests/test_leads.py
+++ b/admindash/backend/tests/test_leads.py
@@ -470,12 +470,15 @@ def test_public_intake_source_field_overridden(client):
 # ── public lead model route ───────────────────────────────────────────────────
 
 
-def _stub_query_with_base_fields(mock, *, base_fields=None):
-    """Stub /api/query so models table returns a lead model with given base_fields list."""
+def _stub_query_with_base_fields(mock, *, base_fields=None, custom_fields=None):
+    """Stub /api/query so models table returns a lead model with given base_fields and custom_fields lists."""
     def responder(request):
         body = _j.loads(request.content)
         if body.get("table") == "models":
-            data = [{"model_definition": {"lead": {"base_fields": base_fields, "custom_fields": []}}}] if base_fields is not None else []
+            data = [{"model_definition": {"lead": {
+                "base_fields": base_fields,
+                "custom_fields": custom_fields or [],
+            }}}] if base_fields is not None else []
             return httpx.Response(200, json={"data": data, "total": len(data)})
         return httpx.Response(200, json={"data": [], "total": 0})
     mock.post("http://localhost:5800/api/query").mock(side_effect=responder)
@@ -483,19 +486,21 @@ def _stub_query_with_base_fields(mock, *, base_fields=None):
 
 @respx.mock
 def test_public_model_returns_prospect_fields_from_model(client):
-    """Model's base_fields are returned minus all four reserved fields."""
+    """Model's base_fields + custom_fields are returned minus all four reserved fields."""
     _stub_query_with_base_fields(respx, base_fields=[
         {"name": "guardian_name", "type": "str", "required": True},
-        {"name": "hear_about_us", "type": "str", "required": False},
         {"name": "stage", "type": "selection", "required": False},
         {"name": "source", "type": "str", "required": False},
         {"name": "lead_id", "type": "str", "required": False},
         {"name": "converted_family_id", "type": "str", "required": False},
+    ], custom_fields=[
+        {"name": "hear_about_us", "type": "str", "required": False},
     ])
     resp = client.get("/api/public/leads/t1/model")
     assert resp.status_code == 200
     names = [f["name"] for f in resp.json()["fields"]]
     assert "guardian_name" in names
+    # custom_fields must be surfaced on the public form
     assert "hear_about_us" in names
     for reserved in ("stage", "source", "lead_id", "converted_family_id"):
         assert reserved not in names

--- a/admindash/backend/tests/test_leads.py
+++ b/admindash/backend/tests/test_leads.py
@@ -161,3 +161,39 @@ def test_stage_change_rejects_unknown_stage(client):
     resp = client.patch("/api/leads/t1/ld1/stage", json={"stage": "Nope"},
         headers={"Authorization": "Bearer good"})
     assert resp.status_code == 400
+
+
+# ── activity create + timeline routes ────────────────────────────────────────
+
+
+@respx.mock
+def test_add_activity(client):
+    _stub_auth(respx)
+    act = respx.post("http://localhost:5800/api/entities/t1/lead_activity").mock(
+        return_value=httpx.Response(201, json={"entity_id": "la1"}))
+    resp = client.post("/api/leads/t1/ld1/activities",
+        json={"type": "call", "body": "Left voicemail"},
+        headers={"Authorization": "Bearer good"})
+    assert resp.status_code == 201
+    b = _j.loads(act.calls.last.request.content)["base_data"]
+    assert b["type"] == "call" and b["lead_id"] == "ld1" and b["created_by"] == "u1"
+
+
+@respx.mock
+def test_add_activity_rejects_bad_type(client):
+    _stub_auth(respx)
+    resp = client.post("/api/leads/t1/ld1/activities",
+        json={"type": "carrier_pigeon", "body": "x"},
+        headers={"Authorization": "Bearer good"})
+    assert resp.status_code == 400
+
+
+@respx.mock
+def test_list_activities_desc(client):
+    _stub_auth(respx)
+    route = respx.post("http://localhost:5800/api/query").mock(
+        return_value=httpx.Response(200, json={"data": [{"entity_id": "la2"}, {"entity_id": "la1"}], "total": 2}))
+    resp = client.get("/api/leads/t1/ld1/activities", headers={"Authorization": "Bearer good"})
+    assert resp.status_code == 200
+    sql = _j.loads(route.calls.last.request.content)["sql"]
+    assert "lead_activity" in sql and "lead_id = 'ld1'" in sql and "ORDER BY _created_at DESC" in sql

--- a/admindash/frontend/src/App.tsx
+++ b/admindash/frontend/src/App.tsx
@@ -46,7 +46,7 @@ function AppRoutes() {
                       path="/students/bulk-add"
                       element={<BulkAddStudentsPage tenant={tenant} />}
                     />
-                    <Route path="/leads" element={<LeadPage />} />
+                    <Route path="/leads" element={<LeadPage tenant={tenant} />} />
                     <Route path="/programs" element={<ProgramPage tenant={tenant} />} />
                     <Route path="*" element={<Navigate to="/home" replace />} />
                   </Routes>

--- a/admindash/frontend/src/App.tsx
+++ b/admindash/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { DashboardProvider } from './contexts/DashboardContext.tsx';
 import Navbar from './components/Navbar.tsx';
 import Footer from './components/Footer.tsx';
 import LoginPage from './pages/LoginPage.tsx';
+import PublicInquiryPage from './pages/PublicInquiryPage.tsx';
 import HomePage from './pages/HomePage.tsx';
 import StudentsPage from './pages/StudentsPage.tsx';
 import BulkAddStudentsPage from './pages/BulkAddStudentsPage.tsx';
@@ -24,6 +25,8 @@ function AppRoutes() {
         path="/login"
         element={user ? <Navigate to="/home" replace /> : <LoginPage />}
       />
+
+      <Route path="/inquire/:tenantId" element={<PublicInquiryPage />} />
 
       <Route
         path="*"

--- a/admindash/frontend/src/api/client.ts
+++ b/admindash/frontend/src/api/client.ts
@@ -6,6 +6,7 @@ import type {
   DuplicateCheckResponse,
   Lead,
   LeadActivity,
+  LeadModelField,
 } from '../types/models.ts';
 
 import { ADMINDASH_API_URL } from '../config.ts';
@@ -201,6 +202,7 @@ export interface ConvertPayload {
   family_name: string; primary_address: string;
   primary_email?: string; primary_phone?: string;
   student_first_name: string; student_last_name: string; grade_level?: string;
+  target_stage?: string;
 }
 export async function convertLead(tenantId: string, leadId: string, payload: ConvertPayload) {
   const resp = await fetch(`${API_BASE}/api/leads/${tenantId}/${leadId}/convert`, {
@@ -210,6 +212,14 @@ export async function convertLead(tenantId: string, leadId: string, payload: Con
   if (resp.status === 409) throw new Error(await resp.text());
   if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
   return resp.json();
+}
+
+// Public model fetch — NO auth header.
+export async function fetchPublicLeadModel(tenant: string): Promise<LeadModelField[]> {
+  const resp = await fetch(`${API_BASE}/api/public/leads/${tenant}/model`);
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+  const data = await resp.json();
+  return data.fields as LeadModelField[];
 }
 
 // Public intake — NO auth header.

--- a/admindash/frontend/src/api/client.ts
+++ b/admindash/frontend/src/api/client.ts
@@ -4,6 +4,8 @@ import type {
   NextIdResponse,
   DuplicateCheckRequest,
   DuplicateCheckResponse,
+  Lead,
+  LeadActivity,
 } from '../types/models.ts';
 
 import { ADMINDASH_API_URL } from '../config.ts';
@@ -147,4 +149,74 @@ export async function checkDuplicateStudents(
   );
   if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
   return resp.json();
+}
+
+export async function listLeads(tenantId: string, stage?: string): Promise<Lead[]> {
+  const q = stage ? `?stage=${encodeURIComponent(stage)}` : '';
+  const resp = await fetch(`${API_BASE}/api/leads/${tenantId}${q}`, { headers: authHeaders() });
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+  return (await resp.json()).leads as Lead[];
+}
+
+export async function getLead(tenantId: string, leadId: string): Promise<Lead> {
+  const resp = await fetch(`${API_BASE}/api/leads/${tenantId}/${leadId}`, { headers: authHeaders() });
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+  return resp.json();
+}
+
+export async function createLead(tenantId: string, fields: Partial<Lead>): Promise<Lead> {
+  const resp = await fetch(`${API_BASE}/api/leads/${tenantId}`, {
+    method: 'POST', headers: { 'Content-Type': 'application/json', ...authHeaders() },
+    body: JSON.stringify(fields),
+  });
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+  return resp.json();
+}
+
+export async function updateLeadStage(tenantId: string, leadId: string, stage: string): Promise<Lead> {
+  const resp = await fetch(`${API_BASE}/api/leads/${tenantId}/${leadId}/stage`, {
+    method: 'PATCH', headers: { 'Content-Type': 'application/json', ...authHeaders() },
+    body: JSON.stringify({ stage }),
+  });
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+  return resp.json();
+}
+
+export async function listActivities(tenantId: string, leadId: string): Promise<LeadActivity[]> {
+  const resp = await fetch(`${API_BASE}/api/leads/${tenantId}/${leadId}/activities`, { headers: authHeaders() });
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+  return (await resp.json()).activities as LeadActivity[];
+}
+
+export async function addActivity(tenantId: string, leadId: string, type: string, body: string): Promise<LeadActivity> {
+  const resp = await fetch(`${API_BASE}/api/leads/${tenantId}/${leadId}/activities`, {
+    method: 'POST', headers: { 'Content-Type': 'application/json', ...authHeaders() },
+    body: JSON.stringify({ type, body }),
+  });
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+  return resp.json();
+}
+
+export interface ConvertPayload {
+  family_name: string; primary_address: string;
+  primary_email?: string; primary_phone?: string;
+  student_first_name: string; student_last_name: string; grade_level?: string;
+}
+export async function convertLead(tenantId: string, leadId: string, payload: ConvertPayload) {
+  const resp = await fetch(`${API_BASE}/api/leads/${tenantId}/${leadId}/convert`, {
+    method: 'POST', headers: { 'Content-Type': 'application/json', ...authHeaders() },
+    body: JSON.stringify(payload),
+  });
+  if (resp.status === 409) throw new Error(await resp.text());
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+  return resp.json();
+}
+
+// Public intake — NO auth header.
+export async function submitPublicLead(tenantId: string, fields: Partial<Lead>): Promise<void> {
+  const resp = await fetch(`${API_BASE}/api/public/leads/${tenantId}`, {
+    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(fields),
+  });
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
 }

--- a/admindash/frontend/src/components/AddLeadModal.tsx
+++ b/admindash/frontend/src/components/AddLeadModal.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { type ChangeEvent, type FormEvent } from 'react';
 import { createLead } from '../api/client.ts';
+import './DynamicForm.css';
 import './LeadModal.css';
 
 export default function AddLeadModal(
@@ -29,19 +30,41 @@ export default function AddLeadModal(
   }
 
   return (
-    <div className="modal-backdrop" onClick={onClose}>
-      <form className="modal" onClick={(e) => e.stopPropagation()} onSubmit={submit}>
-        <h3>Add Lead</h3>
-        {error && <p className="error">{error}</p>}
-        <label>Guardian name*<input value={f.guardian_name} onChange={set('guardian_name')} /></label>
-        <label>Email<input value={f.email} onChange={set('email')} /></label>
-        <label>Phone<input value={f.phone} onChange={set('phone')} /></label>
-        <label>Student first name<input value={f.student_first_name} onChange={set('student_first_name')} /></label>
-        <label>Student last name<input value={f.student_last_name} onChange={set('student_last_name')} /></label>
-        <label>Grade of interest<input value={f.grade_of_interest} onChange={set('grade_of_interest')} /></label>
-        <div className="modal-actions">
-          <button type="button" onClick={onClose}>Cancel</button>
-          <button type="submit">Create</button>
+    <div className="lead-modal-overlay" onClick={onClose}>
+      <form className="lead-modal" onClick={(e) => e.stopPropagation()} onSubmit={submit}>
+        <div className="lead-modal-header"><h3>Add Lead</h3></div>
+        <div className="lead-modal-body">
+          {error && <div className="dynamic-form-error">{error}</div>}
+          <div className="dynamic-form-fields">
+            <div className="dynamic-form-field">
+              <label>Guardian name<span className="dynamic-form-required">*</span></label>
+              <input value={f.guardian_name} onChange={set('guardian_name')} />
+            </div>
+            <div className="dynamic-form-field">
+              <label>Email</label>
+              <input value={f.email} onChange={set('email')} />
+            </div>
+            <div className="dynamic-form-field">
+              <label>Phone</label>
+              <input value={f.phone} onChange={set('phone')} />
+            </div>
+            <div className="dynamic-form-field">
+              <label>Student first name</label>
+              <input value={f.student_first_name} onChange={set('student_first_name')} />
+            </div>
+            <div className="dynamic-form-field">
+              <label>Student last name</label>
+              <input value={f.student_last_name} onChange={set('student_last_name')} />
+            </div>
+            <div className="dynamic-form-field">
+              <label>Grade of interest</label>
+              <input value={f.grade_of_interest} onChange={set('grade_of_interest')} />
+            </div>
+          </div>
+          <div className="dynamic-form-actions">
+            <button type="button" className="dynamic-form-btn-secondary" onClick={onClose}>Cancel</button>
+            <button type="submit" className="dynamic-form-btn-primary">Create</button>
+          </div>
         </div>
       </form>
     </div>

--- a/admindash/frontend/src/components/AddLeadModal.tsx
+++ b/admindash/frontend/src/components/AddLeadModal.tsx
@@ -1,12 +1,18 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { type ChangeEvent, type FormEvent } from 'react';
 import { createLead } from '../api/client.ts';
+import { useModel } from '../contexts/ModelContext.tsx';
+import { formModel } from '../utils/leadModel.ts';
+import type { ModelDefinition } from '../types/models.ts';
+import DynamicForm from './DynamicForm.tsx';
 import './DynamicForm.css';
 import './LeadModal.css';
 
 export default function AddLeadModal(
   { tenant, onClose, onCreated }: { tenant: string; onClose: () => void; onCreated: () => void },
 ) {
+  const { getModel } = useModel();
+  const [model, setModel] = useState<ModelDefinition | null>(null);
   const [f, setF] = useState({
     guardian_name: '', email: '', phone: '',
     student_first_name: '', student_last_name: '', grade_of_interest: '', message: '',
@@ -14,7 +20,20 @@ export default function AddLeadModal(
   const [error, setError] = useState<string | null>(null);
   const set = (k: string) => (e: ChangeEvent<HTMLInputElement>) => setF({ ...f, [k]: e.target.value });
 
-  async function submit(e: FormEvent) {
+  useEffect(() => { getModel(tenant, 'lead').then(setModel).catch(() => setModel(null)); }, [tenant, getModel]);
+
+  async function handleCreate(baseData: Record<string, unknown>, customFields: Record<string, unknown>) {
+    setError(null);
+    try {
+      await createLead(tenant, { ...baseData, ...customFields });
+      onCreated();
+    } catch (err) {
+      setError(String(err));
+    }
+  }
+
+  // Fixed-fields fallback (used when the tenant has no lead model).
+  async function submitFixed(e: FormEvent) {
     e.preventDefault();
     if (!f.guardian_name.trim() || (!f.email.trim() && !f.phone.trim())) {
       setError('Guardian name and at least one contact (email or phone) are required.');
@@ -31,42 +50,55 @@ export default function AddLeadModal(
 
   return (
     <div className="lead-modal-overlay" onClick={onClose}>
-      <form className="lead-modal" onClick={(e) => e.stopPropagation()} onSubmit={submit}>
+      <div className="lead-modal" onClick={(e) => e.stopPropagation()}>
         <div className="lead-modal-header"><h3>Add Lead</h3></div>
         <div className="lead-modal-body">
-          {error && <div className="dynamic-form-error">{error}</div>}
-          <div className="dynamic-form-fields">
-            <div className="dynamic-form-field">
-              <label>Guardian name<span className="dynamic-form-required">*</span></label>
-              <input value={f.guardian_name} onChange={set('guardian_name')} />
-            </div>
-            <div className="dynamic-form-field">
-              <label>Email</label>
-              <input value={f.email} onChange={set('email')} />
-            </div>
-            <div className="dynamic-form-field">
-              <label>Phone</label>
-              <input value={f.phone} onChange={set('phone')} />
-            </div>
-            <div className="dynamic-form-field">
-              <label>Student first name</label>
-              <input value={f.student_first_name} onChange={set('student_first_name')} />
-            </div>
-            <div className="dynamic-form-field">
-              <label>Student last name</label>
-              <input value={f.student_last_name} onChange={set('student_last_name')} />
-            </div>
-            <div className="dynamic-form-field">
-              <label>Grade of interest</label>
-              <input value={f.grade_of_interest} onChange={set('grade_of_interest')} />
-            </div>
-          </div>
-          <div className="dynamic-form-actions">
-            <button type="button" className="dynamic-form-btn-secondary" onClick={onClose}>Cancel</button>
-            <button type="submit" className="dynamic-form-btn-primary">Create</button>
-          </div>
+          {model ? (
+            <>
+              {error && <div className="dynamic-form-error">{error}</div>}
+              <DynamicForm
+                modelDefinition={formModel(model)}
+                onSubmit={handleCreate}
+                onCancel={onClose}
+              />
+            </>
+          ) : (
+            <form onSubmit={submitFixed}>
+              {error && <div className="dynamic-form-error">{error}</div>}
+              <div className="dynamic-form-fields">
+                <div className="dynamic-form-field">
+                  <label>Guardian name<span className="dynamic-form-required">*</span></label>
+                  <input value={f.guardian_name} onChange={set('guardian_name')} />
+                </div>
+                <div className="dynamic-form-field">
+                  <label>Email</label>
+                  <input value={f.email} onChange={set('email')} />
+                </div>
+                <div className="dynamic-form-field">
+                  <label>Phone</label>
+                  <input value={f.phone} onChange={set('phone')} />
+                </div>
+                <div className="dynamic-form-field">
+                  <label>Student first name</label>
+                  <input value={f.student_first_name} onChange={set('student_first_name')} />
+                </div>
+                <div className="dynamic-form-field">
+                  <label>Student last name</label>
+                  <input value={f.student_last_name} onChange={set('student_last_name')} />
+                </div>
+                <div className="dynamic-form-field">
+                  <label>Grade of interest</label>
+                  <input value={f.grade_of_interest} onChange={set('grade_of_interest')} />
+                </div>
+              </div>
+              <div className="dynamic-form-actions">
+                <button type="button" className="dynamic-form-btn-secondary" onClick={onClose}>Cancel</button>
+                <button type="submit" className="dynamic-form-btn-primary">Create</button>
+              </div>
+            </form>
+          )}
         </div>
-      </form>
+      </div>
     </div>
   );
 }

--- a/admindash/frontend/src/components/AddLeadModal.tsx
+++ b/admindash/frontend/src/components/AddLeadModal.tsx
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+import { type ChangeEvent, type FormEvent } from 'react';
+import { createLead } from '../api/client.ts';
+import './LeadModal.css';
+
+export default function AddLeadModal(
+  { tenant, onClose, onCreated }: { tenant: string; onClose: () => void; onCreated: () => void },
+) {
+  const [f, setF] = useState({
+    guardian_name: '', email: '', phone: '',
+    student_first_name: '', student_last_name: '', grade_of_interest: '', message: '',
+  });
+  const [error, setError] = useState<string | null>(null);
+  const set = (k: string) => (e: ChangeEvent<HTMLInputElement>) => setF({ ...f, [k]: e.target.value });
+
+  async function submit(e: FormEvent) {
+    e.preventDefault();
+    if (!f.guardian_name.trim() || (!f.email.trim() && !f.phone.trim())) {
+      setError('Guardian name and at least one contact (email or phone) are required.');
+      return;
+    }
+    try {
+      const payload = Object.fromEntries(Object.entries(f).filter(([, v]) => v.trim()));
+      await createLead(tenant, payload);
+      onCreated();
+    } catch (err) {
+      setError(String(err));
+    }
+  }
+
+  return (
+    <div className="modal-backdrop" onClick={onClose}>
+      <form className="modal" onClick={(e) => e.stopPropagation()} onSubmit={submit}>
+        <h3>Add Lead</h3>
+        {error && <p className="error">{error}</p>}
+        <label>Guardian name*<input value={f.guardian_name} onChange={set('guardian_name')} /></label>
+        <label>Email<input value={f.email} onChange={set('email')} /></label>
+        <label>Phone<input value={f.phone} onChange={set('phone')} /></label>
+        <label>Student first name<input value={f.student_first_name} onChange={set('student_first_name')} /></label>
+        <label>Student last name<input value={f.student_last_name} onChange={set('student_last_name')} /></label>
+        <label>Grade of interest<input value={f.grade_of_interest} onChange={set('grade_of_interest')} /></label>
+        <div className="modal-actions">
+          <button type="button" onClick={onClose}>Cancel</button>
+          <button type="submit">Create</button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/admindash/frontend/src/components/ConvertToFamilyModal.tsx
+++ b/admindash/frontend/src/components/ConvertToFamilyModal.tsx
@@ -1,6 +1,9 @@
-import { useState, type FormEvent } from 'react';
+import { useEffect, useState, type FormEvent } from 'react';
 import { convertLead } from '../api/client.ts';
+import { useModel } from '../contexts/ModelContext.tsx';
+import { leadStages } from '../utils/leadModel.ts';
 import type { Lead } from '../types/models.ts';
+import type { ModelDefinition } from '../types/models.ts';
 import './DynamicForm.css';
 import './LeadModal.css';
 
@@ -8,12 +11,25 @@ export default function ConvertToFamilyModal(
   { tenant, lead, onClose, onConverted }:
   { tenant: string; lead: Lead; onClose: () => void; onConverted: () => void },
 ) {
+  const { getModel } = useModel();
+  const [model, setModel] = useState<ModelDefinition | null>(null);
   const [familyName, setFamilyName] = useState(`${lead.guardian_name}`);
   const [address, setAddress] = useState('');
   const [firstName, setFirstName] = useState(lead.student_first_name ?? '');
   const [lastName, setLastName] = useState(lead.student_last_name ?? '');
   const [grade, setGrade] = useState(lead.grade_of_interest ?? '');
+  const [targetStage, setTargetStage] = useState<string>('');
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => { getModel(tenant, 'lead').then(setModel).catch(() => setModel(null)); }, [tenant, getModel]);
+
+  const stages = leadStages(model);
+
+  // Default target stage to the last stage once stages resolve.
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setTargetStage((prev) => prev || stages[stages.length - 1] || '');
+  }, [stages]);
 
   async function submit(e: FormEvent) {
     e.preventDefault();
@@ -26,6 +42,7 @@ export default function ConvertToFamilyModal(
         primary_email: lead.email, primary_phone: lead.phone,
         student_first_name: firstName, student_last_name: lastName,
         grade_level: grade || undefined,
+        target_stage: targetStage || undefined,
       });
       onConverted();
     } catch (err) { setError(String(err)); }
@@ -57,6 +74,12 @@ export default function ConvertToFamilyModal(
             <div className="dynamic-form-field">
               <label>Grade</label>
               <input value={grade} onChange={(e) => setGrade(e.target.value)} />
+            </div>
+            <div className="dynamic-form-field">
+              <label>Move lead to stage</label>
+              <select value={targetStage} onChange={(e) => setTargetStage(e.target.value)}>
+                {stages.map((s) => <option key={s} value={s}>{s}</option>)}
+              </select>
             </div>
           </div>
           <div className="dynamic-form-actions">

--- a/admindash/frontend/src/components/ConvertToFamilyModal.tsx
+++ b/admindash/frontend/src/components/ConvertToFamilyModal.tsx
@@ -1,0 +1,50 @@
+import { useState, type FormEvent } from 'react';
+import { convertLead } from '../api/client.ts';
+import type { Lead } from '../types/models.ts';
+import './LeadModal.css';
+
+export default function ConvertToFamilyModal(
+  { tenant, lead, onClose, onConverted }:
+  { tenant: string; lead: Lead; onClose: () => void; onConverted: () => void },
+) {
+  const [familyName, setFamilyName] = useState(`${lead.guardian_name}`);
+  const [address, setAddress] = useState('');
+  const [firstName, setFirstName] = useState(lead.student_first_name ?? '');
+  const [lastName, setLastName] = useState(lead.student_last_name ?? '');
+  const [grade, setGrade] = useState(lead.grade_of_interest ?? '');
+  const [error, setError] = useState<string | null>(null);
+
+  async function submit(e: FormEvent) {
+    e.preventDefault();
+    if (!address.trim() || !firstName.trim() || !lastName.trim()) {
+      setError('Address and student name are required.'); return;
+    }
+    try {
+      await convertLead(tenant, lead.entity_id, {
+        family_name: familyName, primary_address: address,
+        primary_email: lead.email, primary_phone: lead.phone,
+        student_first_name: firstName, student_last_name: lastName,
+        grade_level: grade || undefined,
+      });
+      onConverted();
+    } catch (err) { setError(String(err)); }
+  }
+
+  return (
+    <div className="modal-backdrop" onClick={onClose}>
+      <form className="modal" onClick={(e) => e.stopPropagation()} onSubmit={submit}>
+        <h3>Convert to Family</h3>
+        {error && <p className="error">{error}</p>}
+        <label>Family name<input value={familyName} onChange={(e) => setFamilyName(e.target.value)} /></label>
+        <label>Primary address*<input value={address} onChange={(e) => setAddress(e.target.value)} /></label>
+        <label>Student first name*<input value={firstName} onChange={(e) => setFirstName(e.target.value)} /></label>
+        <label>Student last name*<input value={lastName} onChange={(e) => setLastName(e.target.value)} /></label>
+        <label>Grade<input value={grade} onChange={(e) => setGrade(e.target.value)} /></label>
+        <div className="modal-actions">
+          <button type="button" onClick={onClose}>Cancel</button>
+          <button type="submit">Convert</button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/admindash/frontend/src/components/ConvertToFamilyModal.tsx
+++ b/admindash/frontend/src/components/ConvertToFamilyModal.tsx
@@ -1,6 +1,7 @@
 import { useState, type FormEvent } from 'react';
 import { convertLead } from '../api/client.ts';
 import type { Lead } from '../types/models.ts';
+import './DynamicForm.css';
 import './LeadModal.css';
 
 export default function ConvertToFamilyModal(
@@ -31,18 +32,37 @@ export default function ConvertToFamilyModal(
   }
 
   return (
-    <div className="modal-backdrop" onClick={onClose}>
-      <form className="modal" onClick={(e) => e.stopPropagation()} onSubmit={submit}>
-        <h3>Convert to Family</h3>
-        {error && <p className="error">{error}</p>}
-        <label>Family name<input value={familyName} onChange={(e) => setFamilyName(e.target.value)} /></label>
-        <label>Primary address*<input value={address} onChange={(e) => setAddress(e.target.value)} /></label>
-        <label>Student first name*<input value={firstName} onChange={(e) => setFirstName(e.target.value)} /></label>
-        <label>Student last name*<input value={lastName} onChange={(e) => setLastName(e.target.value)} /></label>
-        <label>Grade<input value={grade} onChange={(e) => setGrade(e.target.value)} /></label>
-        <div className="modal-actions">
-          <button type="button" onClick={onClose}>Cancel</button>
-          <button type="submit">Convert</button>
+    <div className="lead-modal-overlay" onClick={onClose}>
+      <form className="lead-modal" onClick={(e) => e.stopPropagation()} onSubmit={submit}>
+        <div className="lead-modal-header"><h3>Convert to Family</h3></div>
+        <div className="lead-modal-body">
+          {error && <div className="dynamic-form-error">{error}</div>}
+          <div className="dynamic-form-fields">
+            <div className="dynamic-form-field">
+              <label>Family name</label>
+              <input value={familyName} onChange={(e) => setFamilyName(e.target.value)} />
+            </div>
+            <div className="dynamic-form-field">
+              <label>Primary address<span className="dynamic-form-required">*</span></label>
+              <input value={address} onChange={(e) => setAddress(e.target.value)} />
+            </div>
+            <div className="dynamic-form-field">
+              <label>Student first name<span className="dynamic-form-required">*</span></label>
+              <input value={firstName} onChange={(e) => setFirstName(e.target.value)} />
+            </div>
+            <div className="dynamic-form-field">
+              <label>Student last name<span className="dynamic-form-required">*</span></label>
+              <input value={lastName} onChange={(e) => setLastName(e.target.value)} />
+            </div>
+            <div className="dynamic-form-field">
+              <label>Grade</label>
+              <input value={grade} onChange={(e) => setGrade(e.target.value)} />
+            </div>
+          </div>
+          <div className="dynamic-form-actions">
+            <button type="button" className="dynamic-form-btn-secondary" onClick={onClose}>Cancel</button>
+            <button type="submit" className="dynamic-form-btn-primary">Convert</button>
+          </div>
         </div>
       </form>
     </div>

--- a/admindash/frontend/src/components/ImportEmailModal.tsx
+++ b/admindash/frontend/src/components/ImportEmailModal.tsx
@@ -3,7 +3,7 @@ import { type FormEvent } from 'react';
 import { createLead } from '../api/client.ts';
 import { parseInquiryEmail } from '../utils/parseInquiryEmail.ts';
 import { useModel } from '../contexts/ModelContext.tsx';
-import { formModel } from '../utils/leadModel.ts';
+import { formModel, formatFieldLabel } from '../utils/leadModel.ts';
 import type { ModelDefinition } from '../types/models.ts';
 import './DynamicForm.css';
 import './LeadModal.css';
@@ -12,10 +12,6 @@ const FIXED_REVIEW_KEYS = [
   'guardian_name', 'email', 'phone',
   'student_first_name', 'student_last_name', 'message',
 ] as const;
-
-function formatLabel(name: string): string {
-  return name.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
-}
 
 export default function ImportEmailModal(
   { tenant, onClose, onCreated }: { tenant: string; onClose: () => void; onCreated: () => void },
@@ -90,7 +86,7 @@ export default function ImportEmailModal(
               <div className="dynamic-form-fields">
                 {Object.keys(parsed).map((k) => (
                   <div key={k} className="dynamic-form-field">
-                    <label>{formatLabel(k)}</label>
+                    <label>{formatFieldLabel(k)}</label>
                     <input
                       value={parsed[k]}
                       onChange={(e) => setParsed({ ...parsed, [k]: e.target.value })}

--- a/admindash/frontend/src/components/ImportEmailModal.tsx
+++ b/admindash/frontend/src/components/ImportEmailModal.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { type FormEvent } from 'react';
 import { createLead } from '../api/client.ts';
 import { parseInquiryEmail } from '../utils/parseInquiryEmail.ts';
+import './DynamicForm.css';
 import './LeadModal.css';
 
 export default function ImportEmailModal(
@@ -40,39 +41,46 @@ export default function ImportEmailModal(
   }
 
   return (
-    <div className="modal-backdrop" onClick={onClose}>
-      <form className="modal" onClick={(e) => e.stopPropagation()} onSubmit={confirm}>
-        <h3>Import from Email</h3>
-        {error && <p className="error">{error}</p>}
-        {!parsed ? (
-          <>
-            <textarea
-              rows={10}
-              value={raw}
-              onChange={(e) => setRaw(e.target.value)}
-              placeholder="Paste the inquiry email here…"
-            />
-            <div className="modal-actions">
-              <button type="button" onClick={onClose}>Cancel</button>
-              <button type="button" onClick={doParse} disabled={!raw.trim()}>Parse</button>
-            </div>
-          </>
-        ) : (
-          <>
-            {Object.keys(parsed).map((k) => (
-              <label key={k}>{k}
-                <input
-                  value={parsed[k]}
-                  onChange={(e) => setParsed({ ...parsed, [k]: e.target.value })}
+    <div className="lead-modal-overlay" onClick={onClose}>
+      <form className="lead-modal" onClick={(e) => e.stopPropagation()} onSubmit={confirm}>
+        <div className="lead-modal-header"><h3>Import from Email</h3></div>
+        <div className="lead-modal-body">
+          {error && <div className="dynamic-form-error">{error}</div>}
+          {!parsed ? (
+            <>
+              <div className="dynamic-form-field">
+                <textarea
+                  rows={10}
+                  value={raw}
+                  onChange={(e) => setRaw(e.target.value)}
+                  placeholder="Paste the inquiry email here…"
                 />
-              </label>
-            ))}
-            <div className="modal-actions">
-              <button type="button" onClick={() => setParsed(null)}>Back</button>
-              <button type="submit">Create Lead</button>
-            </div>
-          </>
-        )}
+              </div>
+              <div className="dynamic-form-actions">
+                <button type="button" className="dynamic-form-btn-secondary" onClick={onClose}>Cancel</button>
+                <button type="button" className="dynamic-form-btn-primary" onClick={doParse} disabled={!raw.trim()}>Parse</button>
+              </div>
+            </>
+          ) : (
+            <>
+              <div className="dynamic-form-fields">
+                {Object.keys(parsed).map((k) => (
+                  <div key={k} className="dynamic-form-field">
+                    <label>{k}</label>
+                    <input
+                      value={parsed[k]}
+                      onChange={(e) => setParsed({ ...parsed, [k]: e.target.value })}
+                    />
+                  </div>
+                ))}
+              </div>
+              <div className="dynamic-form-actions">
+                <button type="button" className="dynamic-form-btn-secondary" onClick={() => setParsed(null)}>Back</button>
+                <button type="submit" className="dynamic-form-btn-primary">Create Lead</button>
+              </div>
+            </>
+          )}
+        </div>
       </form>
     </div>
   );

--- a/admindash/frontend/src/components/ImportEmailModal.tsx
+++ b/admindash/frontend/src/components/ImportEmailModal.tsx
@@ -1,0 +1,79 @@
+import { useState } from 'react';
+import { type FormEvent } from 'react';
+import { createLead } from '../api/client.ts';
+import { parseInquiryEmail } from '../utils/parseInquiryEmail.ts';
+import './LeadModal.css';
+
+export default function ImportEmailModal(
+  { tenant, onClose, onCreated }: { tenant: string; onClose: () => void; onCreated: () => void },
+) {
+  const [raw, setRaw] = useState('');
+  const [parsed, setParsed] = useState<Record<string, string> | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  function doParse() {
+    const p = parseInquiryEmail(raw);
+    setParsed({
+      guardian_name: p.guardian_name ?? '',
+      email: p.email ?? '',
+      phone: p.phone ?? '',
+      student_first_name: p.student_first_name ?? '',
+      student_last_name: p.student_last_name ?? '',
+      message: p.message ?? '',
+    });
+  }
+
+  async function confirm(e: FormEvent) {
+    e.preventDefault();
+    if (!parsed) return;
+    if (!parsed.guardian_name.trim() || (!parsed.email.trim() && !parsed.phone.trim())) {
+      setError('Guardian name and at least one contact are required.');
+      return;
+    }
+    try {
+      const payload = Object.fromEntries(Object.entries(parsed).filter(([, v]) => v.trim()));
+      await createLead(tenant, { ...payload, source: 'email_import' });
+      onCreated();
+    } catch (err) {
+      setError(String(err));
+    }
+  }
+
+  return (
+    <div className="modal-backdrop" onClick={onClose}>
+      <form className="modal" onClick={(e) => e.stopPropagation()} onSubmit={confirm}>
+        <h3>Import from Email</h3>
+        {error && <p className="error">{error}</p>}
+        {!parsed ? (
+          <>
+            <textarea
+              rows={10}
+              value={raw}
+              onChange={(e) => setRaw(e.target.value)}
+              placeholder="Paste the inquiry email here…"
+            />
+            <div className="modal-actions">
+              <button type="button" onClick={onClose}>Cancel</button>
+              <button type="button" onClick={doParse} disabled={!raw.trim()}>Parse</button>
+            </div>
+          </>
+        ) : (
+          <>
+            {Object.keys(parsed).map((k) => (
+              <label key={k}>{k}
+                <input
+                  value={parsed[k]}
+                  onChange={(e) => setParsed({ ...parsed, [k]: e.target.value })}
+                />
+              </label>
+            ))}
+            <div className="modal-actions">
+              <button type="button" onClick={() => setParsed(null)}>Back</button>
+              <button type="submit">Create Lead</button>
+            </div>
+          </>
+        )}
+      </form>
+    </div>
+  );
+}

--- a/admindash/frontend/src/components/ImportEmailModal.tsx
+++ b/admindash/frontend/src/components/ImportEmailModal.tsx
@@ -1,36 +1,60 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { type FormEvent } from 'react';
 import { createLead } from '../api/client.ts';
 import { parseInquiryEmail } from '../utils/parseInquiryEmail.ts';
+import { useModel } from '../contexts/ModelContext.tsx';
+import { formModel } from '../utils/leadModel.ts';
+import type { ModelDefinition } from '../types/models.ts';
 import './DynamicForm.css';
 import './LeadModal.css';
+
+const FIXED_REVIEW_KEYS = [
+  'guardian_name', 'email', 'phone',
+  'student_first_name', 'student_last_name', 'message',
+] as const;
+
+function formatLabel(name: string): string {
+  return name.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
 
 export default function ImportEmailModal(
   { tenant, onClose, onCreated }: { tenant: string; onClose: () => void; onCreated: () => void },
 ) {
+  const { getModel } = useModel();
+  const [model, setModel] = useState<ModelDefinition | null>(null);
   const [raw, setRaw] = useState('');
   const [parsed, setParsed] = useState<Record<string, string> | null>(null);
   const [error, setError] = useState<string | null>(null);
 
+  useEffect(() => { getModel(tenant, 'lead').then(setModel).catch(() => setModel(null)); }, [tenant, getModel]);
+
+  // Field names shown in the review step: model base fields (non-reserved) or fixed fallback.
+  const reviewFieldNames: string[] = model
+    ? formModel(model).base_fields.map((fld) => fld.name)
+    : [...FIXED_REVIEW_KEYS];
+
   function doParse() {
     const p = parseInquiryEmail(raw);
-    setParsed({
+    // Values the parser can produce, keyed by name.
+    const parserValues: Record<string, string> = {
       guardian_name: p.guardian_name ?? '',
       email: p.email ?? '',
       phone: p.phone ?? '',
       student_first_name: p.student_first_name ?? '',
       student_last_name: p.student_last_name ?? '',
       message: p.message ?? '',
-    });
+    };
+    // Pre-fill review fields by matching field name; leave others blank.
+    const initial: Record<string, string> = {};
+    for (const name of reviewFieldNames) {
+      initial[name] = parserValues[name] ?? '';
+    }
+    setParsed(initial);
   }
 
   async function confirm(e: FormEvent) {
     e.preventDefault();
     if (!parsed) return;
-    if (!parsed.guardian_name.trim() || (!parsed.email.trim() && !parsed.phone.trim())) {
-      setError('Guardian name and at least one contact are required.');
-      return;
-    }
     try {
       const payload = Object.fromEntries(Object.entries(parsed).filter(([, v]) => v.trim()));
       await createLead(tenant, { ...payload, source: 'email_import' });
@@ -66,7 +90,7 @@ export default function ImportEmailModal(
               <div className="dynamic-form-fields">
                 {Object.keys(parsed).map((k) => (
                   <div key={k} className="dynamic-form-field">
-                    <label>{k}</label>
+                    <label>{formatLabel(k)}</label>
                     <input
                       value={parsed[k]}
                       onChange={(e) => setParsed({ ...parsed, [k]: e.target.value })}

--- a/admindash/frontend/src/components/LeadDetailDrawer.css
+++ b/admindash/frontend/src/components/LeadDetailDrawer.css
@@ -173,3 +173,24 @@
   color: var(--text-primary);
   text-align: center;
 }
+
+.lead-detail-fields {
+  margin: 0 0 1rem;
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 0.25rem 0.75rem;
+}
+.lead-detail-field {
+  display: contents;
+}
+.lead-detail-field dt {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+.lead-detail-field dd {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--text-primary);
+  word-break: break-word;
+}

--- a/admindash/frontend/src/components/LeadDetailDrawer.css
+++ b/admindash/frontend/src/components/LeadDetailDrawer.css
@@ -118,23 +118,6 @@
   flex: 1;
 }
 
-.activity-form button[type="submit"] {
-  font-size: 1rem;
-  font-weight: 600;
-  padding: 0.4rem 0.75rem;
-  border: none;
-  border-radius: var(--radius-sm);
-  background: var(--color-accent);
-  color: #fff;
-  cursor: pointer;
-  transition: all 0.15s;
-}
-
-.activity-form button[type="submit"]:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-}
-
 .lead-drawer h3 {
   font-size: 0.95rem;
   font-weight: 600;
@@ -179,7 +162,7 @@
   flex-shrink: 0;
 }
 
-.badge-call     { background: rgba(66, 153, 225, 0.15); color: #2b6cb0; }
-.badge-email    { background: rgba(72, 187, 120, 0.15); color: #276749; }
-.badge-note     { background: rgba(159, 122, 234, 0.15); color: #553c9a; }
-.badge-stage_change { background: rgba(237, 137, 54, 0.15); color: #c05621; }
+.badge-call     { background: var(--accent-muted); color: var(--info); }
+.badge-email    { background: rgba(99, 153, 34, 0.15); color: var(--success); }
+.badge-note     { background: var(--bg-tertiary); color: var(--text-tertiary); }
+.badge-stage_change { background: rgba(239, 159, 39, 0.15); color: var(--warning); }

--- a/admindash/frontend/src/components/LeadDetailDrawer.css
+++ b/admindash/frontend/src/components/LeadDetailDrawer.css
@@ -166,3 +166,10 @@
 .badge-email    { background: rgba(99, 153, 34, 0.15); color: var(--success); }
 .badge-note     { background: var(--bg-tertiary); color: var(--text-tertiary); }
 .badge-stage_change { background: rgba(239, 159, 39, 0.15); color: var(--warning); }
+
+.stage-change-preview {
+  margin: 0.75rem 0 0.25rem;
+  font-size: 1rem;
+  color: var(--text-primary);
+  text-align: center;
+}

--- a/admindash/frontend/src/components/LeadDetailDrawer.css
+++ b/admindash/frontend/src/components/LeadDetailDrawer.css
@@ -1,0 +1,180 @@
+.drawer-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 900;
+  animation: fadeIn 0.2s ease;
+}
+
+.lead-drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  height: 100%;
+  width: 420px;
+  max-width: 95vw;
+  background: var(--bg-card);
+  border-left: 1px solid var(--border-primary);
+  padding: 1.5rem;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-shadow: -8px 0 40px rgba(0, 0, 0, 0.15);
+  animation: slideInRight 0.2s ease;
+}
+
+@keyframes slideInRight {
+  from { transform: translateX(100%); }
+  to   { transform: translateX(0); }
+}
+
+.drawer-close {
+  align-self: flex-end;
+  background: none;
+  border: none;
+  font-size: 1.4rem;
+  cursor: pointer;
+  color: var(--text-secondary);
+  line-height: 1;
+  padding: 0.15rem 0.4rem;
+  border-radius: var(--radius-sm);
+  transition: background 0.15s;
+}
+
+.drawer-close:hover {
+  background: var(--bg-secondary);
+}
+
+.lead-drawer h2 {
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.lead-drawer p {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.lead-drawer label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+
+.lead-drawer label select {
+  font-family: var(--font-sans);
+  font-size: 0.9rem;
+  padding: 0.45rem 0.65rem;
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-sm);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  outline: none;
+  cursor: pointer;
+  transition: border-color 0.15s;
+}
+
+.lead-drawer label select:focus {
+  border-color: var(--color-accent);
+}
+
+.activity-form {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.activity-form select,
+.activity-form input {
+  font-family: var(--font-sans);
+  font-size: 0.875rem;
+  padding: 0.4rem 0.6rem;
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-sm);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.activity-form select:focus,
+.activity-form input:focus {
+  border-color: var(--color-accent);
+}
+
+.activity-form input {
+  flex: 1;
+}
+
+.activity-form button[type="submit"] {
+  font-size: 1rem;
+  font-weight: 600;
+  padding: 0.4rem 0.75rem;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: var(--color-accent);
+  color: #fff;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.activity-form button[type="submit"]:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.lead-drawer h3 {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+  border-top: 1px solid var(--border-primary);
+  padding-top: 0.75rem;
+}
+
+.activity-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.activity-list li {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  color: var(--text-primary);
+}
+
+.activity-list small {
+  margin-left: auto;
+  color: var(--text-secondary);
+  font-size: 0.78rem;
+  white-space: nowrap;
+}
+
+.badge {
+  display: inline-block;
+  font-size: 0.72rem;
+  font-weight: 600;
+  padding: 0.15rem 0.45rem;
+  border-radius: var(--radius-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  flex-shrink: 0;
+}
+
+.badge-call     { background: rgba(66, 153, 225, 0.15); color: #2b6cb0; }
+.badge-email    { background: rgba(72, 187, 120, 0.15); color: #276749; }
+.badge-note     { background: rgba(159, 122, 234, 0.15); color: #553c9a; }
+.badge-stage_change { background: rgba(237, 137, 54, 0.15); color: #c05621; }

--- a/admindash/frontend/src/components/LeadDetailDrawer.css
+++ b/admindash/frontend/src/components/LeadDetailDrawer.css
@@ -24,6 +24,11 @@
   animation: slideInRight 0.2s ease;
 }
 
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
 @keyframes slideInRight {
   from { transform: translateX(100%); }
   to   { transform: translateX(0); }

--- a/admindash/frontend/src/components/LeadDetailDrawer.tsx
+++ b/admindash/frontend/src/components/LeadDetailDrawer.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, useCallback, type FormEvent } from 'react';
 import { useTranslation } from '../hooks/useTranslation.ts';
 import { listActivities, addActivity, updateLeadStage } from '../api/client.ts';
 import { useModel } from '../contexts/ModelContext.tsx';
-import { leadStages, formModel } from '../utils/leadModel.ts';
+import { leadStages, formModel, formatFieldLabel } from '../utils/leadModel.ts';
 import { type Lead, type LeadActivity } from '../types/models.ts';
 import type { ModelDefinition } from '../types/models.ts';
 import ConvertToFamilyModal from './ConvertToFamilyModal.tsx';
@@ -11,10 +11,6 @@ import './LeadModal.css';
 import './LeadDetailDrawer.css';
 
 const ACTIVITY_TYPES = ['call', 'email', 'note'] as const;
-
-function formatLabel(name: string): string {
-  return name.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
-}
 
 function formatValue(val: unknown): string {
   if (Array.isArray(val)) return val.join(', ');
@@ -94,7 +90,7 @@ export default function LeadDetailDrawer(
           <dl className="lead-detail-fields">
             {displayFields.map((fld) => (
               <div key={fld.name} className="lead-detail-field">
-                <dt>{formatLabel(fld.name)}</dt>
+                <dt>{formatFieldLabel(fld.name)}</dt>
                 <dd>{formatValue(lead[fld.name])}</dd>
               </div>
             ))}

--- a/admindash/frontend/src/components/LeadDetailDrawer.tsx
+++ b/admindash/frontend/src/components/LeadDetailDrawer.tsx
@@ -1,7 +1,10 @@
 import { useEffect, useState, useCallback, type FormEvent } from 'react';
 import { useTranslation } from '../hooks/useTranslation.ts';
 import { listActivities, addActivity, updateLeadStage } from '../api/client.ts';
-import { LEAD_STAGES, type Lead, type LeadActivity } from '../types/models.ts';
+import { useModel } from '../contexts/ModelContext.tsx';
+import { leadStages, formModel } from '../utils/leadModel.ts';
+import { type Lead, type LeadActivity } from '../types/models.ts';
+import type { ModelDefinition } from '../types/models.ts';
 import ConvertToFamilyModal from './ConvertToFamilyModal.tsx';
 import './DynamicForm.css';
 import './LeadModal.css';
@@ -9,11 +12,22 @@ import './LeadDetailDrawer.css';
 
 const ACTIVITY_TYPES = ['call', 'email', 'note'] as const;
 
+function formatLabel(name: string): string {
+  return name.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function formatValue(val: unknown): string {
+  if (Array.isArray(val)) return val.join(', ');
+  return String(val);
+}
+
 export default function LeadDetailDrawer(
   { tenant, lead, onClose, onChanged }:
   { tenant: string; lead: Lead; onClose: () => void; onChanged: () => void },
 ) {
   const { t } = useTranslation();
+  const { getModel } = useModel();
+  const [model, setModel] = useState<ModelDefinition | null>(null);
   const [activities, setActivities] = useState<LeadActivity[]>([]);
   const [stage, setStage] = useState(lead.stage);
   const [pendingStage, setPendingStage] = useState<Lead['stage'] | null>(null);
@@ -21,6 +35,10 @@ export default function LeadDetailDrawer(
   const [actType, setActType] = useState<(typeof ACTIVITY_TYPES)[number]>('note');
   const [actBody, setActBody] = useState('');
   const [showConvert, setShowConvert] = useState(false);
+
+  useEffect(() => { getModel(tenant, 'lead').then(setModel).catch(() => setModel(null)); }, [tenant, getModel]);
+
+  const stages = leadStages(model);
 
   const loadActs = useCallback(
     () => listActivities(tenant, lead.entity_id),
@@ -56,18 +74,42 @@ export default function LeadDetailDrawer(
     setActivities(await loadActs());
   }
 
+  // Dynamic read-only field list from the model's non-reserved fields.
+  const displayFields = model
+    ? [...formModel(model).base_fields, ...formModel(model).custom_fields].filter(
+        (fld) => {
+          const v = lead[fld.name];
+          return v != null && v !== '' && !(Array.isArray(v) && v.length === 0);
+        },
+      )
+    : null;
+
   return (
     <div className="drawer-backdrop" onClick={onClose}>
       <aside className="lead-drawer" onClick={(e) => e.stopPropagation()}>
         <button className="drawer-close" onClick={onClose}>×</button>
-        <h2>{lead.guardian_name}</h2>
-        <p>{lead.email} {lead.phone}</p>
-        <p>{lead.student_first_name} {lead.student_last_name} — {lead.grade_of_interest}</p>
+        <h2>{String(lead.guardian_name ?? '')}</h2>
+
+        {displayFields ? (
+          <dl className="lead-detail-fields">
+            {displayFields.map((fld) => (
+              <div key={fld.name} className="lead-detail-field">
+                <dt>{formatLabel(fld.name)}</dt>
+                <dd>{formatValue(lead[fld.name])}</dd>
+              </div>
+            ))}
+          </dl>
+        ) : (
+          <>
+            <p>{lead.email} {lead.phone}</p>
+            <p>{lead.student_first_name} {lead.student_last_name} — {lead.grade_of_interest}</p>
+          </>
+        )}
 
         <div className="dynamic-form-field">
           <label>{t('leads.stage')}</label>
           <select value={stage} onChange={(e) => requestStageChange(e.target.value)}>
-            {LEAD_STAGES.map((s) => <option key={s} value={s}>{s}</option>)}
+            {stages.map((s) => <option key={s} value={s}>{s}</option>)}
           </select>
         </div>
 

--- a/admindash/frontend/src/components/LeadDetailDrawer.tsx
+++ b/admindash/frontend/src/components/LeadDetailDrawer.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useState, useCallback, type FormEvent } from 'react';
+import { useTranslation } from '../hooks/useTranslation.ts';
+import { listActivities, addActivity, updateLeadStage } from '../api/client.ts';
+import { LEAD_STAGES, type Lead, type LeadActivity } from '../types/models.ts';
+import ConvertToFamilyModal from './ConvertToFamilyModal.tsx';
+import './LeadDetailDrawer.css';
+
+const ACTIVITY_TYPES = ['call', 'email', 'note'] as const;
+
+export default function LeadDetailDrawer(
+  { tenant, lead, onClose, onChanged }:
+  { tenant: string; lead: Lead; onClose: () => void; onChanged: () => void },
+) {
+  const { t } = useTranslation();
+  const [activities, setActivities] = useState<LeadActivity[]>([]);
+  const [stage, setStage] = useState(lead.stage);
+  const [actType, setActType] = useState<(typeof ACTIVITY_TYPES)[number]>('note');
+  const [actBody, setActBody] = useState('');
+  const [showConvert, setShowConvert] = useState(false);
+
+  const loadActs = useCallback(
+    () => listActivities(tenant, lead.entity_id),
+    [tenant, lead.entity_id],
+  );
+  useEffect(() => { loadActs().then(setActivities); }, [loadActs]);
+
+  async function changeStage(next: string) {
+    setStage(next as Lead['stage']);
+    await updateLeadStage(tenant, lead.entity_id, next);
+    setActivities(await loadActs());
+    onChanged();
+  }
+
+  async function submitActivity(e: FormEvent) {
+    e.preventDefault();
+    if (!actBody.trim()) return;
+    await addActivity(tenant, lead.entity_id, actType, actBody.trim());
+    setActBody('');
+    setActivities(await loadActs());
+  }
+
+  return (
+    <div className="drawer-backdrop" onClick={onClose}>
+      <aside className="lead-drawer" onClick={(e) => e.stopPropagation()}>
+        <button className="drawer-close" onClick={onClose}>×</button>
+        <h2>{lead.guardian_name}</h2>
+        <p>{lead.email} {lead.phone}</p>
+        <p>{lead.student_first_name} {lead.student_last_name} — {lead.grade_of_interest}</p>
+
+        <label>{t('leads.stage')}
+          <select value={stage} onChange={(e) => void changeStage(e.target.value)}>
+            {LEAD_STAGES.map((s) => <option key={s} value={s}>{s}</option>)}
+          </select>
+        </label>
+
+        <button disabled={!!lead.converted_family_id} onClick={() => setShowConvert(true)}>
+          {lead.converted_family_id ? `Converted → ${lead.converted_family_id}` : t('leads.convert')}
+        </button>
+
+        <form onSubmit={submitActivity} className="activity-form">
+          <select value={actType} onChange={(e) => setActType(e.target.value as typeof actType)}>
+            {ACTIVITY_TYPES.map((ty) => <option key={ty} value={ty}>{ty}</option>)}
+          </select>
+          <input value={actBody} onChange={(e) => setActBody(e.target.value)} placeholder={t('leads.addActivity')} />
+          <button type="submit">+</button>
+        </form>
+
+        <h3>{t('leads.activityTimeline')}</h3>
+        <ul className="activity-list">
+          {activities.map((a) => (
+            <li key={a.entity_id}>
+              <span className={`badge badge-${a.type}`}>{a.type}</span>
+              <span>{a.type === 'stage_change' ? `${a.stage_from} → ${a.stage_to}` : a.body}</span>
+              <small>{a._created_at?.slice(0, 16).replace('T', ' ')}</small>
+            </li>
+          ))}
+        </ul>
+
+        {showConvert && (
+          <ConvertToFamilyModal tenant={tenant} lead={lead}
+            onClose={() => setShowConvert(false)}
+            onConverted={() => { setShowConvert(false); onChanged(); onClose(); }} />
+        )}
+      </aside>
+    </div>
+  );
+}

--- a/admindash/frontend/src/components/LeadDetailDrawer.tsx
+++ b/admindash/frontend/src/components/LeadDetailDrawer.tsx
@@ -4,6 +4,7 @@ import { listActivities, addActivity, updateLeadStage } from '../api/client.ts';
 import { LEAD_STAGES, type Lead, type LeadActivity } from '../types/models.ts';
 import ConvertToFamilyModal from './ConvertToFamilyModal.tsx';
 import './DynamicForm.css';
+import './LeadModal.css';
 import './LeadDetailDrawer.css';
 
 const ACTIVITY_TYPES = ['call', 'email', 'note'] as const;
@@ -15,6 +16,8 @@ export default function LeadDetailDrawer(
   const { t } = useTranslation();
   const [activities, setActivities] = useState<LeadActivity[]>([]);
   const [stage, setStage] = useState(lead.stage);
+  const [pendingStage, setPendingStage] = useState<Lead['stage'] | null>(null);
+  const [savingStage, setSavingStage] = useState(false);
   const [actType, setActType] = useState<(typeof ACTIVITY_TYPES)[number]>('note');
   const [actBody, setActBody] = useState('');
   const [showConvert, setShowConvert] = useState(false);
@@ -25,11 +28,24 @@ export default function LeadDetailDrawer(
   );
   useEffect(() => { loadActs().then(setActivities); }, [loadActs]);
 
-  async function changeStage(next: string) {
-    setStage(next as Lead['stage']);
-    await updateLeadStage(tenant, lead.entity_id, next);
-    setActivities(await loadActs());
-    onChanged();
+  // Selecting a new stage only stages the change; it is committed on confirm.
+  function requestStageChange(next: string) {
+    if (next !== stage) setPendingStage(next as Lead['stage']);
+  }
+
+  async function confirmStageChange() {
+    if (!pendingStage) return;
+    const next = pendingStage;
+    setSavingStage(true);
+    try {
+      await updateLeadStage(tenant, lead.entity_id, next);
+      setStage(next);
+      setActivities(await loadActs());
+      onChanged();
+      setPendingStage(null);
+    } finally {
+      setSavingStage(false);
+    }
   }
 
   async function submitActivity(e: FormEvent) {
@@ -50,7 +66,7 @@ export default function LeadDetailDrawer(
 
         <div className="dynamic-form-field">
           <label>{t('leads.stage')}</label>
-          <select value={stage} onChange={(e) => void changeStage(e.target.value)}>
+          <select value={stage} onChange={(e) => requestStageChange(e.target.value)}>
             {LEAD_STAGES.map((s) => <option key={s} value={s}>{s}</option>)}
           </select>
         </div>
@@ -81,6 +97,30 @@ export default function LeadDetailDrawer(
             </li>
           ))}
         </ul>
+
+        {pendingStage && (
+          <div className="lead-modal-overlay" onClick={() => !savingStage && setPendingStage(null)}>
+            <div className="lead-modal" onClick={(e) => e.stopPropagation()}>
+              <div className="lead-modal-header"><h3>{t('leads.confirmStageTitle')}</h3></div>
+              <div className="lead-modal-body">
+                <p>{t('leads.confirmStagePrompt')}</p>
+                <p className="stage-change-preview">
+                  <strong>{stage}</strong> → <strong>{pendingStage}</strong>
+                </p>
+                <div className="dynamic-form-actions">
+                  <button type="button" className="dynamic-form-btn-secondary"
+                    disabled={savingStage} onClick={() => setPendingStage(null)}>
+                    {t('leads.cancel')}
+                  </button>
+                  <button type="button" className="dynamic-form-btn-primary"
+                    disabled={savingStage} onClick={() => void confirmStageChange()}>
+                    {t('leads.confirm')}
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
 
         {showConvert && (
           <ConvertToFamilyModal tenant={tenant} lead={lead}

--- a/admindash/frontend/src/components/LeadDetailDrawer.tsx
+++ b/admindash/frontend/src/components/LeadDetailDrawer.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from '../hooks/useTranslation.ts';
 import { listActivities, addActivity, updateLeadStage } from '../api/client.ts';
 import { LEAD_STAGES, type Lead, type LeadActivity } from '../types/models.ts';
 import ConvertToFamilyModal from './ConvertToFamilyModal.tsx';
+import './DynamicForm.css';
 import './LeadDetailDrawer.css';
 
 const ACTIVITY_TYPES = ['call', 'email', 'note'] as const;
@@ -47,13 +48,18 @@ export default function LeadDetailDrawer(
         <p>{lead.email} {lead.phone}</p>
         <p>{lead.student_first_name} {lead.student_last_name} — {lead.grade_of_interest}</p>
 
-        <label>{t('leads.stage')}
+        <div className="dynamic-form-field">
+          <label>{t('leads.stage')}</label>
           <select value={stage} onChange={(e) => void changeStage(e.target.value)}>
             {LEAD_STAGES.map((s) => <option key={s} value={s}>{s}</option>)}
           </select>
-        </label>
+        </div>
 
-        <button disabled={!!lead.converted_family_id} onClick={() => setShowConvert(true)}>
+        <button
+          className={`dynamic-form-btn-primary ${lead.converted_family_id ? 'dynamic-form-btn-invalid' : ''}`}
+          disabled={!!lead.converted_family_id}
+          onClick={() => setShowConvert(true)}
+        >
           {lead.converted_family_id ? `Converted → ${lead.converted_family_id}` : t('leads.convert')}
         </button>
 
@@ -62,7 +68,7 @@ export default function LeadDetailDrawer(
             {ACTIVITY_TYPES.map((ty) => <option key={ty} value={ty}>{ty}</option>)}
           </select>
           <input value={actBody} onChange={(e) => setActBody(e.target.value)} placeholder={t('leads.addActivity')} />
-          <button type="submit">+</button>
+          <button type="submit" className="dynamic-form-btn-primary">+</button>
         </form>
 
         <h3>{t('leads.activityTimeline')}</h3>

--- a/admindash/frontend/src/components/LeadDetailDrawer.tsx
+++ b/admindash/frontend/src/components/LeadDetailDrawer.tsx
@@ -71,13 +71,12 @@ export default function LeadDetailDrawer(
   }
 
   // Dynamic read-only field list from the model's non-reserved fields.
+  const fm = formModel(model);
   const displayFields = model
-    ? [...formModel(model).base_fields, ...formModel(model).custom_fields].filter(
-        (fld) => {
-          const v = lead[fld.name];
-          return v != null && v !== '' && !(Array.isArray(v) && v.length === 0);
-        },
-      )
+    ? [...fm.base_fields, ...fm.custom_fields].filter((fld) => {
+        const v = lead[fld.name];
+        return v != null && v !== '' && !(Array.isArray(v) && v.length === 0);
+      })
     : null;
 
   return (

--- a/admindash/frontend/src/components/LeadModal.css
+++ b/admindash/frontend/src/components/LeadModal.css
@@ -3,125 +3,57 @@
   to { opacity: 1; }
 }
 
-.modal-backdrop {
+.lead-modal-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: rgba(0, 0, 0, 0.4);
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 1000;
-  animation: fadeIn 0.2s ease;
+  z-index: 200;
 }
 
-.modal {
+.lead-modal {
   background: var(--bg-card);
-  border-radius: 12px;
-  padding: 1.5rem;
-  max-width: 480px;
-  width: 90%;
-  max-height: 80vh;
+  border-radius: var(--radius-md);
+  width: 92%;
+  max-width: 640px;
+  max-height: 85vh;
   overflow-y: auto;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
+  box-shadow: var(--shadow-elevated);
 }
 
-.modal h3 {
+.lead-modal-header {
+  padding: 1.25rem 1.5rem;
+  border-bottom: 1px solid var(--border-primary);
+}
+
+.lead-modal-header h3 {
   font-size: 1.1rem;
   font-weight: 600;
-  margin: 0 0 0.25rem 0;
-  color: var(--text-primary);
+  margin: 0;
 }
 
-.modal label {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-  font-size: 0.85rem;
-  font-weight: 500;
-  color: var(--text-secondary);
+.lead-modal-body {
+  padding: 1rem 1.5rem 1.5rem;
 }
 
-.modal label input,
-.modal label textarea,
-.modal textarea {
+.lead-modal-body textarea {
   font-family: var(--font-sans);
-  font-size: 0.9rem;
-  padding: 0.45rem 0.65rem;
+  font-size: 0.85rem;
+  padding: 0.45rem 0.6rem;
   border: 1px solid var(--border-primary);
-  border-radius: var(--radius-sm);
+  border-radius: 8px;
   background: var(--bg-secondary);
   color: var(--text-primary);
   outline: none;
-  transition: border-color 0.15s;
+  transition: border-color 0.2s, box-shadow 0.2s;
   width: 100%;
   box-sizing: border-box;
-}
-
-.modal label input:focus,
-.modal textarea:focus {
-  border-color: var(--color-accent);
-}
-
-.modal textarea {
   resize: vertical;
 }
 
-.modal-actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 0.75rem;
-  padding-top: 0.5rem;
-  border-top: 1px solid var(--border-subtle);
-  margin-top: 0.25rem;
-}
-
-.modal-actions button {
-  font-family: var(--font-sans);
-  font-size: 0.85rem;
-  font-weight: 500;
-  padding: 0.45rem 1rem;
-  border-radius: var(--radius-sm);
-  border: none;
-  cursor: pointer;
-  transition: all 0.15s;
-}
-
-.modal-actions button[type="submit"],
-.modal-actions button:last-child {
-  background: var(--color-accent);
-  color: #fff;
-}
-
-.modal-actions button[type="submit"]:hover,
-.modal-actions button:last-child:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
-}
-
-.modal-actions button[type="button"]:first-child {
-  background: var(--bg-tertiary);
-  color: var(--text-secondary);
-}
-
-.modal-actions button[type="button"]:first-child:hover {
-  background: var(--border-primary);
-}
-
-.modal-actions button:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-  transform: none;
-}
-
-.error {
-  font-size: 0.85rem;
-  color: var(--color-danger, #e53e3e);
-  background: rgba(229, 62, 62, 0.08);
-  border: 1px solid rgba(229, 62, 62, 0.2);
-  border-radius: var(--radius-sm);
-  padding: 0.5rem 0.75rem;
-  margin: 0;
+.lead-modal-body textarea:focus {
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px rgba(55, 138, 221, 0.15);
 }

--- a/admindash/frontend/src/components/LeadModal.css
+++ b/admindash/frontend/src/components/LeadModal.css
@@ -1,0 +1,122 @@
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  animation: fadeIn 0.2s ease;
+}
+
+.modal {
+  background: var(--bg-card);
+  border-radius: 12px;
+  padding: 1.5rem;
+  max-width: 480px;
+  width: 90%;
+  max-height: 80vh;
+  overflow-y: auto;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.modal h3 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin: 0 0 0.25rem 0;
+  color: var(--text-primary);
+}
+
+.modal label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+
+.modal label input,
+.modal label textarea,
+.modal textarea {
+  font-family: var(--font-sans);
+  font-size: 0.9rem;
+  padding: 0.45rem 0.65rem;
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-sm);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  outline: none;
+  transition: border-color 0.15s;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.modal label input:focus,
+.modal textarea:focus {
+  border-color: var(--color-accent);
+}
+
+.modal textarea {
+  resize: vertical;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--border-subtle);
+  margin-top: 0.25rem;
+}
+
+.modal-actions button {
+  font-family: var(--font-sans);
+  font-size: 0.85rem;
+  font-weight: 500;
+  padding: 0.45rem 1rem;
+  border-radius: var(--radius-sm);
+  border: none;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.modal-actions button[type="submit"],
+.modal-actions button:last-child {
+  background: var(--color-accent);
+  color: #fff;
+}
+
+.modal-actions button[type="submit"]:hover,
+.modal-actions button:last-child:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+}
+
+.modal-actions button[type="button"]:first-child {
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+}
+
+.modal-actions button[type="button"]:first-child:hover {
+  background: var(--border-primary);
+}
+
+.modal-actions button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.error {
+  font-size: 0.85rem;
+  color: var(--color-danger, #e53e3e);
+  background: rgba(229, 62, 62, 0.08);
+  border: 1px solid rgba(229, 62, 62, 0.2);
+  border-radius: var(--radius-sm);
+  padding: 0.5rem 0.75rem;
+  margin: 0;
+}

--- a/admindash/frontend/src/components/LeadModal.css
+++ b/admindash/frontend/src/components/LeadModal.css
@@ -1,3 +1,8 @@
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
 .modal-backdrop {
   position: fixed;
   inset: 0;

--- a/admindash/frontend/src/i18n/translations.ts
+++ b/admindash/frontend/src/i18n/translations.ts
@@ -173,6 +173,10 @@ export const translations: Record<Locale, Record<string, string>> = {
     'leads.addActivity': 'Add Activity',
     'leads.stage': 'Stage',
     'leads.activityTimeline': 'Activity',
+    'leads.confirmStageTitle': 'Change stage',
+    'leads.confirmStagePrompt': "Change this lead's stage? The change will be recorded in the activity log.",
+    'leads.confirm': 'Confirm',
+    'leads.cancel': 'Cancel',
 
     // Bulk Add Students
     'bulkAdd.entryButton': 'Bulk add',
@@ -464,6 +468,10 @@ export const translations: Record<Locale, Record<string, string>> = {
     'leads.addActivity': '\u6dfb\u52a0\u6d3b\u52a8',
     'leads.stage': '\u9636\u6bb5',
     'leads.activityTimeline': '\u6d3b\u52a8',
+    'leads.confirmStageTitle': '\u66f4\u6539\u9636\u6bb5',
+    'leads.confirmStagePrompt': '\u786e\u5b9a\u66f4\u6539\u8be5\u5ba2\u6237\u7684\u9636\u6bb5\uff1f\u6b64\u66f4\u6539\u5c06\u8bb0\u5f55\u5728\u6d3b\u52a8\u65e5\u5fd7\u4e2d\u3002',
+    'leads.confirm': '\u786e\u8ba4',
+    'leads.cancel': '\u53d6\u6d88',
 
     // Bulk Add Students
     'bulkAdd.entryButton': '\u6279\u91cf\u6dfb\u52a0',

--- a/admindash/frontend/src/i18n/translations.ts
+++ b/admindash/frontend/src/i18n/translations.ts
@@ -164,6 +164,15 @@ export const translations: Record<Locale, Record<string, string>> = {
 
     // Lead
     'lead.title': 'Lead Management',
+    'leads.title': 'Leads',
+    'leads.addManual': 'Add Lead',
+    'leads.importEmail': 'Import from Email',
+    'leads.filterAll': 'All stages',
+    'leads.empty': 'No leads yet',
+    'leads.convert': 'Convert to Family',
+    'leads.addActivity': 'Add Activity',
+    'leads.stage': 'Stage',
+    'leads.activityTimeline': 'Activity',
 
     // Bulk Add Students
     'bulkAdd.entryButton': 'Bulk add',
@@ -446,6 +455,15 @@ export const translations: Record<Locale, Record<string, string>> = {
 
     // Lead
     'lead.title': '\u5ba2\u6237\u7ba1\u7406',
+    'leads.title': '\u5ba2\u6237',
+    'leads.addManual': '\u6dfb\u52a0\u5ba2\u6237',
+    'leads.importEmail': '\u4ece\u90ae\u4ef6\u5bfc\u5165',
+    'leads.filterAll': '\u5168\u90e8\u9636\u6bb5',
+    'leads.empty': '\u6682\u65e0\u5ba2\u6237',
+    'leads.convert': '\u8f6c\u5316\u4e3a\u5bb6\u5ead',
+    'leads.addActivity': '\u6dfb\u52a0\u6d3b\u52a8',
+    'leads.stage': '\u9636\u6bb5',
+    'leads.activityTimeline': '\u6d3b\u52a8',
 
     // Bulk Add Students
     'bulkAdd.entryButton': '\u6279\u91cf\u6dfb\u52a0',

--- a/admindash/frontend/src/pages/LeadPage.css
+++ b/admindash/frontend/src/pages/LeadPage.css
@@ -13,3 +13,11 @@
 .placeholder-page p {
   color: var(--text-tertiary);
 }
+
+.leads-header { display: flex; justify-content: space-between; align-items: center; }
+.leads-actions { display: flex; gap: var(--space-2, 8px); }
+.leads-board { display: flex; gap: var(--space-3, 12px); overflow-x: auto; }
+.leads-column { min-width: 200px; flex: 1; }
+.lead-card { display: flex; flex-direction: column; gap: 2px; width: 100%; text-align: left;
+  padding: var(--space-2, 8px); margin-bottom: var(--space-2, 8px);
+  border: 1px solid var(--color-border, #ddd); border-radius: var(--radius-md, 6px); background: var(--color-surface, #fff); cursor: pointer; }

--- a/admindash/frontend/src/pages/LeadPage.css
+++ b/admindash/frontend/src/pages/LeadPage.css
@@ -1,23 +1,116 @@
-.placeholder-page {
+.leads-page {
   animation: fadeIn 0.3s ease;
 }
 
-.placeholder-page h1 {
+.leads-page h1 {
   font-size: 28px;
   font-weight: 800;
   letter-spacing: -0.02em;
-  color: #1A202C;
-  margin-bottom: 0.75rem;
+  color: var(--text-primary);
+  margin-bottom: 1rem;
 }
 
-.placeholder-page p {
+.leads-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.leads-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.leads-stage-filter {
+  font-family: var(--font-sans);
+  font-size: 0.85rem;
+  padding: 0.45rem 0.6rem;
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-sm);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  cursor: pointer;
+  outline: none;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.leads-stage-filter:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(55, 138, 221, 0.15);
+}
+
+.leads-board {
+  display: flex;
+  gap: 1rem;
+  overflow-x: auto;
+  margin-top: 1rem;
+}
+
+.leads-column {
+  min-width: 220px;
+  flex: 1;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-md);
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.leads-column h2 {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+  margin: 0 0 0.25rem 0;
+}
+
+.leads-column h2 span {
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: var(--text-tertiary);
+  background: var(--bg-tertiary);
+  border-radius: 999px;
+  padding: 0.1rem 0.5rem;
+}
+
+.lead-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  width: 100%;
+  text-align: left;
+  padding: 0.75rem;
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-sm);
+  background: var(--bg-card);
+  cursor: pointer;
+  transition: border-color 0.15s, box-shadow 0.15s, transform 0.15s;
+}
+
+.lead-card:hover {
+  border-color: var(--accent);
+  box-shadow: var(--shadow-card);
+  transform: translateY(-1px);
+}
+
+.lead-card strong {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.lead-card small {
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+}
+
+.lead-card small:last-child {
   color: var(--text-tertiary);
 }
-
-.leads-header { display: flex; justify-content: space-between; align-items: center; }
-.leads-actions { display: flex; gap: var(--space-2, 8px); }
-.leads-board { display: flex; gap: var(--space-3, 12px); overflow-x: auto; }
-.leads-column { min-width: 200px; flex: 1; }
-.lead-card { display: flex; flex-direction: column; gap: 2px; width: 100%; text-align: left;
-  padding: var(--space-2, 8px); margin-bottom: var(--space-2, 8px);
-  border: 1px solid var(--color-border, #ddd); border-radius: var(--radius-md, 6px); background: var(--color-surface, #fff); cursor: pointer; }

--- a/admindash/frontend/src/pages/LeadPage.tsx
+++ b/admindash/frontend/src/pages/LeadPage.tsx
@@ -5,6 +5,7 @@ import { LEAD_STAGES, type Lead, type LeadStage } from '../types/models.ts';
 import LeadDetailDrawer from '../components/LeadDetailDrawer.tsx';
 import AddLeadModal from '../components/AddLeadModal.tsx';
 import ImportEmailModal from '../components/ImportEmailModal.tsx';
+import '../components/DynamicForm.css';
 import './LeadPage.css';
 
 export default function LeadPage({ tenant }: { tenant: string }) {
@@ -31,15 +32,15 @@ export default function LeadPage({ tenant }: { tenant: string }) {
       <header className="leads-header">
         <h1>{t('leads.title')}</h1>
         <div className="leads-actions">
-          <select value={filter} onChange={(e) => setFilter(e.target.value as LeadStage | '')}>
+          <select className="leads-stage-filter" value={filter} onChange={(e) => setFilter(e.target.value as LeadStage | '')}>
             <option value="">{t('leads.filterAll')}</option>
             {LEAD_STAGES.map((s) => <option key={s} value={s}>{s}</option>)}
           </select>
-          <button onClick={() => setShowAdd(true)}>{t('leads.addManual')}</button>
-          <button onClick={() => setShowImport(true)}>{t('leads.importEmail')}</button>
+          <button className="dynamic-form-btn-primary" onClick={() => setShowAdd(true)}>{t('leads.addManual')}</button>
+          <button className="dynamic-form-btn-secondary" onClick={() => setShowImport(true)}>{t('leads.importEmail')}</button>
         </div>
       </header>
-      {error && <p className="error">{error}</p>}
+      {error && <div className="dynamic-form-error">{error}</div>}
       {leads.length === 0 && <p>{t('leads.empty')}</p>}
       <div className="leads-board">
         {LEAD_STAGES.map((stage) => (

--- a/admindash/frontend/src/pages/LeadPage.tsx
+++ b/admindash/frontend/src/pages/LeadPage.tsx
@@ -1,13 +1,68 @@
+import { useEffect, useState, useCallback } from 'react';
 import { useTranslation } from '../hooks/useTranslation.ts';
+import { listLeads } from '../api/client.ts';
+import { LEAD_STAGES, type Lead, type LeadStage } from '../types/models.ts';
+import LeadDetailDrawer from '../components/LeadDetailDrawer.tsx';
+import AddLeadModal from '../components/AddLeadModal.tsx';
+import ImportEmailModal from '../components/ImportEmailModal.tsx';
 import './LeadPage.css';
 
-export default function LeadPage() {
+export default function LeadPage({ tenant }: { tenant: string }) {
   const { t } = useTranslation();
+  const [leads, setLeads] = useState<Lead[]>([]);
+  const [filter, setFilter] = useState<LeadStage | ''>('');
+  const [selected, setSelected] = useState<Lead | null>(null);
+  const [showAdd, setShowAdd] = useState(false);
+  const [showImport, setShowImport] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try { setLeads(await listLeads(tenant, filter || undefined)); }
+    catch (e) { setError(String(e)); }
+  }, [tenant, filter]);
+
+  // eslint-disable-next-line react-hooks/set-state-in-effect
+  useEffect(() => { void load(); }, [load]);
+
+  const byStage = (s: LeadStage) => leads.filter((l) => l.stage === s);
 
   return (
-    <div className="placeholder-page">
-      <h1>{t('lead.title')}</h1>
-      <p>Coming soon.</p>
+    <div className="leads-page">
+      <header className="leads-header">
+        <h1>{t('leads.title')}</h1>
+        <div className="leads-actions">
+          <select value={filter} onChange={(e) => setFilter(e.target.value as LeadStage | '')}>
+            <option value="">{t('leads.filterAll')}</option>
+            {LEAD_STAGES.map((s) => <option key={s} value={s}>{s}</option>)}
+          </select>
+          <button onClick={() => setShowAdd(true)}>{t('leads.addManual')}</button>
+          <button onClick={() => setShowImport(true)}>{t('leads.importEmail')}</button>
+        </div>
+      </header>
+      {error && <p className="error">{error}</p>}
+      {leads.length === 0 && <p>{t('leads.empty')}</p>}
+      <div className="leads-board">
+        {LEAD_STAGES.map((stage) => (
+          <div key={stage} className="leads-column">
+            <h2>{stage} <span>{byStage(stage).length}</span></h2>
+            {byStage(stage).map((l) => (
+              <button key={l.entity_id} className="lead-card" onClick={() => setSelected(l)}>
+                <strong>{l.guardian_name}</strong>
+                <small>{l.student_first_name} {l.student_last_name}</small>
+                <small>{l.email || l.phone}</small>
+              </button>
+            ))}
+          </div>
+        ))}
+      </div>
+      {selected && (
+        <LeadDetailDrawer tenant={tenant} lead={selected}
+          onClose={() => setSelected(null)} onChanged={() => { void load(); }} />
+      )}
+      {showAdd && <AddLeadModal tenant={tenant}
+        onClose={() => setShowAdd(false)} onCreated={() => { setShowAdd(false); void load(); }} />}
+      {showImport && <ImportEmailModal tenant={tenant}
+        onClose={() => setShowImport(false)} onCreated={() => { setShowImport(false); void load(); }} />}
     </div>
   );
 }

--- a/admindash/frontend/src/pages/LeadPage.tsx
+++ b/admindash/frontend/src/pages/LeadPage.tsx
@@ -1,7 +1,10 @@
 import { useEffect, useState, useCallback } from 'react';
 import { useTranslation } from '../hooks/useTranslation.ts';
 import { listLeads } from '../api/client.ts';
-import { LEAD_STAGES, type Lead, type LeadStage } from '../types/models.ts';
+import { useModel } from '../contexts/ModelContext.tsx';
+import { leadStages } from '../utils/leadModel.ts';
+import type { Lead } from '../types/models.ts';
+import type { ModelDefinition } from '../types/models.ts';
 import LeadDetailDrawer from '../components/LeadDetailDrawer.tsx';
 import AddLeadModal from '../components/AddLeadModal.tsx';
 import ImportEmailModal from '../components/ImportEmailModal.tsx';
@@ -10,12 +13,18 @@ import './LeadPage.css';
 
 export default function LeadPage({ tenant }: { tenant: string }) {
   const { t } = useTranslation();
+  const { getModel } = useModel();
+  const [model, setModel] = useState<ModelDefinition | null>(null);
   const [leads, setLeads] = useState<Lead[]>([]);
-  const [filter, setFilter] = useState<LeadStage | ''>('');
+  const [filter, setFilter] = useState<string>('');
   const [selected, setSelected] = useState<Lead | null>(null);
   const [showAdd, setShowAdd] = useState(false);
   const [showImport, setShowImport] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => { getModel(tenant, 'lead').then(setModel).catch(() => setModel(null)); }, [tenant, getModel]);
+
+  const stages = leadStages(model);
 
   const load = useCallback(async () => {
     try { setLeads(await listLeads(tenant, filter || undefined)); }
@@ -25,16 +34,26 @@ export default function LeadPage({ tenant }: { tenant: string }) {
   // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => { void load(); }, [load]);
 
-  const byStage = (s: LeadStage) => leads.filter((l) => l.stage === s);
+  const byStage = (s: string) => leads.filter((l) => l.stage === s);
+  // Leads whose stage is set but no longer matches any known stage.
+  const otherLeads = leads.filter((l) => l.stage && !stages.includes(l.stage));
+
+  const renderCard = (l: Lead) => (
+    <button key={l.entity_id} className="lead-card" onClick={() => setSelected(l)}>
+      <strong>{String(l.guardian_name ?? l.student ?? l.contact ?? '')}</strong>
+      <small>{l.student_first_name} {l.student_last_name}</small>
+      <small>{l.email || l.phone}</small>
+    </button>
+  );
 
   return (
     <div className="leads-page">
       <header className="leads-header">
         <h1>{t('leads.title')}</h1>
         <div className="leads-actions">
-          <select className="leads-stage-filter" value={filter} onChange={(e) => setFilter(e.target.value as LeadStage | '')}>
+          <select className="leads-stage-filter" value={filter} onChange={(e) => setFilter(e.target.value)}>
             <option value="">{t('leads.filterAll')}</option>
-            {LEAD_STAGES.map((s) => <option key={s} value={s}>{s}</option>)}
+            {stages.map((s) => <option key={s} value={s}>{s}</option>)}
           </select>
           <button className="dynamic-form-btn-primary" onClick={() => setShowAdd(true)}>{t('leads.addManual')}</button>
           <button className="dynamic-form-btn-secondary" onClick={() => setShowImport(true)}>{t('leads.importEmail')}</button>
@@ -43,18 +62,18 @@ export default function LeadPage({ tenant }: { tenant: string }) {
       {error && <div className="dynamic-form-error">{error}</div>}
       {leads.length === 0 && <p>{t('leads.empty')}</p>}
       <div className="leads-board">
-        {LEAD_STAGES.map((stage) => (
+        {stages.map((stage) => (
           <div key={stage} className="leads-column">
             <h2>{stage} <span>{byStage(stage).length}</span></h2>
-            {byStage(stage).map((l) => (
-              <button key={l.entity_id} className="lead-card" onClick={() => setSelected(l)}>
-                <strong>{l.guardian_name}</strong>
-                <small>{l.student_first_name} {l.student_last_name}</small>
-                <small>{l.email || l.phone}</small>
-              </button>
-            ))}
+            {byStage(stage).map(renderCard)}
           </div>
         ))}
+        {otherLeads.length > 0 && (
+          <div className="leads-column">
+            <h2>Other <span>{otherLeads.length}</span></h2>
+            {otherLeads.map(renderCard)}
+          </div>
+        )}
       </div>
       {selected && (
         <LeadDetailDrawer tenant={tenant} lead={selected}

--- a/admindash/frontend/src/pages/PublicInquiryPage.css
+++ b/admindash/frontend/src/pages/PublicInquiryPage.css
@@ -1,0 +1,76 @@
+.inquiry-page {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: var(--space-6, 48px) var(--space-4, 16px);
+  min-height: 100vh;
+  background: var(--color-bg, #f7f8fa);
+}
+
+.inquiry-page h1 {
+  font-size: 28px;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: #1A202C;
+  margin-bottom: var(--space-4, 16px);
+}
+
+.inquiry-page form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3, 12px);
+  width: 100%;
+  max-width: 480px;
+  background: var(--color-surface, #fff);
+  border: 1px solid var(--color-border, #ddd);
+  border-radius: var(--radius-md, 6px);
+  padding: var(--space-5, 32px);
+}
+
+.inquiry-page label {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1, 4px);
+  font-size: 14px;
+  color: var(--text-secondary, #4A5568);
+  font-weight: 500;
+}
+
+.inquiry-page input,
+.inquiry-page textarea {
+  padding: var(--space-2, 8px) var(--space-2, 8px);
+  border: 1px solid var(--color-border, #ddd);
+  border-radius: var(--radius-sm, 4px);
+  font-size: 14px;
+  background: var(--color-bg, #f7f8fa);
+  color: #1A202C;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.inquiry-page textarea {
+  min-height: 80px;
+  resize: vertical;
+}
+
+.inquiry-page button[type='submit'] {
+  padding: var(--space-2, 8px) var(--space-4, 16px);
+  background: var(--color-primary, #3B82F6);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-md, 6px);
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  align-self: flex-start;
+}
+
+.inquiry-page button[type='submit']:hover {
+  background: var(--color-primary-hover, #2563EB);
+}
+
+.inquiry-page .error {
+  color: var(--color-error, #E53E3E);
+  font-size: 14px;
+  margin-bottom: var(--space-2, 8px);
+}

--- a/admindash/frontend/src/pages/PublicInquiryPage.css
+++ b/admindash/frontend/src/pages/PublicInquiryPage.css
@@ -2,75 +2,25 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: var(--space-6, 48px) var(--space-4, 16px);
+  padding: 3rem 1rem;
   min-height: 100vh;
-  background: var(--color-bg, #f7f8fa);
+  background: var(--bg-primary, #F8FAFC);
 }
 
 .inquiry-page h1 {
   font-size: 28px;
   font-weight: 800;
   letter-spacing: -0.02em;
-  color: #1A202C;
-  margin-bottom: var(--space-4, 16px);
+  color: var(--text-primary, #1A202C);
+  margin-bottom: 1rem;
 }
 
 .inquiry-page form {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-3, 12px);
   width: 100%;
-  max-width: 480px;
-  background: var(--color-surface, #fff);
-  border: 1px solid var(--color-border, #ddd);
-  border-radius: var(--radius-md, 6px);
-  padding: var(--space-5, 32px);
-}
-
-.inquiry-page label {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-1, 4px);
-  font-size: 14px;
-  color: var(--text-secondary, #4A5568);
-  font-weight: 500;
-}
-
-.inquiry-page input,
-.inquiry-page textarea {
-  padding: var(--space-2, 8px) var(--space-2, 8px);
-  border: 1px solid var(--color-border, #ddd);
-  border-radius: var(--radius-sm, 4px);
-  font-size: 14px;
-  background: var(--color-bg, #f7f8fa);
-  color: #1A202C;
-  width: 100%;
-  box-sizing: border-box;
-}
-
-.inquiry-page textarea {
-  min-height: 80px;
-  resize: vertical;
-}
-
-.inquiry-page button[type='submit'] {
-  padding: var(--space-2, 8px) var(--space-4, 16px);
-  background: var(--color-primary, #3B82F6);
-  color: #fff;
-  border: none;
-  border-radius: var(--radius-md, 6px);
-  font-size: 14px;
-  font-weight: 600;
-  cursor: pointer;
-  align-self: flex-start;
-}
-
-.inquiry-page button[type='submit']:hover {
-  background: var(--color-primary-hover, #2563EB);
-}
-
-.inquiry-page .error {
-  color: var(--color-error, #E53E3E);
-  font-size: 14px;
-  margin-bottom: var(--space-2, 8px);
+  max-width: 640px;
+  background: var(--bg-card, #FFF);
+  border: 1px solid var(--border-primary, #E2E8F0);
+  border-radius: var(--radius-md, 12px);
+  box-shadow: var(--shadow-card);
+  padding: 2rem;
 }

--- a/admindash/frontend/src/pages/PublicInquiryPage.tsx
+++ b/admindash/frontend/src/pages/PublicInquiryPage.tsx
@@ -8,7 +8,7 @@ import './PublicInquiryPage.css';
 
 const DEFAULT_FIELDS: LeadModelField[] = [
   { name: 'guardian_name', type: 'str', required: true },
-  { name: 'email', type: 'email', required: true },
+  { name: 'email', type: 'email', required: false },
   { name: 'phone', type: 'phone', required: false },
   { name: 'student_first_name', type: 'str', required: false },
   { name: 'student_last_name', type: 'str', required: false },

--- a/admindash/frontend/src/pages/PublicInquiryPage.tsx
+++ b/admindash/frontend/src/pages/PublicInquiryPage.tsx
@@ -1,28 +1,107 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { submitPublicLead } from '../api/client.ts';
+import { fetchPublicLeadModel, submitPublicLead } from '../api/client.ts';
+import { formatFieldLabel } from '../utils/leadModel.ts';
+import { type LeadModelField } from '../types/models.ts';
 import '../components/DynamicForm.css';
 import './PublicInquiryPage.css';
 
+const DEFAULT_FIELDS: LeadModelField[] = [
+  { name: 'guardian_name', type: 'str', required: true },
+  { name: 'email', type: 'email', required: true },
+  { name: 'phone', type: 'phone', required: false },
+  { name: 'student_first_name', type: 'str', required: false },
+  { name: 'student_last_name', type: 'str', required: false },
+  { name: 'grade_of_interest', type: 'str', required: false },
+  { name: 'message', type: 'str', required: false },
+];
+
+function renderInput(
+  field: LeadModelField,
+  value: string,
+  onChange: (v: string) => void,
+) {
+  const id = `field-${field.name}`;
+  if (field.name === 'message' || (field.type !== 'email' && field.type !== 'phone' && field.type !== 'selection' && field.type !== 'str' && field.type !== 'number' && field.type !== 'date')) {
+    return (
+      <textarea
+        id={id}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      />
+    );
+  }
+  if (field.type === 'selection' && field.options && field.options.length > 0) {
+    return (
+      <select id={id} value={value} onChange={(e) => onChange(e.target.value)}>
+        <option value="">-- select --</option>
+        {field.options.map((opt) => (
+          <option key={opt} value={opt}>{opt}</option>
+        ))}
+      </select>
+    );
+  }
+  const inputType = field.type === 'email' ? 'email' : field.type === 'phone' ? 'tel' : 'text';
+  return (
+    <input
+      id={id}
+      type={inputType}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  );
+}
+
 export default function PublicInquiryPage() {
   const { tenantId = '' } = useParams();
-  const [f, setF] = useState({ guardian_name: '', email: '', phone: '',
-    student_first_name: '', student_last_name: '', grade_of_interest: '', message: '' });
+  const [fields, setFields] = useState<LeadModelField[]>(DEFAULT_FIELDS);
+  const [values, setValues] = useState<Record<string, string>>({});
   const [done, setDone] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const set = (k: string) => (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) =>
-    setF({ ...f, [k]: e.target.value });
+
+  function applyFields(modelFields: LeadModelField[]) {
+    setFields(modelFields);
+    const init: Record<string, string> = {};
+    for (const f of modelFields) init[f.name] = '';
+    setValues(init);
+  }
+
+  useEffect(() => {
+    if (!tenantId) return;
+    fetchPublicLeadModel(tenantId)
+      .then((modelFields) => {
+        if (modelFields && modelFields.length > 0) {
+          applyFields(modelFields);
+        } else {
+          applyFields(DEFAULT_FIELDS);
+        }
+      })
+      .catch(() => applyFields(DEFAULT_FIELDS));
+  }, [tenantId]);
+
+  function setValue(name: string, v: string) {
+    setValues((prev) => ({ ...prev, [name]: v }));
+  }
 
   async function submit(e: React.FormEvent) {
     e.preventDefault();
-    if (!f.guardian_name.trim() || !f.email.trim()) {
-      setError('Name and email are required.'); return;
+    const missing = fields
+      .filter((f) => f.required && !(values[f.name] ?? '').trim())
+      .map((f) => formatFieldLabel(f.name));
+    if (missing.length > 0) {
+      setError(`Required: ${missing.join(', ')}`);
+      return;
     }
+    setError(null);
     try {
-      const payload = Object.fromEntries(Object.entries(f).filter(([, v]) => v.trim()));
+      const payload = Object.fromEntries(
+        Object.entries(values).filter(([, v]) => v.trim()),
+      );
       await submitPublicLead(tenantId, payload);
       setDone(true);
-    } catch { setError('Sorry, something went wrong. Please try again.'); }
+    } catch {
+      setError('Sorry, something went wrong. Please try again.');
+    }
   }
 
   if (done) return <div className="inquiry-page"><h1>Thank you!</h1><p>We'll be in touch soon.</p></div>;
@@ -33,34 +112,15 @@ export default function PublicInquiryPage() {
       <form onSubmit={submit}>
         {error && <div className="dynamic-form-error">{error}</div>}
         <div className="dynamic-form-fields">
-          <div className="dynamic-form-field">
-            <label>Your name<span className="dynamic-form-required">*</span></label>
-            <input value={f.guardian_name} onChange={set('guardian_name')} />
-          </div>
-          <div className="dynamic-form-field">
-            <label>Email<span className="dynamic-form-required">*</span></label>
-            <input value={f.email} onChange={set('email')} />
-          </div>
-          <div className="dynamic-form-field">
-            <label>Phone</label>
-            <input value={f.phone} onChange={set('phone')} />
-          </div>
-          <div className="dynamic-form-field">
-            <label>Student first name</label>
-            <input value={f.student_first_name} onChange={set('student_first_name')} />
-          </div>
-          <div className="dynamic-form-field">
-            <label>Student last name</label>
-            <input value={f.student_last_name} onChange={set('student_last_name')} />
-          </div>
-          <div className="dynamic-form-field">
-            <label>Grade of interest</label>
-            <input value={f.grade_of_interest} onChange={set('grade_of_interest')} />
-          </div>
-          <div className="dynamic-form-field">
-            <label>Message</label>
-            <textarea value={f.message} onChange={set('message')} />
-          </div>
+          {fields.map((field) => (
+            <div key={field.name} className="dynamic-form-field">
+              <label htmlFor={`field-${field.name}`}>
+                {formatFieldLabel(field.name)}
+                {field.required && <span className="dynamic-form-required">*</span>}
+              </label>
+              {renderInput(field, values[field.name] ?? '', (v) => setValue(field.name, v))}
+            </div>
+          ))}
         </div>
         <div className="dynamic-form-actions">
           <button type="submit" className="dynamic-form-btn-primary">Submit</button>

--- a/admindash/frontend/src/pages/PublicInquiryPage.tsx
+++ b/admindash/frontend/src/pages/PublicInquiryPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { submitPublicLead } from '../api/client.ts';
+import '../components/DynamicForm.css';
 import './PublicInquiryPage.css';
 
 export default function PublicInquiryPage() {
@@ -29,16 +30,41 @@ export default function PublicInquiryPage() {
   return (
     <div className="inquiry-page">
       <h1>Request Information</h1>
-      {error && <p className="error">{error}</p>}
       <form onSubmit={submit}>
-        <label>Your name*<input value={f.guardian_name} onChange={set('guardian_name')} /></label>
-        <label>Email*<input value={f.email} onChange={set('email')} /></label>
-        <label>Phone<input value={f.phone} onChange={set('phone')} /></label>
-        <label>Student first name<input value={f.student_first_name} onChange={set('student_first_name')} /></label>
-        <label>Student last name<input value={f.student_last_name} onChange={set('student_last_name')} /></label>
-        <label>Grade of interest<input value={f.grade_of_interest} onChange={set('grade_of_interest')} /></label>
-        <label>Message<textarea value={f.message} onChange={set('message')} /></label>
-        <button type="submit">Submit</button>
+        {error && <div className="dynamic-form-error">{error}</div>}
+        <div className="dynamic-form-fields">
+          <div className="dynamic-form-field">
+            <label>Your name<span className="dynamic-form-required">*</span></label>
+            <input value={f.guardian_name} onChange={set('guardian_name')} />
+          </div>
+          <div className="dynamic-form-field">
+            <label>Email<span className="dynamic-form-required">*</span></label>
+            <input value={f.email} onChange={set('email')} />
+          </div>
+          <div className="dynamic-form-field">
+            <label>Phone</label>
+            <input value={f.phone} onChange={set('phone')} />
+          </div>
+          <div className="dynamic-form-field">
+            <label>Student first name</label>
+            <input value={f.student_first_name} onChange={set('student_first_name')} />
+          </div>
+          <div className="dynamic-form-field">
+            <label>Student last name</label>
+            <input value={f.student_last_name} onChange={set('student_last_name')} />
+          </div>
+          <div className="dynamic-form-field">
+            <label>Grade of interest</label>
+            <input value={f.grade_of_interest} onChange={set('grade_of_interest')} />
+          </div>
+          <div className="dynamic-form-field">
+            <label>Message</label>
+            <textarea value={f.message} onChange={set('message')} />
+          </div>
+        </div>
+        <div className="dynamic-form-actions">
+          <button type="submit" className="dynamic-form-btn-primary">Submit</button>
+        </div>
       </form>
     </div>
   );

--- a/admindash/frontend/src/pages/PublicInquiryPage.tsx
+++ b/admindash/frontend/src/pages/PublicInquiryPage.tsx
@@ -1,0 +1,45 @@
+import { useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { submitPublicLead } from '../api/client.ts';
+import './PublicInquiryPage.css';
+
+export default function PublicInquiryPage() {
+  const { tenantId = '' } = useParams();
+  const [f, setF] = useState({ guardian_name: '', email: '', phone: '',
+    student_first_name: '', student_last_name: '', grade_of_interest: '', message: '' });
+  const [done, setDone] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const set = (k: string) => (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) =>
+    setF({ ...f, [k]: e.target.value });
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!f.guardian_name.trim() || !f.email.trim()) {
+      setError('Name and email are required.'); return;
+    }
+    try {
+      const payload = Object.fromEntries(Object.entries(f).filter(([, v]) => v.trim()));
+      await submitPublicLead(tenantId, payload);
+      setDone(true);
+    } catch { setError('Sorry, something went wrong. Please try again.'); }
+  }
+
+  if (done) return <div className="inquiry-page"><h1>Thank you!</h1><p>We'll be in touch soon.</p></div>;
+
+  return (
+    <div className="inquiry-page">
+      <h1>Request Information</h1>
+      {error && <p className="error">{error}</p>}
+      <form onSubmit={submit}>
+        <label>Your name*<input value={f.guardian_name} onChange={set('guardian_name')} /></label>
+        <label>Email*<input value={f.email} onChange={set('email')} /></label>
+        <label>Phone<input value={f.phone} onChange={set('phone')} /></label>
+        <label>Student first name<input value={f.student_first_name} onChange={set('student_first_name')} /></label>
+        <label>Student last name<input value={f.student_last_name} onChange={set('student_last_name')} /></label>
+        <label>Grade of interest<input value={f.grade_of_interest} onChange={set('grade_of_interest')} /></label>
+        <label>Message<textarea value={f.message} onChange={set('message')} /></label>
+        <button type="submit">Submit</button>
+      </form>
+    </div>
+  );
+}

--- a/admindash/frontend/src/types/models.ts
+++ b/admindash/frontend/src/types/models.ts
@@ -106,3 +106,36 @@ export interface DuplicateCheckRequest {
 export interface DuplicateCheckResponse {
   matches: DuplicateMatch[];
 }
+
+export const LEAD_STAGES = [
+  'New', 'Contacted', 'Tour Scheduled', 'Toured', 'Enrolled', 'Lost',
+] as const;
+export type LeadStage = (typeof LEAD_STAGES)[number];
+
+export interface Lead {
+  entity_id: string;
+  lead_id?: string;
+  guardian_name: string;
+  email?: string;
+  phone?: string;
+  student_first_name?: string;
+  student_last_name?: string;
+  grade_of_interest?: string;
+  message?: string;
+  source: 'web_form' | 'manual' | 'email_import';
+  stage: LeadStage;
+  converted_family_id?: string;
+  _created_at?: string;
+  _updated_at?: string;
+}
+
+export interface LeadActivity {
+  entity_id: string;
+  lead_id: string;
+  type: 'call' | 'email' | 'note' | 'stage_change';
+  body: string;
+  stage_from?: string;
+  stage_to?: string;
+  created_by: string;
+  _created_at?: string;
+}

--- a/admindash/frontend/src/types/models.ts
+++ b/admindash/frontend/src/types/models.ts
@@ -107,10 +107,11 @@ export interface DuplicateCheckResponse {
   matches: DuplicateMatch[];
 }
 
-export const LEAD_STAGES = [
-  'New', 'Contacted', 'Tour Scheduled', 'Toured', 'Enrolled', 'Lost',
-] as const;
-export type LeadStage = (typeof LEAD_STAGES)[number];
+export const DEFAULT_LEAD_STAGES = ['New', 'Contacted', 'Tour Scheduled', 'Toured', 'Enrolled', 'Lost'] as const;
+// Backward-compat alias
+export const LEAD_STAGES = DEFAULT_LEAD_STAGES;
+// Relaxed to string — stages are now customer-defined via model
+export type LeadStage = string;
 
 export interface Lead {
   entity_id: string;
@@ -123,10 +124,20 @@ export interface Lead {
   grade_of_interest?: string;
   message?: string;
   source: 'web_form' | 'manual' | 'email_import';
-  stage: LeadStage;
+  stage: string;
   converted_family_id?: string;
   _created_at?: string;
   _updated_at?: string;
+  // Index signature for dynamically-defined custom fields
+  [key: string]: unknown;
+}
+
+export interface LeadModelField {
+  name: string;
+  type: string;
+  required?: boolean;
+  options?: string[];
+  multiple?: boolean;
 }
 
 export interface LeadActivity {

--- a/admindash/frontend/src/utils/leadModel.ts
+++ b/admindash/frontend/src/utils/leadModel.ts
@@ -2,6 +2,14 @@ import type { ModelDefinition } from '../types/models.ts';
 import { DEFAULT_LEAD_STAGES } from '../types/models.ts';
 
 /**
+ * Humanize a field name into a readable label.
+ * e.g. "guardian_name" → "Guardian Name"
+ */
+export function formatFieldLabel(name: string): string {
+  return name.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+/**
  * Return the list of lead stages for a given ModelDefinition.
  * Looks for a field named "stage" (in base_fields then custom_fields) with
  * a non-empty options array. Falls back to DEFAULT_LEAD_STAGES if not found.

--- a/admindash/frontend/src/utils/leadModel.ts
+++ b/admindash/frontend/src/utils/leadModel.ts
@@ -1,0 +1,20 @@
+import type { ModelDefinition } from '../types/models.ts';
+import { DEFAULT_LEAD_STAGES } from '../types/models.ts';
+
+/**
+ * Return the list of lead stages for a given ModelDefinition.
+ * Looks for a field named "stage" (in base_fields then custom_fields) with
+ * a non-empty options array. Falls back to DEFAULT_LEAD_STAGES if not found.
+ */
+export function leadStages(model: ModelDefinition | undefined | null): string[] {
+  if (model) {
+    const allFields = [...(model.base_fields ?? []), ...(model.custom_fields ?? [])];
+    const stageField = allFields.find(
+      (f) => f.name === 'stage' && Array.isArray(f.options) && f.options.length > 0,
+    );
+    if (stageField?.options) {
+      return stageField.options;
+    }
+  }
+  return [...DEFAULT_LEAD_STAGES];
+}

--- a/admindash/frontend/src/utils/leadModel.ts
+++ b/admindash/frontend/src/utils/leadModel.ts
@@ -18,3 +18,22 @@ export function leadStages(model: ModelDefinition | undefined | null): string[] 
   }
   return [...DEFAULT_LEAD_STAGES];
 }
+
+/**
+ * Build a ModelDefinition suitable for capture/edit forms by excluding
+ * reserved internal fields (stage/source/converted_family_id/lead_id) from
+ * both base_fields and custom_fields.
+ *
+ * When `model` is null, both field lists come back empty — callers should
+ * detect that and fall back to their fixed hardcoded inputs.
+ */
+export function formModel(
+  model: ModelDefinition | null,
+  exclude: string[] = ['stage', 'source', 'converted_family_id', 'lead_id'],
+): ModelDefinition {
+  const keep = (f: { name: string }) => !exclude.includes(f.name);
+  return {
+    base_fields: (model?.base_fields ?? []).filter(keep),
+    custom_fields: (model?.custom_fields ?? []).filter(keep),
+  };
+}

--- a/admindash/frontend/src/utils/parseInquiryEmail.ts
+++ b/admindash/frontend/src/utils/parseInquiryEmail.ts
@@ -1,4 +1,6 @@
 // Best-effort extraction of lead fields from a pasted inquiry email.
+// Handles both labeled emails ("Name: Jane Doe" / "Phone: 555-1234") and
+// free-prose emails ("Hi, my name is Jane Doe and my son Max ...").
 export interface ParsedInquiry {
   guardian_name?: string;
   email?: string;
@@ -8,16 +10,72 @@ export interface ParsedInquiry {
   message?: string;
 }
 
+// Value of a "Label: value" (or "Label - value") line for any of the alternatives.
+function labeled(text: string, labels: string): string | undefined {
+  const m = text.match(new RegExp(`^[ \\t]*(?:${labels})[ \\t]*[:\\-][ \\t]*(.+?)[ \\t]*$`, 'im'));
+  return m ? m[1].trim() : undefined;
+}
+
+function splitName(full: string): { first?: string; last?: string } {
+  const parts = full.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return {};
+  if (parts.length === 1) return { first: parts[0] };
+  return { first: parts[0], last: parts.slice(1).join(' ') };
+}
+
 export function parseInquiryEmail(text: string): ParsedInquiry {
   const out: ParsedInquiry = {};
+
+  // Email — first address anywhere in the text (strip trailing sentence punctuation).
   const email = text.match(/[\w.+-]+@[\w-]+\.[\w.-]+/);
-  if (email) out.email = email[0];
-  const phone = text.match(/(\+?\d[\d\s().-]{7,}\d)/);
-  if (phone) out.phone = phone[1].trim();
-  const name = text.match(/(?:my name is|from|regards,|thanks,|sincerely,)\s*([A-Z][a-z]+(?:\s+[A-Z][a-z]+)?)/i);
-  if (name) out.guardian_name = name[1].trim();
-  const student = text.match(/(?:my child|my son|my daughter|student)\s+(?:is\s+)?([A-Z][a-z]+)(?:\s+([A-Z][a-z]+))?/i);
-  if (student) { out.student_first_name = student[1]; if (student[2]) out.student_last_name = student[2]; }
-  out.message = text.trim().slice(0, 2000);
+  if (email) out.email = email[0].replace(/[.,;:]+$/, '');
+
+  // Phone — labeled first, then the first phone-like run of digits.
+  const phoneRaw =
+    labeled(text, 'phone|tel|telephone|mobile|cell|contact number') ??
+    text.match(/(\+?\d[\d\s().-]{7,}\d)/)?.[1];
+  if (phoneRaw && phoneRaw.replace(/\D/g, '').length >= 7) out.phone = phoneRaw.trim();
+
+  // Guardian name — labeled, then "my name is X", then a signature line.
+  let name =
+    labeled(text, 'name|parent name|guardian name|parent/?guardian|parent|guardian|from') ??
+    text.match(/\bmy name is\s+([A-Z][a-zA-Z'’-]+(?:\s+[A-Z][a-zA-Z'’-]+){0,2})/)?.[1] ??
+    text.match(
+      /^[ \t]*(?:regards|thanks|thank you|sincerely|best|cheers)[,!]?[ \t]*\r?\n+[ \t]*([A-Z][a-zA-Z'’-]+(?:\s+[A-Z][a-zA-Z'’-]+){0,2})[ \t]*$/im,
+    )?.[1];
+  if (name) {
+    // Drop an email address the label may have swept up ("Jane Doe <jane@x.com>").
+    name = name.replace(/<[^>]*>/g, '').replace(/[\w.+-]+@[\w-]+\.[\w.-]+/g, '').trim();
+    if (name && /[A-Za-z]/.test(name) && name.split(/\s+/).length <= 4) out.guardian_name = name;
+  }
+
+  // Student name — labeled child/student, or "my son/daughter/child (named) X Y".
+  const studentName =
+    labeled(text, 'student|student name|child|child name|son|daughter') ??
+    text.match(
+      /\bmy (?:son|daughter|child)(?:,?\s+(?:named|is|called))?\s+([A-Z][a-zA-Z'’-]+(?:\s+[A-Z][a-zA-Z'’-]+)?)/,
+    )?.[1];
+  if (studentName) {
+    const { first, last } = splitName(studentName);
+    if (first) out.student_first_name = first;
+    if (last) out.student_last_name = last;
+  }
+
+  // Message — prefer a labeled comments/message block; otherwise the body with the
+  // lines we already pulled out as structured fields removed (so it isn't a raw dump).
+  const msgLabeled = labeled(text, 'message|comments?|notes?|inquiry|enquiry|regarding|reason|questions?');
+  if (msgLabeled) {
+    out.message = msgLabeled.slice(0, 2000);
+  } else {
+    const noise =
+      /^[ \t]*(?:name|parent|guardian|from|to|subject|date|sent|phone|tel|telephone|mobile|cell|e-?mail|student|child|son|daughter|grade)[ \t]*[-:]/i;
+    const body = text
+      .split(/\r?\n/)
+      .filter((l) => l.trim() && !noise.test(l))
+      .join('\n')
+      .trim();
+    if (body) out.message = body.slice(0, 2000);
+  }
+
   return out;
 }

--- a/admindash/frontend/src/utils/parseInquiryEmail.ts
+++ b/admindash/frontend/src/utils/parseInquiryEmail.ts
@@ -1,0 +1,23 @@
+// Best-effort extraction of lead fields from a pasted inquiry email.
+export interface ParsedInquiry {
+  guardian_name?: string;
+  email?: string;
+  phone?: string;
+  student_first_name?: string;
+  student_last_name?: string;
+  message?: string;
+}
+
+export function parseInquiryEmail(text: string): ParsedInquiry {
+  const out: ParsedInquiry = {};
+  const email = text.match(/[\w.+-]+@[\w-]+\.[\w.-]+/);
+  if (email) out.email = email[0];
+  const phone = text.match(/(\+?\d[\d\s().-]{7,}\d)/);
+  if (phone) out.phone = phone[1].trim();
+  const name = text.match(/(?:my name is|from|regards,|thanks,|sincerely,)\s*([A-Z][a-z]+(?:\s+[A-Z][a-z]+)?)/i);
+  if (name) out.guardian_name = name[1].trim();
+  const student = text.match(/(?:my child|my son|my daughter|student)\s+(?:is\s+)?([A-Z][a-z]+)(?:\s+([A-Z][a-z]+))?/i);
+  if (student) { out.student_first_name = student[1]; if (student[2]) out.student_last_name = student[2]; }
+  out.message = text.trim().slice(0, 2000);
+  return out;
+}

--- a/datacore/src/datacore/api/routes.py
+++ b/datacore/src/datacore/api/routes.py
@@ -20,6 +20,7 @@ DUPLICATE_CHECK_THRESHOLD = float(
 DEFAULT_ABBREVS = {
     "student": "ST",
     "program": "PR",
+    "lead": "LD",
 }
 
 

--- a/datacore/tests/test_entity_auto_id.py
+++ b/datacore/tests/test_entity_auto_id.py
@@ -122,3 +122,58 @@ def test_default_abbrevs_cleaned_up(program_client):
     # After this test, the fixture teardown will restore DEFAULT_ABBREVS.
     # We verify it still has 'program' during the test (before teardown).
     assert "program" in DEFAULT_ABBREVS
+
+
+@pytest.fixture
+def lead_client():
+    """Client with 'lead' registered in DEFAULT_ABBREVS."""
+    original = dict(DEFAULT_ABBREVS)
+    DEFAULT_ABBREVS["lead"] = "LD"
+    with tempfile.TemporaryDirectory() as tmp:
+        mock_embedder = MagicMock()
+        mock_embedder.embed.return_value = [0.0] * 1024
+        store = Store(data_dir=tmp, embedder=mock_embedder)
+        app = create_app(store)
+        client = TestClient(app)
+        client.put(
+            "/api/tenants/t1",
+            json={
+                "base_data": {
+                    "tenant_id": "t1",
+                    "name": "Acme Child Center",
+                    "primary_address": "123 Main St",
+                },
+            },
+        )
+        yield client, store
+    DEFAULT_ABBREVS.clear()
+    DEFAULT_ABBREVS.update(original)
+
+
+def test_lead_gets_sequential_human_id():
+    """Creating a lead without lead_id should auto-assign one."""
+    # This test verifies lead auto-ID WITHOUT the fixture managing DEFAULT_ABBREVS
+    # to confirm lead_id generation works after adding "lead" to DEFAULT_ABBREVS permanently
+    with tempfile.TemporaryDirectory() as tmp:
+        mock_embedder = MagicMock()
+        mock_embedder.embed.return_value = [0.0] * 1024
+        store = Store(data_dir=tmp, embedder=mock_embedder)
+        app = create_app(store)
+        client = TestClient(app)
+        client.put(
+            "/api/tenants/t1",
+            json={
+                "base_data": {
+                    "tenant_id": "t1",
+                    "name": "Acme Child Center",
+                    "primary_address": "123 Main St",
+                },
+            },
+        )
+        resp = client.post(
+            "/api/entities/t1/lead",
+            json={"base_data": {"guardian_name": "Sam Rivera", "email": "sam@example.com"}},
+        )
+        assert resp.status_code == 201
+        lead_id = resp.json()["base_data"]["lead_id"]
+        assert "-LD" in lead_id  # e.g. ACC-LD260001

--- a/datacore/tests/test_entity_auto_id.py
+++ b/datacore/tests/test_entity_auto_id.py
@@ -124,32 +124,6 @@ def test_default_abbrevs_cleaned_up(program_client):
     assert "program" in DEFAULT_ABBREVS
 
 
-@pytest.fixture
-def lead_client():
-    """Client with 'lead' registered in DEFAULT_ABBREVS."""
-    original = dict(DEFAULT_ABBREVS)
-    DEFAULT_ABBREVS["lead"] = "LD"
-    with tempfile.TemporaryDirectory() as tmp:
-        mock_embedder = MagicMock()
-        mock_embedder.embed.return_value = [0.0] * 1024
-        store = Store(data_dir=tmp, embedder=mock_embedder)
-        app = create_app(store)
-        client = TestClient(app)
-        client.put(
-            "/api/tenants/t1",
-            json={
-                "base_data": {
-                    "tenant_id": "t1",
-                    "name": "Acme Child Center",
-                    "primary_address": "123 Main St",
-                },
-            },
-        )
-        yield client, store
-    DEFAULT_ABBREVS.clear()
-    DEFAULT_ABBREVS.update(original)
-
-
 def test_lead_gets_sequential_human_id():
     """Creating a lead without lead_id should auto-assign one."""
     # This test verifies lead auto-ID WITHOUT the fixture managing DEFAULT_ABBREVS

--- a/docs/superpowers/plans/2026-07-20-admindash-leads-module.md
+++ b/docs/superpowers/plans/2026-07-20-admindash-leads-module.md
@@ -1,0 +1,1536 @@
+# AdminDash Leads Module Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a lead-management module to AdminDash — intake (public web form + manual + email import), a fixed pipeline, a denormalized activity log, and a convert-to-family action.
+
+**Architecture:** Leads and activities are new DataCore entity types (`lead`, `lead_activity`) stored in the existing shared per-tenant entities table — no new storage. A dedicated AdminDash backend `leads` router enforces lead-specific rules (public-intake field allowlist, tenant validation, stage auto-logging, convert guard) by proxying to DataCore's entity + query API over sync `httpx`. The frontend uses a fixed lead schema (not the model-driven DynamicForm) with new pages plus one public unauthenticated route.
+
+**Tech Stack:** Python 3 / FastAPI / httpx / pytest + respx (backend); React 19 + TypeScript + Vite, native fetch, `@neoapex/ui-tokens` (frontend); DataCore LanceDB entity store.
+
+## Global Constraints
+
+- Pipeline stages, in order: `New`, `Contacted`, `Tour Scheduled`, `Toured`, `Enrolled`, `Lost`. `Enrolled` and `Lost` are terminal. Copy this list verbatim wherever stages are enumerated.
+- Activity types: `call`, `email`, `note` (admin-created), `stage_change` (system-created only).
+- Lead `source` values: `web_form`, `manual`, `email_import`.
+- DataCore entity `PUT` **replaces** `base_data` — every update must read the current entity via `/api/query`, merge, and send the full `base_data`.
+- DataCore `/api/query` body: `{tenant_id, table: "entities", sql}`; the SQL references the table alias `data`; `base_data` fields are flattened to top-level columns; response is `{data: [...rows], total}`.
+- DataCore entity create: `POST {datacore}/api/entities/{tenant}/{type}` with `{base_data, custom_fields}` → `201` with the full record (includes `entity_id`, and `base_data.lead_id` once the abbrev exists).
+- DataCore has **no auth**; every authenticated AdminDash route uses `Depends(require_authenticated_user)`. The single public route must NOT use it.
+- Backend HTTP to DataCore uses **sync `httpx`** (so `respx` intercepts it in tests), mirroring `app/api/entities.py`.
+- Match existing code style. Backend files live under `admindash/backend/app/`; run backend commands from `admindash/` with `uv run`.
+- Timestamps: rely on DataCore's `_created_at` / `_updated_at` metadata; do not hand-roll timestamps in `base_data`.
+
+---
+
+## Task 1: DataCore — human-friendly `lead` ids
+
+**Files:**
+- Modify: `datacore/src/datacore/api/routes.py` (the `DEFAULT_ABBREVS` dict near the top)
+- Test: `datacore/tests/test_entities_api.py` (or the existing entity-API test module; create `test_lead_id.py` if none fits)
+
+**Interfaces:**
+- Produces: leads created via `POST /api/entities/{tenant}/lead` receive `base_data.lead_id` of the form `{ABBREV}-LD{YY}{NNNN}`.
+
+- [ ] **Step 1: Locate the current abbrevs and existing entity-create test**
+
+Run: `grep -n "DEFAULT_ABBREVS" datacore/src/datacore/api/routes.py` and `ls datacore/tests/ | grep -i entit`
+Expected: `DEFAULT_ABBREVS = {"student": "ST", "program": "PR"}` around line 20; an entities API test file exists.
+
+- [ ] **Step 2: Write the failing test**
+
+Add to the entity-API test module (adjust fixture names to match the file's existing DataCore test client + tenant setup):
+
+```python
+def test_lead_gets_sequential_human_id(client, seeded_tenant):
+    # seeded_tenant creates a 'tenant' entity so _check_tenant_exists passes
+    resp = client.post(
+        f"/api/entities/{seeded_tenant}/lead",
+        json={"base_data": {"guardian_name": "Sam Rivera", "email": "sam@example.com"}},
+    )
+    assert resp.status_code == 201
+    lead_id = resp.json()["base_data"]["lead_id"]
+    assert "-LD" in lead_id  # e.g. TES-LD260001
+```
+
+- [ ] **Step 3: Run it and confirm it fails**
+
+Run: `cd datacore && uv run python -m pytest tests/ -k lead_gets_sequential_human_id -v`
+Expected: FAIL — `lead_id` KeyError (no abbrev registered).
+
+- [ ] **Step 4: Add the abbrev**
+
+In `routes.py`:
+
+```python
+DEFAULT_ABBREVS = {
+    "student": "ST",
+    "program": "PR",
+    "lead": "LD",
+}
+```
+
+- [ ] **Step 5: Run the test and the full datacore suite**
+
+Run: `cd datacore && uv run python -m pytest tests/ -k lead_gets_sequential_human_id -v`
+Expected: PASS
+Run: `cd datacore && uv run python -m pytest tests/ -q`
+Expected: all pass (no regressions).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add datacore/src/datacore/api/routes.py datacore/tests/
+git commit -m "feat(datacore): sequential human id for lead entity type"
+```
+
+---
+
+## Task 2: AdminDash backend — leads DataCore client helpers + schemas
+
+**Files:**
+- Create: `admindash/backend/app/api/leads.py`
+- Test: `admindash/backend/tests/test_leads.py`
+
+**Interfaces:**
+- Produces (module-level, used by later tasks):
+  - `STAGES: list[str]` — the six stages in order.
+  - `TERMINAL_STAGES = {"Enrolled", "Lost"}`.
+  - `ACTIVITY_TYPES = {"call", "email", "note"}`.
+  - `router = APIRouter()`.
+  - `_dc_create(tenant, entity_type, base_data, token) -> dict` (returns DataCore record; `token=None` allowed for public path).
+  - `_dc_update(tenant, entity_type, entity_id, base_data, token) -> dict`.
+  - `_dc_query(tenant, sql, token) -> list[dict]` (returns the `data` list).
+  - `_get_lead(tenant, lead_id, token) -> dict | None` (active lead row incl. `entity_id`, flattened base_data columns).
+
+- [ ] **Step 1: Write the failing test for the client helpers via the create route (defined in Task 3). Start with the module import + schema test:**
+
+```python
+# admindash/backend/tests/test_leads.py
+import httpx
+import respx
+
+
+def _stub_auth(mock):
+    mock.get("http://localhost:5800/auth/me").mock(
+        return_value=httpx.Response(200, json={"id": "u1", "tenant_id": "t1"})
+    )
+
+
+def test_stages_constant_is_ordered():
+    from app.api.leads import STAGES
+    assert STAGES == ["New", "Contacted", "Tour Scheduled", "Toured", "Enrolled", "Lost"]
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `cd admindash && uv run pytest backend/tests/test_leads.py -k stages_constant -v`
+Expected: FAIL — `ModuleNotFoundError: app.api.leads`.
+
+- [ ] **Step 3: Create the module with constants, schemas, and helpers**
+
+```python
+# admindash/backend/app/api/leads.py
+"""Lead-management routes — proxy to DataCore with lead-specific business rules."""
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, model_validator
+
+from app.auth import require_authenticated_user
+from app.config import settings
+
+router = APIRouter()
+
+STAGES = ["New", "Contacted", "Tour Scheduled", "Toured", "Enrolled", "Lost"]
+TERMINAL_STAGES = {"Enrolled", "Lost"}
+ACTIVITY_TYPES = {"call", "email", "note"}
+
+
+# ── DataCore client helpers (sync httpx so respx intercepts) ──────────────
+def _dc(method: str, path: str, token: str | None, json_body: dict | None = None):
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = token
+    try:
+        resp = httpx.request(
+            method, f"{settings.datacore_url}{path}",
+            json=json_body, headers=headers, timeout=30.0,
+        )
+    except httpx.RequestError:
+        raise HTTPException(status.HTTP_502_BAD_GATEWAY, "DataCore is unreachable")
+    return resp
+
+
+def _dc_create(tenant: str, entity_type: str, base_data: dict, token: str | None) -> dict:
+    resp = _dc("POST", f"/api/entities/{tenant}/{entity_type}", token,
+               {"base_data": base_data, "custom_fields": {}})
+    if resp.status_code not in (200, 201):
+        raise HTTPException(resp.status_code, f"DataCore create failed: {resp.text}")
+    return resp.json()
+
+
+def _dc_update(tenant: str, entity_type: str, entity_id: str, base_data: dict, token: str | None) -> dict:
+    resp = _dc("PUT", f"/api/entities/{tenant}/{entity_type}/{entity_id}", token,
+               {"base_data": base_data, "custom_fields": {}})
+    if resp.status_code not in (200, 201):
+        raise HTTPException(resp.status_code, f"DataCore update failed: {resp.text}")
+    return resp.json()
+
+
+def _dc_query(tenant: str, sql: str, token: str | None) -> list[dict]:
+    resp = _dc("POST", "/api/query", token,
+               {"tenant_id": tenant, "table": "entities", "sql": sql})
+    if resp.status_code != 200:
+        raise HTTPException(resp.status_code, f"DataCore query failed: {resp.text}")
+    return resp.json().get("data", [])
+
+
+def _get_lead(tenant: str, lead_id: str, token: str | None) -> dict | None:
+    rows = _dc_query(
+        tenant,
+        f"SELECT * FROM data WHERE entity_type = 'lead' "
+        f"AND entity_id = '{lead_id}' AND _status = 'active'",
+        token,
+    )
+    return rows[0] if rows else None
+
+
+def _tenant_exists(tenant: str) -> bool:
+    rows = _dc_query(
+        tenant,
+        f"SELECT entity_id FROM data WHERE entity_type = 'tenant' "
+        f"AND entity_id = '{tenant}' AND _status = 'active'",
+        None,
+    )
+    return bool(rows)
+
+
+# ── Schemas ───────────────────────────────────────────────────────────────
+class LeadCreate(BaseModel):
+    guardian_name: str
+    email: str | None = None
+    phone: str | None = None
+    student_first_name: str | None = None
+    student_last_name: str | None = None
+    grade_of_interest: str | None = None
+    message: str | None = None
+
+    @model_validator(mode="after")
+    def _contact_required(self):
+        if not (self.email or self.phone):
+            raise ValueError("At least one of email or phone is required")
+        return self
+
+
+class PublicLeadCreate(LeadCreate):
+    """Same prospect fields; internal fields (stage/source/converted_family_id) are never accepted."""
+
+
+class StageUpdate(BaseModel):
+    stage: str
+
+
+class ActivityCreate(BaseModel):
+    type: str
+    body: str
+
+
+class ConvertRequest(BaseModel):
+    family_name: str
+    primary_address: str
+    primary_email: str | None = None
+    primary_phone: str | None = None
+    student_first_name: str
+    student_last_name: str
+    grade_level: str | None = None
+```
+
+- [ ] **Step 4: Run the constant test**
+
+Run: `cd admindash && uv run pytest backend/tests/test_leads.py -k stages_constant -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add admindash/backend/app/api/leads.py admindash/backend/tests/test_leads.py
+git commit -m "feat(admindash): leads router scaffold — DataCore helpers and schemas"
+```
+
+---
+
+## Task 3: AdminDash backend — create / list / get lead routes
+
+**Files:**
+- Modify: `admindash/backend/app/api/leads.py`
+- Modify: `admindash/backend/app/main.py` (register router)
+- Test: `admindash/backend/tests/test_leads.py`
+
+**Interfaces:**
+- Consumes: helpers/schemas from Task 2.
+- Produces: `POST /api/leads/{tenant}`, `GET /api/leads/{tenant}?stage=`, `GET /api/leads/{tenant}/{lead_id}`.
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+@respx.mock
+def test_create_lead_manual(client):
+    _stub_auth(respx)
+    route = respx.post("http://localhost:5800/api/entities/t1/lead").mock(
+        return_value=httpx.Response(201, json={
+            "entity_id": "ld1", "base_data": {
+                "guardian_name": "Sam Rivera", "email": "sam@example.com",
+                "source": "manual", "stage": "New"}})
+    )
+    resp = client.post("/api/leads/t1",
+        json={"guardian_name": "Sam Rivera", "email": "sam@example.com"},
+        headers={"Authorization": "Bearer good"})
+    assert resp.status_code == 201
+    sent = route.calls.last.request
+    import json as _j
+    body = _j.loads(sent.content)
+    assert body["base_data"]["source"] == "manual"
+    assert body["base_data"]["stage"] == "New"
+
+
+@respx.mock
+def test_create_lead_requires_contact(client):
+    _stub_auth(respx)
+    resp = client.post("/api/leads/t1", json={"guardian_name": "No Contact"},
+        headers={"Authorization": "Bearer good"})
+    assert resp.status_code == 422
+
+
+@respx.mock
+def test_list_leads_filters_by_stage(client):
+    _stub_auth(respx)
+    route = respx.post("http://localhost:5800/api/query").mock(
+        return_value=httpx.Response(200, json={"data": [{"entity_id": "ld1", "stage": "Toured"}], "total": 1}))
+    resp = client.get("/api/leads/t1?stage=Toured", headers={"Authorization": "Bearer good"})
+    assert resp.status_code == 200
+    import json as _j
+    sql = _j.loads(route.calls.last.request.content)["sql"]
+    assert "entity_type = 'lead'" in sql and "stage = 'Toured'" in sql
+
+
+def test_list_leads_requires_auth(client):
+    resp = client.get("/api/leads/t1")
+    assert resp.status_code == 401
+```
+
+- [ ] **Step 2: Run and confirm failure**
+
+Run: `cd admindash && uv run pytest backend/tests/test_leads.py -k "create_lead or list_leads" -v`
+Expected: FAIL (routes not defined / 404).
+
+- [ ] **Step 3: Implement the routes in `leads.py`**
+
+```python
+@router.post("/leads/{tenant_id}", status_code=201)
+def create_lead(tenant_id: str, body: LeadCreate, user=Depends(require_authenticated_user)):
+    base = body.model_dump(exclude_none=True)
+    base.update({"source": "manual", "stage": "New"})
+    return _dc_create(tenant_id, "lead", base, user["_token"])
+
+
+@router.get("/leads/{tenant_id}")
+def list_leads(tenant_id: str, stage: str | None = None, user=Depends(require_authenticated_user)):
+    where = "entity_type = 'lead' AND _status = 'active'"
+    if stage:
+        if stage not in STAGES:
+            raise HTTPException(400, f"Unknown stage: {stage}")
+        where += f" AND stage = '{stage}'"
+    rows = _dc_query(tenant_id, f"SELECT * FROM data WHERE {where}", user["_token"])
+    return {"leads": rows}
+
+
+@router.get("/leads/{tenant_id}/{lead_id}")
+def get_lead(tenant_id: str, lead_id: str, user=Depends(require_authenticated_user)):
+    lead = _get_lead(tenant_id, lead_id, user["_token"])
+    if not lead:
+        raise HTTPException(404, "Lead not found")
+    return lead
+```
+
+- [ ] **Step 4: Register the router in `main.py`**
+
+Add import and include (mount under `/api` so paths are `/api/leads/...`):
+
+```python
+from app.api import auth, entities, extract, health, leads, query
+...
+app.include_router(leads.router, prefix="/api", tags=["leads"])
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `cd admindash && uv run pytest backend/tests/test_leads.py -k "create_lead or list_leads" -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add admindash/backend/app/api/leads.py admindash/backend/app/main.py admindash/backend/tests/test_leads.py
+git commit -m "feat(admindash): create/list/get lead routes"
+```
+
+---
+
+## Task 4: AdminDash backend — stage transition with auto-logged activity
+
+**Files:**
+- Modify: `admindash/backend/app/api/leads.py`
+- Test: `admindash/backend/tests/test_leads.py`
+
+**Interfaces:**
+- Consumes: `_get_lead`, `_dc_update`, `_dc_create`, `STAGES`.
+- Produces: `PATCH /api/leads/{tenant}/{lead_id}/stage`; internal `_log_stage_change(tenant, lead_id, frm, to, token)`.
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+def _stub_lead(mock, lead_id="ld1", stage="New"):
+    mock.post("http://localhost:5800/api/query").mock(
+        return_value=httpx.Response(200, json={"data": [
+            {"entity_id": lead_id, "guardian_name": "Sam", "email": "s@e.com",
+             "stage": stage, "source": "manual"}], "total": 1}))
+
+
+@respx.mock
+def test_stage_change_updates_and_logs(client):
+    _stub_auth(respx)
+    _stub_lead(respx, stage="New")
+    upd = respx.put("http://localhost:5800/api/entities/t1/lead/ld1").mock(
+        return_value=httpx.Response(200, json={"entity_id": "ld1", "base_data": {"stage": "Contacted"}}))
+    act = respx.post("http://localhost:5800/api/entities/t1/lead_activity").mock(
+        return_value=httpx.Response(201, json={"entity_id": "la1"}))
+    resp = client.patch("/api/leads/t1/ld1/stage", json={"stage": "Contacted"},
+        headers={"Authorization": "Bearer good"})
+    assert resp.status_code == 200
+    assert upd.called and act.called
+    import json as _j
+    act_body = _j.loads(act.calls.last.request.content)["base_data"]
+    assert act_body["type"] == "stage_change"
+    assert act_body["stage_from"] == "New" and act_body["stage_to"] == "Contacted"
+    assert act_body["created_by"] == "system"
+
+
+@respx.mock
+def test_stage_change_same_stage_no_activity(client):
+    _stub_auth(respx)
+    _stub_lead(respx, stage="Contacted")
+    upd = respx.put("http://localhost:5800/api/entities/t1/lead/ld1").mock(
+        return_value=httpx.Response(200, json={"entity_id": "ld1"}))
+    act = respx.post("http://localhost:5800/api/entities/t1/lead_activity").mock(
+        return_value=httpx.Response(201, json={}))
+    resp = client.patch("/api/leads/t1/ld1/stage", json={"stage": "Contacted"},
+        headers={"Authorization": "Bearer good"})
+    assert resp.status_code == 200
+    assert not act.called
+
+
+@respx.mock
+def test_stage_change_rejects_unknown_stage(client):
+    _stub_auth(respx)
+    resp = client.patch("/api/leads/t1/ld1/stage", json={"stage": "Nope"},
+        headers={"Authorization": "Bearer good"})
+    assert resp.status_code == 400
+```
+
+- [ ] **Step 2: Run and confirm failure**
+
+Run: `cd admindash && uv run pytest backend/tests/test_leads.py -k stage_change -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+```python
+def _log_stage_change(tenant: str, lead_id: str, frm: str, to: str, token: str | None):
+    _dc_create(tenant, "lead_activity", {
+        "lead_id": lead_id, "type": "stage_change", "body": f"{frm} → {to}",
+        "stage_from": frm, "stage_to": to, "created_by": "system",
+    }, token)
+
+
+@router.patch("/leads/{tenant_id}/{lead_id}/stage")
+def update_stage(tenant_id: str, lead_id: str, body: StageUpdate,
+                 user=Depends(require_authenticated_user)):
+    if body.stage not in STAGES:
+        raise HTTPException(400, f"Unknown stage: {body.stage}")
+    lead = _get_lead(tenant_id, lead_id, user["_token"])
+    if not lead:
+        raise HTTPException(404, "Lead not found")
+    current = lead.get("stage", "New")
+    base = _lead_base_data(lead)  # helper below: reconstruct base_data for full PUT
+    base["stage"] = body.stage
+    updated = _dc_update(tenant_id, "lead", lead_id, base, user["_token"])
+    if body.stage != current:
+        _log_stage_change(tenant_id, lead_id, current, body.stage, user["_token"])
+    return updated
+```
+
+Add a helper that reconstructs the lead's `base_data` from the flattened query row (drop metadata/system columns) so the full-replace PUT keeps existing fields:
+
+```python
+_LEAD_FIELDS = ["guardian_name", "email", "phone", "student_first_name",
+                "student_last_name", "grade_of_interest", "message", "source",
+                "stage", "lead_id", "converted_family_id"]
+
+
+def _lead_base_data(row: dict) -> dict:
+    return {k: row[k] for k in _LEAD_FIELDS if row.get(k) is not None}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd admindash && uv run pytest backend/tests/test_leads.py -k stage_change -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add admindash/backend/app/api/leads.py admindash/backend/tests/test_leads.py
+git commit -m "feat(admindash): lead stage transitions with auto-logged stage_change"
+```
+
+---
+
+## Task 5: AdminDash backend — activity create + timeline
+
+**Files:**
+- Modify: `admindash/backend/app/api/leads.py`
+- Test: `admindash/backend/tests/test_leads.py`
+
+**Interfaces:**
+- Produces: `POST /api/leads/{tenant}/{lead_id}/activities`, `GET /api/leads/{tenant}/{lead_id}/activities`.
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+@respx.mock
+def test_add_activity(client):
+    _stub_auth(respx)
+    act = respx.post("http://localhost:5800/api/entities/t1/lead_activity").mock(
+        return_value=httpx.Response(201, json={"entity_id": "la1"}))
+    resp = client.post("/api/leads/t1/ld1/activities",
+        json={"type": "call", "body": "Left voicemail"},
+        headers={"Authorization": "Bearer good"})
+    assert resp.status_code == 201
+    import json as _j
+    b = _j.loads(act.calls.last.request.content)["base_data"]
+    assert b["type"] == "call" and b["lead_id"] == "ld1" and b["created_by"] == "u1"
+
+
+@respx.mock
+def test_add_activity_rejects_bad_type(client):
+    _stub_auth(respx)
+    resp = client.post("/api/leads/t1/ld1/activities",
+        json={"type": "carrier_pigeon", "body": "x"},
+        headers={"Authorization": "Bearer good"})
+    assert resp.status_code == 400
+
+
+@respx.mock
+def test_list_activities_desc(client):
+    _stub_auth(respx)
+    route = respx.post("http://localhost:5800/api/query").mock(
+        return_value=httpx.Response(200, json={"data": [{"entity_id": "la2"}, {"entity_id": "la1"}], "total": 2}))
+    resp = client.get("/api/leads/t1/ld1/activities", headers={"Authorization": "Bearer good"})
+    assert resp.status_code == 200
+    import json as _j
+    sql = _j.loads(route.calls.last.request.content)["sql"]
+    assert "lead_activity" in sql and "lead_id = 'ld1'" in sql and "ORDER BY _created_at DESC" in sql
+```
+
+- [ ] **Step 2: Run and confirm failure**
+
+Run: `cd admindash && uv run pytest backend/tests/test_leads.py -k activit -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+```python
+@router.post("/leads/{tenant_id}/{lead_id}/activities", status_code=201)
+def add_activity(tenant_id: str, lead_id: str, body: ActivityCreate,
+                 user=Depends(require_authenticated_user)):
+    if body.type not in ACTIVITY_TYPES:
+        raise HTTPException(400, f"Unknown activity type: {body.type}")
+    return _dc_create(tenant_id, "lead_activity", {
+        "lead_id": lead_id, "type": body.type, "body": body.body,
+        "created_by": user.get("id", "unknown"),
+    }, user["_token"])
+
+
+@router.get("/leads/{tenant_id}/{lead_id}/activities")
+def list_activities(tenant_id: str, lead_id: str, user=Depends(require_authenticated_user)):
+    rows = _dc_query(
+        tenant_id,
+        f"SELECT * FROM data WHERE entity_type = 'lead_activity' "
+        f"AND lead_id = '{lead_id}' AND _status = 'active' ORDER BY _created_at DESC",
+        user["_token"])
+    return {"activities": rows}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd admindash && uv run pytest backend/tests/test_leads.py -k activit -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add admindash/backend/app/api/leads.py admindash/backend/tests/test_leads.py
+git commit -m "feat(admindash): lead activity log create + timeline"
+```
+
+---
+
+## Task 6: AdminDash backend — convert to family
+
+**Files:**
+- Modify: `admindash/backend/app/api/leads.py`
+- Test: `admindash/backend/tests/test_leads.py`
+
+**Interfaces:**
+- Consumes: `_get_lead`, `_dc_create`, `_dc_update`, `_lead_base_data`, `_log_stage_change`, `TERMINAL_STAGES`.
+- Produces: `POST /api/leads/{tenant}/{lead_id}/convert`.
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+@respx.mock
+def test_convert_creates_family_student_and_links(client):
+    _stub_auth(respx)
+    respx.post("http://localhost:5800/api/query").mock(
+        return_value=httpx.Response(200, json={"data": [
+            {"entity_id": "ld1", "guardian_name": "Sam", "email": "s@e.com",
+             "stage": "Toured", "source": "manual"}], "total": 1}))
+    fam = respx.post("http://localhost:5800/api/entities/t1/family").mock(
+        return_value=httpx.Response(201, json={"entity_id": "fam1", "base_data": {"family_id": "F-1"}}))
+    stu = respx.post("http://localhost:5800/api/entities/t1/student").mock(
+        return_value=httpx.Response(201, json={"entity_id": "stu1"}))
+    upd = respx.put("http://localhost:5800/api/entities/t1/lead/ld1").mock(
+        return_value=httpx.Response(200, json={"entity_id": "ld1"}))
+    act = respx.post("http://localhost:5800/api/entities/t1/lead_activity").mock(
+        return_value=httpx.Response(201, json={}))
+    resp = client.post("/api/leads/t1/ld1/convert",
+        json={"family_name": "Rivera Family", "primary_address": "1 Main St",
+              "student_first_name": "Ada", "student_last_name": "Rivera"},
+        headers={"Authorization": "Bearer good"})
+    assert resp.status_code == 201
+    assert fam.called and stu.called and upd.called and act.called
+    import json as _j
+    stu_body = _j.loads(stu.calls.last.request.content)["base_data"]
+    assert stu_body["family_id"] == "fam1" and stu_body["status"] == "Enrolled"
+    lead_body = _j.loads(upd.calls.last.request.content)["base_data"]
+    assert lead_body["converted_family_id"] == "fam1" and lead_body["stage"] == "Enrolled"
+
+
+@respx.mock
+def test_convert_guards_double_conversion(client):
+    _stub_auth(respx)
+    respx.post("http://localhost:5800/api/query").mock(
+        return_value=httpx.Response(200, json={"data": [
+            {"entity_id": "ld1", "guardian_name": "Sam", "email": "s@e.com",
+             "stage": "Enrolled", "converted_family_id": "famX"}], "total": 1}))
+    resp = client.post("/api/leads/t1/ld1/convert",
+        json={"family_name": "X", "primary_address": "Y",
+              "student_first_name": "A", "student_last_name": "B"},
+        headers={"Authorization": "Bearer good"})
+    assert resp.status_code == 409
+    assert "famX" in resp.json()["detail"]
+```
+
+- [ ] **Step 2: Run and confirm failure**
+
+Run: `cd admindash && uv run pytest backend/tests/test_leads.py -k convert -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+```python
+@router.post("/leads/{tenant_id}/{lead_id}/convert", status_code=201)
+def convert_lead(tenant_id: str, lead_id: str, body: ConvertRequest,
+                 user=Depends(require_authenticated_user)):
+    token = user["_token"]
+    lead = _get_lead(tenant_id, lead_id, token)
+    if not lead:
+        raise HTTPException(404, "Lead not found")
+    if lead.get("converted_family_id"):
+        raise HTTPException(409, f"Lead already converted to family {lead['converted_family_id']}")
+
+    family = _dc_create(tenant_id, "family", {
+        "family_name": body.family_name,
+        "primary_address": body.primary_address,
+        "primary_email": body.primary_email or lead.get("email"),
+        "primary_phone": body.primary_phone or lead.get("phone"),
+    }, token)
+    family_id = family["entity_id"]
+
+    student_base = {
+        "first_name": body.student_first_name,
+        "last_name": body.student_last_name,
+        "family_id": family_id,
+        "primary_address": body.primary_address,
+        "status": "Enrolled",
+    }
+    if body.grade_level:
+        student_base["grade_level"] = body.grade_level
+    student = _dc_create(tenant_id, "student", student_base, token)
+
+    base = _lead_base_data(lead)
+    base["converted_family_id"] = family_id
+    prev_stage = base.get("stage", "New")
+    base["stage"] = "Enrolled"
+    _dc_update(tenant_id, "lead", lead_id, base, token)
+    if prev_stage != "Enrolled":
+        _log_stage_change(tenant_id, lead_id, prev_stage, "Enrolled", token)
+
+    return {"family_id": family_id, "student_id": student["entity_id"], "lead_id": lead_id}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd admindash && uv run pytest backend/tests/test_leads.py -k convert -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add admindash/backend/app/api/leads.py admindash/backend/tests/test_leads.py
+git commit -m "feat(admindash): convert lead to family + student with double-convert guard"
+```
+
+---
+
+## Task 7: AdminDash backend — public web-form intake (unauthenticated)
+
+**Files:**
+- Modify: `admindash/backend/app/api/leads.py`
+- Test: `admindash/backend/tests/test_leads.py`
+
+**Interfaces:**
+- Consumes: `_tenant_exists`, `_dc_create`, `PublicLeadCreate`.
+- Produces: `POST /api/public/leads/{tenant}` (no auth).
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+@respx.mock
+def test_public_intake_creates_web_form_lead(client):
+    respx.post("http://localhost:5800/api/query").mock(  # tenant existence check
+        return_value=httpx.Response(200, json={"data": [{"entity_id": "t1"}], "total": 1}))
+    create = respx.post("http://localhost:5800/api/entities/t1/lead").mock(
+        return_value=httpx.Response(201, json={"entity_id": "ld1"}))
+    resp = client.post("/api/public/leads/t1",
+        json={"guardian_name": "Prospect", "email": "p@e.com", "stage": "Enrolled",
+              "converted_family_id": "hack"})  # internal fields must be ignored
+    assert resp.status_code == 201
+    import json as _j
+    b = _j.loads(create.calls.last.request.content)["base_data"]
+    assert b["source"] == "web_form" and b["stage"] == "New"
+    assert "converted_family_id" not in b
+
+
+@respx.mock
+def test_public_intake_unknown_tenant_404(client):
+    respx.post("http://localhost:5800/api/query").mock(
+        return_value=httpx.Response(200, json={"data": [], "total": 0}))
+    resp = client.post("/api/public/leads/ghost",
+        json={"guardian_name": "P", "email": "p@e.com"})
+    assert resp.status_code == 404
+
+
+def test_public_intake_needs_no_jwt(client):
+    # No Authorization header at all — must not 401 on auth (tenant check will run)
+    import respx as _r
+    with _r.mock:
+        _r.post("http://localhost:5800/api/query").mock(
+            return_value=httpx.Response(200, json={"data": [], "total": 0}))
+        resp = client.post("/api/public/leads/t1", json={"guardian_name": "P", "phone": "555"})
+    assert resp.status_code != 401
+```
+
+- [ ] **Step 2: Run and confirm failure**
+
+Run: `cd admindash && uv run pytest backend/tests/test_leads.py -k public_intake -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+```python
+@router.post("/public/leads/{tenant_id}", status_code=201)
+def public_intake(tenant_id: str, body: PublicLeadCreate):
+    if not _tenant_exists(tenant_id):
+        raise HTTPException(404, "Unknown tenant")
+    base = body.model_dump(exclude_none=True)
+    base.update({"source": "web_form", "stage": "New"})  # force; internal fields never in schema
+    return _dc_create(tenant_id, "lead", base, None)
+```
+
+Note: `PublicLeadCreate` has no `stage`/`converted_family_id` fields, so FastAPI ignores them in the payload — the test's injected internal fields are dropped at validation.
+
+- [ ] **Step 4: Run tests + full backend suite**
+
+Run: `cd admindash && uv run pytest backend/tests/test_leads.py -v`
+Expected: PASS.
+Run: `cd admindash && uv run pytest backend/tests/ -q`
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add admindash/backend/app/api/leads.py admindash/backend/tests/test_leads.py
+git commit -m "feat(admindash): public unauthenticated lead intake with field allowlist"
+```
+
+---
+
+## Task 8: Frontend — types, API client, email parser
+
+**Files:**
+- Modify: `admindash/frontend/src/types/models.ts`
+- Modify: `admindash/frontend/src/api/client.ts`
+- Create: `admindash/frontend/src/utils/parseInquiryEmail.ts`
+
+**Interfaces:**
+- Produces: `Lead`, `LeadActivity`, `LEAD_STAGES` types/consts; client fns `listLeads`, `getLead`, `createLead`, `updateLeadStage`, `listActivities`, `addActivity`, `convertLead`, `submitPublicLead`; `parseInquiryEmail`.
+
+- [ ] **Step 1: Add types to `models.ts`**
+
+```typescript
+export const LEAD_STAGES = [
+  'New', 'Contacted', 'Tour Scheduled', 'Toured', 'Enrolled', 'Lost',
+] as const;
+export type LeadStage = (typeof LEAD_STAGES)[number];
+
+export interface Lead {
+  entity_id: string;
+  lead_id?: string;
+  guardian_name: string;
+  email?: string;
+  phone?: string;
+  student_first_name?: string;
+  student_last_name?: string;
+  grade_of_interest?: string;
+  message?: string;
+  source: 'web_form' | 'manual' | 'email_import';
+  stage: LeadStage;
+  converted_family_id?: string;
+  _created_at?: string;
+  _updated_at?: string;
+}
+
+export interface LeadActivity {
+  entity_id: string;
+  lead_id: string;
+  type: 'call' | 'email' | 'note' | 'stage_change';
+  body: string;
+  stage_from?: string;
+  stage_to?: string;
+  created_by: string;
+  _created_at?: string;
+}
+```
+
+- [ ] **Step 2: Add client functions to `client.ts`** (mirror existing fetch+`authHeaders()` style)
+
+```typescript
+import type { Lead, LeadActivity } from '../types/models.ts';
+
+export async function listLeads(tenantId: string, stage?: string): Promise<Lead[]> {
+  const q = stage ? `?stage=${encodeURIComponent(stage)}` : '';
+  const resp = await fetch(`${API_BASE}/api/leads/${tenantId}${q}`, { headers: authHeaders() });
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+  return (await resp.json()).leads as Lead[];
+}
+
+export async function getLead(tenantId: string, leadId: string): Promise<Lead> {
+  const resp = await fetch(`${API_BASE}/api/leads/${tenantId}/${leadId}`, { headers: authHeaders() });
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+  return resp.json();
+}
+
+export async function createLead(tenantId: string, fields: Partial<Lead>): Promise<Lead> {
+  const resp = await fetch(`${API_BASE}/api/leads/${tenantId}`, {
+    method: 'POST', headers: { 'Content-Type': 'application/json', ...authHeaders() },
+    body: JSON.stringify(fields),
+  });
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+  return resp.json();
+}
+
+export async function updateLeadStage(tenantId: string, leadId: string, stage: string): Promise<Lead> {
+  const resp = await fetch(`${API_BASE}/api/leads/${tenantId}/${leadId}/stage`, {
+    method: 'PATCH', headers: { 'Content-Type': 'application/json', ...authHeaders() },
+    body: JSON.stringify({ stage }),
+  });
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+  return resp.json();
+}
+
+export async function listActivities(tenantId: string, leadId: string): Promise<LeadActivity[]> {
+  const resp = await fetch(`${API_BASE}/api/leads/${tenantId}/${leadId}/activities`, { headers: authHeaders() });
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+  return (await resp.json()).activities as LeadActivity[];
+}
+
+export async function addActivity(tenantId: string, leadId: string, type: string, body: string): Promise<LeadActivity> {
+  const resp = await fetch(`${API_BASE}/api/leads/${tenantId}/${leadId}/activities`, {
+    method: 'POST', headers: { 'Content-Type': 'application/json', ...authHeaders() },
+    body: JSON.stringify({ type, body }),
+  });
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+  return resp.json();
+}
+
+export interface ConvertPayload {
+  family_name: string; primary_address: string;
+  primary_email?: string; primary_phone?: string;
+  student_first_name: string; student_last_name: string; grade_level?: string;
+}
+export async function convertLead(tenantId: string, leadId: string, payload: ConvertPayload) {
+  const resp = await fetch(`${API_BASE}/api/leads/${tenantId}/${leadId}/convert`, {
+    method: 'POST', headers: { 'Content-Type': 'application/json', ...authHeaders() },
+    body: JSON.stringify(payload),
+  });
+  if (resp.status === 409) throw new Error(await resp.text());
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+  return resp.json();
+}
+
+// Public intake — NO auth header.
+export async function submitPublicLead(tenantId: string, fields: Partial<Lead>): Promise<void> {
+  const resp = await fetch(`${API_BASE}/api/public/leads/${tenantId}`, {
+    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(fields),
+  });
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+}
+```
+
+- [ ] **Step 3: Create `parseInquiryEmail.ts`**
+
+```typescript
+// Best-effort extraction of lead fields from a pasted inquiry email.
+export interface ParsedInquiry {
+  guardian_name?: string;
+  email?: string;
+  phone?: string;
+  student_first_name?: string;
+  student_last_name?: string;
+  message?: string;
+}
+
+export function parseInquiryEmail(text: string): ParsedInquiry {
+  const out: ParsedInquiry = {};
+  const email = text.match(/[\w.+-]+@[\w-]+\.[\w.-]+/);
+  if (email) out.email = email[0];
+  const phone = text.match(/(\+?\d[\d\s().-]{7,}\d)/);
+  if (phone) out.phone = phone[1].trim();
+  const name = text.match(/(?:my name is|from|regards,|thanks,|sincerely,)\s*([A-Z][a-z]+(?:\s+[A-Z][a-z]+)?)/i);
+  if (name) out.guardian_name = name[1].trim();
+  const student = text.match(/(?:my child|my son|my daughter|student)\s+(?:is\s+)?([A-Z][a-z]+)(?:\s+([A-Z][a-z]+))?/i);
+  if (student) { out.student_first_name = student[1]; if (student[2]) out.student_last_name = student[2]; }
+  out.message = text.trim().slice(0, 2000);
+  return out;
+}
+```
+
+- [ ] **Step 4: Type-check**
+
+Run: `cd admindash/frontend && npx tsc -b`
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add admindash/frontend/src/types/models.ts admindash/frontend/src/api/client.ts admindash/frontend/src/utils/parseInquiryEmail.ts
+git commit -m "feat(admindash): lead types, API client, email parser"
+```
+
+---
+
+## Task 9: Frontend — leads pipeline page + i18n
+
+**Files:**
+- Rewrite: `admindash/frontend/src/pages/LeadPage.tsx`
+- Modify: `admindash/frontend/src/pages/LeadPage.css` (styles for the board)
+- Modify: `admindash/frontend/src/i18n/translations.ts` (add `leads.*` keys under both `en-US` and `zh-CN`)
+
+**Interfaces:**
+- Consumes: `listLeads`, `LEAD_STAGES`, `Lead`; the tenant comes from the auth user (see Step 3 — `LeadPage` must receive `tenant`).
+- Produces: `LeadPage` renders the pipeline and opens the detail view (Task 10) and the create modals (Task 11).
+
+- [ ] **Step 1: Add i18n keys** to `translations.ts` for both locales (keep `lead.title` used by the placeholder; add the rest):
+
+```typescript
+// within 'en-US':
+'leads.title': 'Leads',
+'leads.addManual': 'Add Lead',
+'leads.importEmail': 'Import from Email',
+'leads.filterAll': 'All stages',
+'leads.empty': 'No leads yet',
+'leads.convert': 'Convert to Family',
+'leads.addActivity': 'Add Activity',
+'leads.stage': 'Stage',
+'leads.activityTimeline': 'Activity',
+// within 'zh-CN': provide translations for each of the above keys.
+```
+
+- [ ] **Step 2: Rewrite `LeadPage.tsx`** as a stage-grouped board with a stage filter and buttons that open the create modals + detail view. Accept a `tenant` prop.
+
+```tsx
+import { useEffect, useState, useCallback } from 'react';
+import { useTranslation } from '../hooks/useTranslation.ts';
+import { listLeads } from '../api/client.ts';
+import { LEAD_STAGES, type Lead, type LeadStage } from '../types/models.ts';
+import LeadDetailDrawer from '../components/LeadDetailDrawer.tsx';
+import AddLeadModal from '../components/AddLeadModal.tsx';
+import ImportEmailModal from '../components/ImportEmailModal.tsx';
+import './LeadPage.css';
+
+export default function LeadPage({ tenant }: { tenant: string }) {
+  const { t } = useTranslation();
+  const [leads, setLeads] = useState<Lead[]>([]);
+  const [filter, setFilter] = useState<LeadStage | ''>('');
+  const [selected, setSelected] = useState<Lead | null>(null);
+  const [showAdd, setShowAdd] = useState(false);
+  const [showImport, setShowImport] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try { setLeads(await listLeads(tenant, filter || undefined)); }
+    catch (e) { setError(String(e)); }
+  }, [tenant, filter]);
+
+  useEffect(() => { void load(); }, [load]);
+
+  const byStage = (s: LeadStage) => leads.filter((l) => l.stage === s);
+
+  return (
+    <div className="leads-page">
+      <header className="leads-header">
+        <h1>{t('leads.title')}</h1>
+        <div className="leads-actions">
+          <select value={filter} onChange={(e) => setFilter(e.target.value as LeadStage | '')}>
+            <option value="">{t('leads.filterAll')}</option>
+            {LEAD_STAGES.map((s) => <option key={s} value={s}>{s}</option>)}
+          </select>
+          <button onClick={() => setShowAdd(true)}>{t('leads.addManual')}</button>
+          <button onClick={() => setShowImport(true)}>{t('leads.importEmail')}</button>
+        </div>
+      </header>
+      {error && <p className="error">{error}</p>}
+      {leads.length === 0 && <p>{t('leads.empty')}</p>}
+      <div className="leads-board">
+        {LEAD_STAGES.map((stage) => (
+          <div key={stage} className="leads-column">
+            <h2>{stage} <span>{byStage(stage).length}</span></h2>
+            {byStage(stage).map((l) => (
+              <button key={l.entity_id} className="lead-card" onClick={() => setSelected(l)}>
+                <strong>{l.guardian_name}</strong>
+                <small>{l.student_first_name} {l.student_last_name}</small>
+                <small>{l.email || l.phone}</small>
+              </button>
+            ))}
+          </div>
+        ))}
+      </div>
+      {selected && (
+        <LeadDetailDrawer tenant={tenant} lead={selected}
+          onClose={() => setSelected(null)} onChanged={() => { void load(); }} />
+      )}
+      {showAdd && <AddLeadModal tenant={tenant}
+        onClose={() => setShowAdd(false)} onCreated={() => { setShowAdd(false); void load(); }} />}
+      {showImport && <ImportEmailModal tenant={tenant}
+        onClose={() => setShowImport(false)} onCreated={() => { setShowImport(false); void load(); }} />}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Update `App.tsx`** to pass `tenant` to `LeadPage`:
+
+Change `<Route path="/leads" element={<LeadPage />} />` to `<Route path="/leads" element={<LeadPage tenant={tenant} />} />`.
+
+- [ ] **Step 4: Add board styles** to `LeadPage.css` (horizontal columns, cards) using `ui-tokens` CSS variables. Keep the existing `.placeholder-page` rule or remove if unused.
+
+```css
+.leads-header { display: flex; justify-content: space-between; align-items: center; }
+.leads-actions { display: flex; gap: var(--space-2, 8px); }
+.leads-board { display: flex; gap: var(--space-3, 12px); overflow-x: auto; }
+.leads-column { min-width: 200px; flex: 1; }
+.lead-card { display: flex; flex-direction: column; gap: 2px; width: 100%; text-align: left;
+  padding: var(--space-2, 8px); margin-bottom: var(--space-2, 8px);
+  border: 1px solid var(--color-border, #ddd); border-radius: var(--radius-md, 6px); background: var(--color-surface, #fff); cursor: pointer; }
+```
+
+- [ ] **Step 5: Type-check** (components referenced in Steps 2 are created in Tasks 10–11; expect unresolved-import errors until then — that's acceptable mid-task. Verify no errors in THIS file's own logic by temporarily building after Task 11.)
+
+Run: `cd admindash/frontend && npx tsc -b` (defer green until Task 11; note failures are only the not-yet-created modal/drawer imports).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add admindash/frontend/src/pages/LeadPage.tsx admindash/frontend/src/pages/LeadPage.css admindash/frontend/src/App.tsx admindash/frontend/src/i18n/translations.ts
+git commit -m "feat(admindash): leads pipeline board page + i18n"
+```
+
+---
+
+## Task 10: Frontend — lead detail drawer (stage control, timeline, add activity, convert entry)
+
+**Files:**
+- Create: `admindash/frontend/src/components/LeadDetailDrawer.tsx`
+- Create: `admindash/frontend/src/components/LeadDetailDrawer.css`
+- Create: `admindash/frontend/src/components/ConvertToFamilyModal.tsx`
+
+**Interfaces:**
+- Consumes: `getLead`, `listActivities`, `addActivity`, `updateLeadStage`, `convertLead`, `LEAD_STAGES`, `Lead`, `LeadActivity`.
+- Props: `{ tenant: string; lead: Lead; onClose: () => void; onChanged: () => void }`.
+
+- [ ] **Step 1: Implement `LeadDetailDrawer.tsx`**
+
+```tsx
+import { useEffect, useState, useCallback } from 'react';
+import { useTranslation } from '../hooks/useTranslation.ts';
+import { listActivities, addActivity, updateLeadStage } from '../api/client.ts';
+import { LEAD_STAGES, type Lead, type LeadActivity } from '../types/models.ts';
+import ConvertToFamilyModal from './ConvertToFamilyModal.tsx';
+import './LeadDetailDrawer.css';
+
+const ACTIVITY_TYPES = ['call', 'email', 'note'] as const;
+
+export default function LeadDetailDrawer(
+  { tenant, lead, onClose, onChanged }:
+  { tenant: string; lead: Lead; onClose: () => void; onChanged: () => void },
+) {
+  const { t } = useTranslation();
+  const [activities, setActivities] = useState<LeadActivity[]>([]);
+  const [stage, setStage] = useState(lead.stage);
+  const [actType, setActType] = useState<(typeof ACTIVITY_TYPES)[number]>('note');
+  const [actBody, setActBody] = useState('');
+  const [showConvert, setShowConvert] = useState(false);
+
+  const loadActs = useCallback(async () => {
+    setActivities(await listActivities(tenant, lead.entity_id));
+  }, [tenant, lead.entity_id]);
+  useEffect(() => { void loadActs(); }, [loadActs]);
+
+  async function changeStage(next: string) {
+    setStage(next as Lead['stage']);
+    await updateLeadStage(tenant, lead.entity_id, next);
+    await loadActs();
+    onChanged();
+  }
+
+  async function submitActivity(e: React.FormEvent) {
+    e.preventDefault();
+    if (!actBody.trim()) return;
+    await addActivity(tenant, lead.entity_id, actType, actBody.trim());
+    setActBody('');
+    await loadActs();
+  }
+
+  return (
+    <div className="drawer-backdrop" onClick={onClose}>
+      <aside className="lead-drawer" onClick={(e) => e.stopPropagation()}>
+        <button className="drawer-close" onClick={onClose}>×</button>
+        <h2>{lead.guardian_name}</h2>
+        <p>{lead.email} {lead.phone}</p>
+        <p>{lead.student_first_name} {lead.student_last_name} — {lead.grade_of_interest}</p>
+
+        <label>{t('leads.stage')}
+          <select value={stage} onChange={(e) => void changeStage(e.target.value)}>
+            {LEAD_STAGES.map((s) => <option key={s} value={s}>{s}</option>)}
+          </select>
+        </label>
+
+        <button disabled={!!lead.converted_family_id} onClick={() => setShowConvert(true)}>
+          {lead.converted_family_id ? `Converted → ${lead.converted_family_id}` : t('leads.convert')}
+        </button>
+
+        <form onSubmit={submitActivity} className="activity-form">
+          <select value={actType} onChange={(e) => setActType(e.target.value as typeof actType)}>
+            {ACTIVITY_TYPES.map((ty) => <option key={ty} value={ty}>{ty}</option>)}
+          </select>
+          <input value={actBody} onChange={(e) => setActBody(e.target.value)} placeholder={t('leads.addActivity')} />
+          <button type="submit">+</button>
+        </form>
+
+        <h3>{t('leads.activityTimeline')}</h3>
+        <ul className="activity-list">
+          {activities.map((a) => (
+            <li key={a.entity_id}>
+              <span className={`badge badge-${a.type}`}>{a.type}</span>
+              <span>{a.type === 'stage_change' ? `${a.stage_from} → ${a.stage_to}` : a.body}</span>
+              <small>{a._created_at?.slice(0, 16).replace('T', ' ')}</small>
+            </li>
+          ))}
+        </ul>
+
+        {showConvert && (
+          <ConvertToFamilyModal tenant={tenant} lead={lead}
+            onClose={() => setShowConvert(false)}
+            onConverted={() => { setShowConvert(false); onChanged(); onClose(); }} />
+        )}
+      </aside>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Implement `ConvertToFamilyModal.tsx`** (pre-fill mapping per design D7; collect required `primary_address`)
+
+```tsx
+import { useState } from 'react';
+import { convertLead } from '../api/client.ts';
+import type { Lead } from '../types/models.ts';
+
+export default function ConvertToFamilyModal(
+  { tenant, lead, onClose, onConverted }:
+  { tenant: string; lead: Lead; onClose: () => void; onConverted: () => void },
+) {
+  const [familyName, setFamilyName] = useState(`${lead.guardian_name}`);
+  const [address, setAddress] = useState('');
+  const [firstName, setFirstName] = useState(lead.student_first_name ?? '');
+  const [lastName, setLastName] = useState(lead.student_last_name ?? '');
+  const [grade, setGrade] = useState(lead.grade_of_interest ?? '');
+  const [error, setError] = useState<string | null>(null);
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!address.trim() || !firstName.trim() || !lastName.trim()) {
+      setError('Address and student name are required.'); return;
+    }
+    try {
+      await convertLead(tenant, lead.entity_id, {
+        family_name: familyName, primary_address: address,
+        primary_email: lead.email, primary_phone: lead.phone,
+        student_first_name: firstName, student_last_name: lastName,
+        grade_level: grade || undefined,
+      });
+      onConverted();
+    } catch (err) { setError(String(err)); }
+  }
+
+  return (
+    <div className="modal-backdrop" onClick={onClose}>
+      <form className="modal" onClick={(e) => e.stopPropagation()} onSubmit={submit}>
+        <h3>Convert to Family</h3>
+        {error && <p className="error">{error}</p>}
+        <label>Family name<input value={familyName} onChange={(e) => setFamilyName(e.target.value)} /></label>
+        <label>Primary address*<input value={address} onChange={(e) => setAddress(e.target.value)} /></label>
+        <label>Student first name*<input value={firstName} onChange={(e) => setFirstName(e.target.value)} /></label>
+        <label>Student last name*<input value={lastName} onChange={(e) => setLastName(e.target.value)} /></label>
+        <label>Grade<input value={grade} onChange={(e) => setGrade(e.target.value)} /></label>
+        <div className="modal-actions">
+          <button type="button" onClick={onClose}>Cancel</button>
+          <button type="submit">Convert</button>
+        </div>
+      </form>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Add `LeadDetailDrawer.css`** (backdrop + right-side drawer + simple badge colors, using `ui-tokens` variables). Reuse existing `.modal-backdrop`/`.modal` styles if present in the app's CSS; otherwise define minimal ones here.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add admindash/frontend/src/components/LeadDetailDrawer.tsx admindash/frontend/src/components/LeadDetailDrawer.css admindash/frontend/src/components/ConvertToFamilyModal.tsx
+git commit -m "feat(admindash): lead detail drawer, stage control, timeline, convert modal"
+```
+
+---
+
+## Task 11: Frontend — manual add + email-import modals
+
+**Files:**
+- Create: `admindash/frontend/src/components/AddLeadModal.tsx`
+- Create: `admindash/frontend/src/components/ImportEmailModal.tsx`
+- Create: `admindash/frontend/src/components/LeadModal.css` (shared modal styles if not already present)
+
+**Interfaces:**
+- Consumes: `createLead`, `parseInquiryEmail`.
+- Props (both): `{ tenant: string; onClose: () => void; onCreated: () => void }`.
+
+- [ ] **Step 1: Implement `AddLeadModal.tsx`**
+
+```tsx
+import { useState } from 'react';
+import { createLead } from '../api/client.ts';
+
+export default function AddLeadModal(
+  { tenant, onClose, onCreated }: { tenant: string; onClose: () => void; onCreated: () => void },
+) {
+  const [f, setF] = useState({ guardian_name: '', email: '', phone: '',
+    student_first_name: '', student_last_name: '', grade_of_interest: '', message: '' });
+  const [error, setError] = useState<string | null>(null);
+  const set = (k: string) => (e: React.ChangeEvent<HTMLInputElement>) => setF({ ...f, [k]: e.target.value });
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!f.guardian_name.trim() || (!f.email.trim() && !f.phone.trim())) {
+      setError('Guardian name and at least one contact (email or phone) are required.'); return;
+    }
+    try {
+      const payload = Object.fromEntries(Object.entries(f).filter(([, v]) => v.trim()));
+      await createLead(tenant, payload);
+      onCreated();
+    } catch (err) { setError(String(err)); }
+  }
+
+  return (
+    <div className="modal-backdrop" onClick={onClose}>
+      <form className="modal" onClick={(e) => e.stopPropagation()} onSubmit={submit}>
+        <h3>Add Lead</h3>
+        {error && <p className="error">{error}</p>}
+        <label>Guardian name*<input value={f.guardian_name} onChange={set('guardian_name')} /></label>
+        <label>Email<input value={f.email} onChange={set('email')} /></label>
+        <label>Phone<input value={f.phone} onChange={set('phone')} /></label>
+        <label>Student first name<input value={f.student_first_name} onChange={set('student_first_name')} /></label>
+        <label>Student last name<input value={f.student_last_name} onChange={set('student_last_name')} /></label>
+        <label>Grade of interest<input value={f.grade_of_interest} onChange={set('grade_of_interest')} /></label>
+        <div className="modal-actions">
+          <button type="button" onClick={onClose}>Cancel</button>
+          <button type="submit">Create</button>
+        </div>
+      </form>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Implement `ImportEmailModal.tsx`** (paste → parse → editable review → confirm with `source: 'email_import'`)
+
+```tsx
+import { useState } from 'react';
+import { createLead } from '../api/client.ts';
+import { parseInquiryEmail } from '../utils/parseInquiryEmail.ts';
+
+export default function ImportEmailModal(
+  { tenant, onClose, onCreated }: { tenant: string; onClose: () => void; onCreated: () => void },
+) {
+  const [raw, setRaw] = useState('');
+  const [parsed, setParsed] = useState<Record<string, string> | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  function doParse() {
+    const p = parseInquiryEmail(raw);
+    setParsed({
+      guardian_name: p.guardian_name ?? '', email: p.email ?? '', phone: p.phone ?? '',
+      student_first_name: p.student_first_name ?? '', student_last_name: p.student_last_name ?? '',
+      message: p.message ?? '',
+    });
+  }
+
+  async function confirm(e: React.FormEvent) {
+    e.preventDefault();
+    if (!parsed) return;
+    if (!parsed.guardian_name.trim() || (!parsed.email.trim() && !parsed.phone.trim())) {
+      setError('Guardian name and at least one contact are required.'); return;
+    }
+    try {
+      const payload = Object.fromEntries(Object.entries(parsed).filter(([, v]) => v.trim()));
+      await createLead(tenant, { ...payload, source: 'email_import' });
+      onCreated();
+    } catch (err) { setError(String(err)); }
+  }
+
+  return (
+    <div className="modal-backdrop" onClick={onClose}>
+      <form className="modal" onClick={(e) => e.stopPropagation()} onSubmit={confirm}>
+        <h3>Import from Email</h3>
+        {error && <p className="error">{error}</p>}
+        {!parsed ? (
+          <>
+            <textarea rows={10} value={raw} onChange={(e) => setRaw(e.target.value)}
+              placeholder="Paste the inquiry email here…" />
+            <div className="modal-actions">
+              <button type="button" onClick={onClose}>Cancel</button>
+              <button type="button" onClick={doParse} disabled={!raw.trim()}>Parse</button>
+            </div>
+          </>
+        ) : (
+          <>
+            {Object.keys(parsed).map((k) => (
+              <label key={k}>{k}
+                <input value={parsed[k]} onChange={(e) => setParsed({ ...parsed, [k]: e.target.value })} />
+              </label>
+            ))}
+            <div className="modal-actions">
+              <button type="button" onClick={() => setParsed(null)}>Back</button>
+              <button type="submit">Create Lead</button>
+            </div>
+          </>
+        )}
+      </form>
+    </div>
+  );
+}
+```
+
+Note: `createLead` for email-import passes `source: 'email_import'`, but the backend `create_lead` route forces `source=manual`. To honor the source, extend `LeadCreate` in the backend to accept an optional `source` limited to `manual|email_import` (default `manual`) and use it — update `create_lead`:
+
+```python
+class LeadCreate(BaseModel):
+    ...
+    source: str | None = None  # 'manual' | 'email_import'; validated below
+    ...
+
+# in create_lead:
+src = body.source if body.source in ("manual", "email_import") else "manual"
+base = body.model_dump(exclude_none=True, exclude={"source"})
+base.update({"source": src, "stage": "New"})
+```
+
+Add a backend test asserting `source=email_import` is honored and any other value falls back to `manual`. (Public intake still forces `web_form` and does not expose `source`.)
+
+- [ ] **Step 3: Shared modal CSS** — ensure `.modal-backdrop`, `.modal`, `.modal-actions`, `.error` exist (add `LeadModal.css` imported by the modals if the app has no global equivalent).
+
+- [ ] **Step 4: Full frontend build + lint**
+
+Run: `cd admindash/frontend && npm run build && npm run lint`
+Expected: build + lint pass (all imports from Tasks 9–11 now resolve).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add admindash/frontend/src/components/AddLeadModal.tsx admindash/frontend/src/components/ImportEmailModal.tsx admindash/frontend/src/components/LeadModal.css admindash/backend/app/api/leads.py admindash/backend/tests/test_leads.py
+git commit -m "feat(admindash): manual add + email-import lead modals; honor email_import source"
+```
+
+---
+
+## Task 12: Frontend — public web-form inquiry page + public route
+
+**Files:**
+- Create: `admindash/frontend/src/pages/PublicInquiryPage.tsx`
+- Create: `admindash/frontend/src/pages/PublicInquiryPage.css`
+- Modify: `admindash/frontend/src/App.tsx` (add a public route OUTSIDE the auth guard)
+
+**Interfaces:**
+- Consumes: `submitPublicLead`; reads `:tenantId` from the route.
+
+- [ ] **Step 1: Implement `PublicInquiryPage.tsx`**
+
+```tsx
+import { useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { submitPublicLead } from '../api/client.ts';
+import './PublicInquiryPage.css';
+
+export default function PublicInquiryPage() {
+  const { tenantId = '' } = useParams();
+  const [f, setF] = useState({ guardian_name: '', email: '', phone: '',
+    student_first_name: '', student_last_name: '', grade_of_interest: '', message: '' });
+  const [done, setDone] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const set = (k: string) => (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) =>
+    setF({ ...f, [k]: e.target.value });
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!f.guardian_name.trim() || !f.email.trim()) {
+      setError('Name and email are required.'); return;
+    }
+    try {
+      const payload = Object.fromEntries(Object.entries(f).filter(([, v]) => v.trim()));
+      await submitPublicLead(tenantId, payload);
+      setDone(true);
+    } catch { setError('Sorry, something went wrong. Please try again.'); }
+  }
+
+  if (done) return <div className="inquiry-page"><h1>Thank you!</h1><p>We’ll be in touch soon.</p></div>;
+
+  return (
+    <div className="inquiry-page">
+      <h1>Request Information</h1>
+      {error && <p className="error">{error}</p>}
+      <form onSubmit={submit}>
+        <label>Your name*<input value={f.guardian_name} onChange={set('guardian_name')} /></label>
+        <label>Email*<input value={f.email} onChange={set('email')} /></label>
+        <label>Phone<input value={f.phone} onChange={set('phone')} /></label>
+        <label>Student first name<input value={f.student_first_name} onChange={set('student_first_name')} /></label>
+        <label>Student last name<input value={f.student_last_name} onChange={set('student_last_name')} /></label>
+        <label>Grade of interest<input value={f.grade_of_interest} onChange={set('grade_of_interest')} /></label>
+        <label>Message<textarea value={f.message} onChange={set('message')} /></label>
+        <button type="submit">Submit</button>
+      </form>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Wire the public route in `App.tsx`** — add it as a sibling of `/login`, BEFORE the catch-all auth guard, so it renders without a session:
+
+```tsx
+import PublicInquiryPage from './pages/PublicInquiryPage.tsx';
+// inside the top-level <Routes>, before the path="*" guarded route:
+<Route path="/inquire/:tenantId" element={<PublicInquiryPage />} />
+```
+
+- [ ] **Step 3: Add minimal `PublicInquiryPage.css`** (centered card form using `ui-tokens`).
+
+- [ ] **Step 4: Build + lint**
+
+Run: `cd admindash/frontend && npm run build && npm run lint`
+Expected: pass.
+
+- [ ] **Step 5: Manual check the public route renders unauthenticated**
+
+Run: `cd admindash/frontend && npm run dev` then visit `http://localhost:5600/inquire/<tenant_id>` in a logged-out browser; confirm the form shows (no redirect to /login).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add admindash/frontend/src/pages/PublicInquiryPage.tsx admindash/frontend/src/pages/PublicInquiryPage.css admindash/frontend/src/App.tsx
+git commit -m "feat(admindash): public lead inquiry web form + unauthenticated route"
+```
+
+---
+
+## Task 13: Full verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: DataCore tests**
+
+Run: `cd datacore && uv run python -m pytest tests/ -q`
+Expected: all pass.
+
+- [ ] **Step 2: AdminDash backend tests**
+
+Run: `cd admindash && uv run pytest backend/tests/ -q`
+Expected: all pass.
+
+- [ ] **Step 3: Frontend build + lint**
+
+Run: `cd admindash/frontend && npm run build && npm run lint`
+Expected: both pass, no TypeScript errors.
+
+- [ ] **Step 4: Manual smoke test** (all services up via `./start-services.sh`)
+
+  1. Log into AdminDash, open Leads. Add a lead manually → appears under **New**.
+  2. Import from email: paste a sample inquiry → review parsed fields → create → appears with source `email_import`.
+  3. Open a lead → advance stage New→Contacted→Tour Scheduled; confirm each transition adds a `stage_change` entry to the timeline.
+  4. Add a `call` and a `note` activity; confirm they show newest-first.
+  5. Visit `/inquire/<tenant_id>` logged-out, submit the form; confirm a new **New** lead with source `web_form`.
+  6. Convert a lead to family: fill address + student name → Convert; confirm a Family + Student were created (check Students page) and the lead is now **Enrolled** and links to the family. Re-open convert → confirm it is blocked as already-converted.
+
+- [ ] **Step 5: Final commit (if any smoke fixes were needed)**
+
+```bash
+git add -A && git commit -m "test(admindash): verify leads module end to end"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** intake manual (T3) / public (T7,T12) / email (T8,T11); pipeline entity + stages + list/filter (T1,T3) and transitions (T4); activity log single denormalized type + auto stage_change + timeline (T4,T5); conversion pre-fill + link + mark enrolled + double-convert guard (T6,T10). All capabilities mapped.
+- **Cross-service order:** Task 1 (DataCore) ships first; AdminDash tolerates a missing `lead_id`, so ordering is safe.
+- **Type consistency:** activity from/to stored as flat `stage_from`/`stage_to` (not a nested `metadata` object) — used consistently in backend (T4) and frontend rendering (T10). `Lead.entity_id` is the identifier threaded through all client calls and routes.

--- a/launchpad/backend/app/api/tenants.py
+++ b/launchpad/backend/app/api/tenants.py
@@ -43,6 +43,10 @@ def get_tenant_profile(tenant_id: str, user=Depends(require_role("admin", "staff
     data = {k: v for k, v in row.items()
             if k not in skip_keys and v is not None and not k.startswith("_")}
     data["tenant_id"] = tenant_id
+    # name is immutable post-creation and may be absent/None on the stored
+    # entity; fall back to the JWT's tenant_name so the field is never blank.
+    if not data.get("name"):
+        data["name"] = user["tenant_name"]
     return data
 
 
@@ -158,6 +162,46 @@ def use_default_model(tenant_id: str, user=Depends(require_role("admin"))):
     )
 
     return base_model
+
+
+@router.post("/tenants/{tenant_id}/model/sync-defaults")
+def sync_default_model(tenant_id: str, user=Depends(require_role("admin"))):
+    """Non-destructively add any base_model entities missing from the tenant's
+    current model. Existing entities (and their customizations) are untouched."""
+    if user["tenant_id"] != tenant_id:
+        raise HTTPException(status_code=403, detail="Tenant mismatch")
+    base_model = json.loads(BASE_MODEL_PATH.read_text())
+
+    resp = httpx.post(
+        _datacore_url("/query"),
+        json={
+            "tenant_id": tenant_id,
+            "table": "models",
+            "sql": "SELECT entity_type FROM data WHERE _status = 'active'",
+        },
+    )
+    if resp.status_code != 200:
+        raise HTTPException(status_code=502, detail="Failed to fetch model")
+    existing = {r["entity_type"] for r in resp.json().get("data", [])}
+
+    missing = {et: definition for et, definition in base_model.items()
+               if et not in existing}
+    if not missing:
+        return {"added": []}
+
+    put_resp = httpx.put(
+        _datacore_url(f"/models/{tenant_id}"),
+        json={
+            "model_definition": missing,
+            "source_filename": "base_model.json",
+            "created_by": user["name"],
+        },
+        timeout=30.0,
+    )
+    if put_resp.status_code != 200:
+        raise HTTPException(status_code=502, detail="Failed to sync model")
+
+    return {"added": sorted(missing.keys())}
 
 
 @router.get("/tenants/{tenant_id}/onboarding-status")

--- a/launchpad/backend/app/api/tenants.py
+++ b/launchpad/backend/app/api/tenants.py
@@ -108,6 +108,39 @@ def get_model(tenant_id: str, user=Depends(get_current_user)):
     return json.loads(md) if isinstance(md, str) else md
 
 
+@router.get("/tenants/{tenant_id}/model/entities")
+def get_model_entities(tenant_id: str, user=Depends(get_current_user)):
+    """Return every entity in the tenant's model as {entity_type: {base_fields, custom_fields}}."""
+    if user["tenant_id"] != tenant_id:
+        raise HTTPException(status_code=403, detail="Tenant mismatch")
+    resp = httpx.post(
+        _datacore_url("/query"),
+        json={
+            "tenant_id": tenant_id,
+            "table": "models",
+            "sql": "SELECT * FROM data WHERE _status = 'active'",
+        },
+    )
+    if resp.status_code != 200:
+        raise HTTPException(status_code=502, detail="Failed to fetch model")
+    entities: dict = {}
+    for row in resp.json().get("data", []):
+        et = row.get("entity_type")
+        md = row.get("model_definition")
+        if isinstance(md, str):
+            try:
+                md = json.loads(md)
+            except (ValueError, TypeError):
+                continue
+        if not isinstance(md, dict) or not et:
+            continue
+        entities[et] = {
+            "base_fields": md.get("base_fields", []),
+            "custom_fields": md.get("custom_fields", []),
+        }
+    return {"entities": entities}
+
+
 @router.get("/tenants/{tenant_id}/model/info")
 def get_model_info(tenant_id: str, user=Depends(get_current_user)):
     if user["tenant_id"] != tenant_id:

--- a/launchpad/backend/app/data/base_model.json
+++ b/launchpad/backend/app/data/base_model.json
@@ -81,6 +81,22 @@
     ],
     "custom_fields": []
   },
+  "lead": {
+    "base_fields": [
+      {"name": "lead_id", "type": "str", "required": true},
+      {"name": "guardian_name", "type": "str", "required": true},
+      {"name": "email", "type": "email", "required": false},
+      {"name": "phone", "type": "phone", "required": false},
+      {"name": "student_first_name", "type": "str", "required": false},
+      {"name": "student_last_name", "type": "str", "required": false},
+      {"name": "grade_of_interest", "type": "str", "required": false},
+      {"name": "message", "type": "str", "required": false},
+      {"name": "source", "type": "selection", "required": false, "options": ["web_form", "manual", "email_import"], "multiple": false},
+      {"name": "stage", "type": "selection", "required": false, "options": ["New", "Contacted", "Tour Scheduled", "Toured", "Enrolled", "Lost"], "multiple": false},
+      {"name": "converted_family_id", "type": "str", "required": false}
+    ],
+    "custom_fields": []
+  },
   "attendance": {
     "base_fields": [
       {"name": "attendance_id", "type": "str", "required": true},

--- a/launchpad/backend/tests/test_base_model_lead.py
+++ b/launchpad/backend/tests/test_base_model_lead.py
@@ -1,0 +1,71 @@
+"""Tests for lead entity in base_model.json."""
+import json
+import pathlib
+
+BASE_MODEL_PATH = pathlib.Path(__file__).parent.parent / "app" / "data" / "base_model.json"
+
+
+def load_model():
+    with open(BASE_MODEL_PATH) as f:
+        return json.load(f)
+
+
+def test_lead_entity_exists():
+    model = load_model()
+    assert "lead" in model, "lead entity must exist in base_model.json"
+
+
+def test_lead_has_base_fields_and_custom_fields():
+    model = load_model()
+    lead = model["lead"]
+    assert "base_fields" in lead
+    assert "custom_fields" in lead
+    assert lead["custom_fields"] == []
+
+
+def test_lead_required_fields_present():
+    model = load_model()
+    fields = {f["name"]: f for f in model["lead"]["base_fields"]}
+    assert "lead_id" in fields
+    assert fields["lead_id"]["required"] is True
+    assert "guardian_name" in fields
+    assert fields["guardian_name"]["required"] is True
+
+
+def test_lead_stage_selection_options():
+    model = load_model()
+    fields = {f["name"]: f for f in model["lead"]["base_fields"]}
+    assert "stage" in fields
+    stage = fields["stage"]
+    assert stage["type"] == "selection"
+    assert stage["required"] is False
+    assert stage["options"] == ["New", "Contacted", "Tour Scheduled", "Toured", "Enrolled", "Lost"]
+    assert stage["multiple"] is False
+
+
+def test_lead_source_selection_options():
+    model = load_model()
+    fields = {f["name"]: f for f in model["lead"]["base_fields"]}
+    assert "source" in fields
+    source = fields["source"]
+    assert source["type"] == "selection"
+    assert source["options"] == ["web_form", "manual", "email_import"]
+    assert source["multiple"] is False
+
+
+def test_lead_field_order():
+    model = load_model()
+    names = [f["name"] for f in model["lead"]["base_fields"]]
+    assert names == [
+        "lead_id",
+        "guardian_name",
+        "email",
+        "phone",
+        "student_first_name",
+        "student_last_name",
+        "grade_of_interest",
+        "message",
+        "source",
+        "stage",
+        "converted_family_id",
+    ]

--- a/launchpad/backend/tests/test_tenants_api.py
+++ b/launchpad/backend/tests/test_tenants_api.py
@@ -1,0 +1,140 @@
+"""Tests for tenant profile fallback and non-destructive model sync-defaults.
+
+These mirror the DataCore-facing behaviour by stubbing the httpx calls used
+inside app.api.tenants and overriding the auth dependency so no real JWT /
+DataCore auth round-trip is needed.
+"""
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.api import tenants
+from app.api.auth import get_current_user
+from app.main import app
+
+ADMIN_USER = {
+    "name": "Admin User",
+    "role": "admin",
+    "tenant_id": "t1",
+    "tenant_name": "Sunrise Academy",
+}
+
+
+class FakeResponse:
+    def __init__(self, status_code=200, data=None, json_body=None):
+        self.status_code = status_code
+        self._json = json_body if json_body is not None else {"data": data or []}
+
+    def json(self):
+        return self._json
+
+
+@pytest.fixture
+def client():
+    app.dependency_overrides[get_current_user] = lambda: ADMIN_USER
+    with TestClient(app) as c:
+        # 173.245.48.1 is inside a Cloudflare range so the ingress
+        # allowlist middleware admits the request in tests.
+        c.headers.update({"fly-client-ip": "173.245.48.1"})
+        yield c
+    app.dependency_overrides.clear()
+
+
+# ─── FIX 1: tenant name fallback ─────────────────────────────
+
+
+def test_get_tenant_profile_falls_back_to_tenant_name_when_missing(client, monkeypatch):
+    # Row has no name field at all.
+    def fake_post(url, json=None, **kwargs):
+        return FakeResponse(data=[{"entity_type": "tenant", "abbrev": "SA"}])
+
+    monkeypatch.setattr(tenants.httpx, "post", fake_post)
+
+    resp = client.get("/api/tenants/t1")
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "Sunrise Academy"
+
+
+def test_get_tenant_profile_falls_back_when_name_is_none(client, monkeypatch):
+    def fake_post(url, json=None, **kwargs):
+        return FakeResponse(data=[{"entity_type": "tenant", "name": None, "abbrev": "SA"}])
+
+    monkeypatch.setattr(tenants.httpx, "post", fake_post)
+
+    resp = client.get("/api/tenants/t1")
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "Sunrise Academy"
+
+
+def test_get_tenant_profile_keeps_stored_name(client, monkeypatch):
+    def fake_post(url, json=None, **kwargs):
+        return FakeResponse(data=[{"entity_type": "tenant", "name": "Stored Name", "abbrev": "SN"}])
+
+    monkeypatch.setattr(tenants.httpx, "post", fake_post)
+
+    resp = client.get("/api/tenants/t1")
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "Stored Name"
+
+
+# ─── FIX 2: non-destructive sync-defaults ────────────────────
+
+
+def _base_model_keys():
+    with open(tenants.BASE_MODEL_PATH) as f:
+        return set(json.load(f).keys())
+
+
+def test_sync_defaults_noop_when_all_present(client, monkeypatch):
+    all_keys = _base_model_keys()
+
+    def fake_post(url, json=None, **kwargs):
+        return FakeResponse(data=[{"entity_type": et} for et in all_keys])
+
+    def fake_put(*args, **kwargs):
+        raise AssertionError("PUT must not be called when nothing is missing")
+
+    monkeypatch.setattr(tenants.httpx, "post", fake_post)
+    monkeypatch.setattr(tenants.httpx, "put", fake_put)
+
+    resp = client.post("/api/tenants/t1/model/sync-defaults")
+    assert resp.status_code == 200
+    assert resp.json() == {"added": []}
+
+
+def test_sync_defaults_adds_only_missing_entities(client, monkeypatch):
+    all_keys = _base_model_keys()
+    present = all_keys - {"lead"}
+    put_calls = []
+
+    def fake_post(url, json=None, **kwargs):
+        return FakeResponse(data=[{"entity_type": et} for et in present])
+
+    def fake_put(url, json=None, **kwargs):
+        put_calls.append(json)
+        return FakeResponse(status_code=200)
+
+    monkeypatch.setattr(tenants.httpx, "post", fake_post)
+    monkeypatch.setattr(tenants.httpx, "put", fake_put)
+
+    resp = client.post("/api/tenants/t1/model/sync-defaults")
+    assert resp.status_code == 200
+    assert resp.json()["added"] == ["lead"]
+
+    assert len(put_calls) == 1
+    sent_keys = set(put_calls[0]["model_definition"].keys())
+    assert sent_keys == {"lead"}
+    assert "lead" in sent_keys
+    assert present.isdisjoint(sent_keys)
+    assert put_calls[0]["source_filename"] == "base_model.json"
+
+
+def test_sync_defaults_tenant_mismatch_returns_403(client, monkeypatch):
+    def fake_post(url, json=None, **kwargs):
+        raise AssertionError("should not query DataCore on tenant mismatch")
+
+    monkeypatch.setattr(tenants.httpx, "post", fake_post)
+
+    resp = client.post("/api/tenants/other/model/sync-defaults")
+    assert resp.status_code == 403

--- a/launchpad/frontend/src/api/client.ts
+++ b/launchpad/frontend/src/api/client.ts
@@ -166,6 +166,14 @@ export async function useDefaultModel(tenantId: string): Promise<Record<string, 
   return res.json();
 }
 
+export async function syncDefaultModel(tenantId: string): Promise<{ added: string[] }> {
+  const res = await authFetch(`${BASE_URL}/tenants/${tenantId}/model/sync-defaults`, {
+    method: "POST",
+  });
+  if (!res.ok) throw new Error("Failed to sync default entities");
+  return res.json();
+}
+
 export async function getTenantModelInfo(tenantId: string): Promise<{ model_definition: Record<string, unknown>; version: number; change_id: string; created_at: string; updated_at: string } | null> {
   const res = await authFetch(`${BASE_URL}/tenants/${tenantId}/model/info`);
   if (!res.ok) throw new Error("Failed to fetch model info");

--- a/launchpad/frontend/src/api/client.ts
+++ b/launchpad/frontend/src/api/client.ts
@@ -174,6 +174,13 @@ export async function syncDefaultModel(tenantId: string): Promise<{ added: strin
   return res.json();
 }
 
+export async function getTenantModelEntities(tenantId: string): Promise<Record<string, { base_fields: { name: string }[]; custom_fields: { name: string }[] }>> {
+  const res = await authFetch(`${BASE_URL}/tenants/${tenantId}/model/entities`);
+  if (!res.ok) throw new Error("Failed to fetch model entities");
+  const data = await res.json();
+  return (data && data.entities) || {};
+}
+
 export async function getTenantModelInfo(tenantId: string): Promise<{ model_definition: Record<string, unknown>; version: number; change_id: string; created_at: string; updated_at: string } | null> {
   const res = await authFetch(`${BASE_URL}/tenants/${tenantId}/model/info`);
   if (!res.ok) throw new Error("Failed to fetch model info");

--- a/launchpad/frontend/src/pages/TenantSettingsPage.tsx
+++ b/launchpad/frontend/src/pages/TenantSettingsPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import type { User, EntityModelDefinition } from "../types/models";
-import { getTenantModel, getTenantProfile, updateTenantProfile, getTenantModelInfo, getExchangeCode, syncDefaultModel } from "../api/client";
+import { getTenantModel, getTenantProfile, updateTenantProfile, getTenantModelInfo, getTenantModelEntities, getExchangeCode, syncDefaultModel } from "../api/client";
 import { PAPERMITE_FRONTEND_URL } from "../config";
 import DynamicEntityForm from "../components/DynamicEntityForm";
 
@@ -30,9 +30,9 @@ export default function TenantSettingsPage({ user }: Props) {
     getTenantModelInfo(user.tenant_id).then(info => {
       if (info) {
         setModelInfo({ version: info.version, change_id: info.change_id, created_at: info.created_at, updated_at: info.updated_at });
-        setModelDefinition(info.model_definition as ModelDefinition);
       }
     }).catch(() => {});
+    getTenantModelEntities(user.tenant_id).then(setModelDefinition).catch(() => {});
   }, [user.tenant_id]);
 
   const handleEditModel = async () => {
@@ -49,8 +49,8 @@ export default function TenantSettingsPage({ user }: Props) {
       const info = await getTenantModelInfo(user.tenant_id);
       if (info) {
         setModelInfo({ version: info.version, change_id: info.change_id, created_at: info.created_at, updated_at: info.updated_at });
-        setModelDefinition(info.model_definition as ModelDefinition);
       }
+      setModelDefinition(await getTenantModelEntities(user.tenant_id));
       setSyncMessage(added.length ? `Added: ${added.join(", ")}` : "Model already up to date.");
     } catch {
       setSyncMessage("Failed to sync default entities.");
@@ -111,14 +111,16 @@ export default function TenantSettingsPage({ user }: Props) {
             <span style={{ color: "var(--text-secondary)" }}>Updated</span>
             <span style={{ color: "var(--text-primary)" }}>{new Date(modelInfo.updated_at).toLocaleString()}</span>
           </div>
-          {modelDefinition && (
+          {modelDefinition && Object.keys(modelDefinition).length > 0 && (
             <div style={{ marginTop: 20 }}>
               <span style={{ color: "var(--text-secondary)", fontSize: 14 }}>Entities</span>
               <div style={{ display: "flex", flexDirection: "column", gap: 8, marginTop: 8 }}>
                 {Object.keys(modelDefinition).sort().map(entityType => {
-                  const entity = modelDefinition[entityType];
-                  const fieldCount = entity.base_fields.length + entity.custom_fields.length;
-                  const fieldNames = [...entity.base_fields, ...entity.custom_fields].map(f => f.name).join(", ");
+                  const entity = modelDefinition[entityType] || { base_fields: [], custom_fields: [] };
+                  const base = entity.base_fields || [];
+                  const custom = entity.custom_fields || [];
+                  const fieldCount = base.length + custom.length;
+                  const fieldNames = [...base, ...custom].map(f => f.name).join(", ");
                   return (
                     <div key={entityType} style={{ padding: "10px 12px", background: "var(--bg-tertiary)", borderRadius: "var(--radius-md)" }}>
                       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", gap: 12 }}>

--- a/launchpad/frontend/src/pages/TenantSettingsPage.tsx
+++ b/launchpad/frontend/src/pages/TenantSettingsPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import type { User, EntityModelDefinition } from "../types/models";
-import { getTenantModel, getTenantProfile, updateTenantProfile, getTenantModelInfo, getExchangeCode } from "../api/client";
+import { getTenantModel, getTenantProfile, updateTenantProfile, getTenantModelInfo, getExchangeCode, syncDefaultModel } from "../api/client";
 import { PAPERMITE_FRONTEND_URL } from "../config";
 import DynamicEntityForm from "../components/DynamicEntityForm";
 
@@ -10,19 +10,28 @@ const btnPrimary: React.CSSProperties = { padding: "8px 16px", fontSize: 14, bac
 const btnSecondary: React.CSSProperties = { padding: "8px 16px", fontSize: 14, background: "var(--bg-secondary)", border: "1px solid var(--border-primary)", borderRadius: "var(--radius-md)", cursor: "pointer", fontFamily: "var(--font-sans)" };
 const card: React.CSSProperties = { background: "var(--bg-card)", border: "1px solid var(--border-primary)", borderRadius: "var(--radius-lg)", padding: 32, boxShadow: "var(--shadow-card)", maxWidth: 600 };
 
+type ModelEntity = { base_fields: { name: string }[]; custom_fields: { name: string }[] };
+type ModelDefinition = Record<string, ModelEntity>;
+
 export default function TenantSettingsPage({ user }: Props) {
   const [model, setModel] = useState<EntityModelDefinition | null>(null);
   const [data, setData] = useState<Record<string, unknown>>({});
   const [modelInfo, setModelInfo] = useState<{ version: number; change_id: string; created_at: string; updated_at: string } | null>(null);
+  const [modelDefinition, setModelDefinition] = useState<ModelDefinition | null>(null);
   const [saved, setSaved] = useState(false);
   const [editing, setEditing] = useState(false);
+  const [syncing, setSyncing] = useState(false);
+  const [syncMessage, setSyncMessage] = useState<string | null>(null);
   const isAdmin = user.role === "admin";
 
   useEffect(() => {
     getTenantModel(user.tenant_id).then(setModel);
     getTenantProfile(user.tenant_id).then(setData);
     getTenantModelInfo(user.tenant_id).then(info => {
-      if (info) setModelInfo({ version: info.version, change_id: info.change_id, created_at: info.created_at, updated_at: info.updated_at });
+      if (info) {
+        setModelInfo({ version: info.version, change_id: info.change_id, created_at: info.created_at, updated_at: info.updated_at });
+        setModelDefinition(info.model_definition as ModelDefinition);
+      }
     }).catch(() => {});
   }, [user.tenant_id]);
 
@@ -30,6 +39,24 @@ export default function TenantSettingsPage({ user }: Props) {
     const code = await getExchangeCode();
     const returnUrl = `${window.location.origin}/settings/tenant`;
     window.location.href = `${PAPERMITE_FRONTEND_URL}/?tenant_id=${user.tenant_id}&code=${encodeURIComponent(code)}&return_url=${encodeURIComponent(returnUrl)}`;
+  };
+
+  const handleSyncDefaults = async () => {
+    setSyncing(true);
+    setSyncMessage(null);
+    try {
+      const { added } = await syncDefaultModel(user.tenant_id);
+      const info = await getTenantModelInfo(user.tenant_id);
+      if (info) {
+        setModelInfo({ version: info.version, change_id: info.change_id, created_at: info.created_at, updated_at: info.updated_at });
+        setModelDefinition(info.model_definition as ModelDefinition);
+      }
+      setSyncMessage(added.length ? `Added: ${added.join(", ")}` : "Model already up to date.");
+    } catch {
+      setSyncMessage("Failed to sync default entities.");
+    } finally {
+      setSyncing(false);
+    }
   };
 
   if (!model) return <p>Loading...</p>;
@@ -84,11 +111,36 @@ export default function TenantSettingsPage({ user }: Props) {
             <span style={{ color: "var(--text-secondary)" }}>Updated</span>
             <span style={{ color: "var(--text-primary)" }}>{new Date(modelInfo.updated_at).toLocaleString()}</span>
           </div>
+          {modelDefinition && (
+            <div style={{ marginTop: 20 }}>
+              <span style={{ color: "var(--text-secondary)", fontSize: 14 }}>Entities</span>
+              <div style={{ display: "flex", flexDirection: "column", gap: 8, marginTop: 8 }}>
+                {Object.keys(modelDefinition).sort().map(entityType => {
+                  const entity = modelDefinition[entityType];
+                  const fieldCount = entity.base_fields.length + entity.custom_fields.length;
+                  const fieldNames = [...entity.base_fields, ...entity.custom_fields].map(f => f.name).join(", ");
+                  return (
+                    <div key={entityType} style={{ padding: "10px 12px", background: "var(--bg-tertiary)", borderRadius: "var(--radius-md)" }}>
+                      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", gap: 12 }}>
+                        <span style={{ color: "var(--text-primary)", fontWeight: 600, fontSize: 14 }}>{entityType}</span>
+                        <span style={{ color: "var(--text-secondary)", fontSize: 13 }}>{fieldCount} fields</span>
+                      </div>
+                      {fieldNames && <div style={{ color: "var(--text-secondary)", fontSize: 12, marginTop: 4 }}>{fieldNames}</div>}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
           {isAdmin && (
-            <div style={{ display: "flex", justifyContent: "flex-end", marginTop: 16 }}>
+            <div style={{ display: "flex", justifyContent: "flex-end", gap: 8, marginTop: 16 }}>
+              <button onClick={handleSyncDefaults} disabled={syncing} style={{ ...btnSecondary, opacity: syncing ? 0.6 : 1, cursor: syncing ? "default" : "pointer" }}>
+                {syncing ? "Syncing…" : "Sync default entities"}
+              </button>
               <button onClick={handleEditModel} style={btnPrimary}>Edit Model</button>
             </div>
           )}
+          {syncMessage && <p style={{ color: "var(--text-secondary)", marginTop: 12, fontSize: 14 }}>{syncMessage}</p>}
         </div>
       )}
     </div>

--- a/openspec/changes/admindash-leads-model-driven/.openspec.yaml
+++ b/openspec/changes/admindash-leads-model-driven/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-21

--- a/openspec/changes/admindash-leads-model-driven/design.md
+++ b/openspec/changes/admindash-leads-model-driven/design.md
@@ -1,0 +1,54 @@
+## Context
+
+Leads were built (unreleased, on `feat/admindash-leads-module`, PR #89) with a **fixed** schema and a **hard-coded** six-stage pipeline. Every other core entity is customer-definable through one shared mechanism: a per-tenant **model definition** (`{entity_type: {base_fields, custom_fields}}`) stored in DataCore, seeded from LaunchPad's `base_model.json` via `POST /tenants/{id}/model/use-default`, and editable in Papermite's extraction **review UI** (rename fields, change types, edit `selection` options, mark required). Selection fields with ordered `options` already model ordered enums (e.g. `student.status`, `program.status`, `enrollment.status`). AdminDash already renders model-driven pages (StudentsPage) via `ModelContext.getModel` + `DynamicForm` + `StatusBadge`.
+
+This change brings leads onto that same mechanism. The two customer-shaped concepts — **stages** and **capture fields** — map cleanly onto an existing construct: stages are the `options` of a `selection` field named `stage`; fields are the model's `base_fields`/`custom_fields`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- `lead` is a seeded, versioned, customer-definable model; today's fields + stages are the default.
+- Defining/reordering **stages** = editing the `stage` field's `options`, through the same LaunchPad/Papermite flow — no new schema or bespoke pipeline editor.
+- AdminDash (management UI **and** public form) derives stages, fields, board, forms, and stage control from the tenant's lead model; changing the model changes the UI.
+- Backward-compatible: no lead model yet ⇒ fall back to today's defaults.
+
+**Non-Goals:**
+- No new field-editor UI — reuse Papermite's review editor and LaunchPad use-default.
+- `lead_activity` is NOT modelled/configurable (transactional log).
+- No per-stage automation/rules, WIP limits, or stage-entry hooks.
+- No migration of existing leads' stage values if a tenant renames stages (documented as a risk).
+
+## Decisions
+
+### D1 — Stages = `options` of a `selection` field named `stage`; `source` also a selection field
+The lead model's `stage` field is `{type: "selection", options: [...ordered stages...]}`. The pipeline order is the option order. `source` becomes `{type: "selection", options: ["web_form","manual","email_import"]}`. This reuses the exact construct behind `student.status`, so the existing review editor already edits it and `DynamicForm`/`StatusBadge` already render it.
+- **Alternative:** a new first-class `stages`/`pipeline` attribute on the model definition. Rejected — needs schema, storage, editor, and API changes across DataCore/Papermite/LaunchPad for no gain over an ordered selection field.
+- **Reserved name:** AdminDash treats the `selection` field literally named `stage` as the pipeline driver.
+
+### D2 — Seed `lead` in `base_model.json`; add `Lead` to Papermite domain
+Add a `lead` entity to `base_model.json` (default fields below), so `use-default` seeds it with the rest. Add a `Lead` Pydantic model to `papermite/backend/app/models/domain.py` and its `ENTITY_CLASSES` so leads surface in the review editor for customization (same as student/program). `lead_activity` is deliberately excluded from the model.
+- Default lead `base_fields`: `lead_id`(str), `guardian_name`(str, required), `email`(email), `phone`(phone), `student_first_name`(str), `student_last_name`(str), `grade_of_interest`(str), `message`(str), `source`(selection: web_form/manual/email_import), `stage`(selection: New/Contacted/Tour Scheduled/Toured/Enrolled/Lost), `converted_family_id`(str); `custom_fields: []`.
+
+### D3 — AdminDash reads stages/fields from the tenant lead model, with fallback
+Frontend: `getModel(tenant, 'lead')`; derive the pipeline from the `stage` field's `options`, build the board columns and the stage dropdown from them, and render add/edit forms with `DynamicForm(model)`. Backend: fetch the lead model (DataCore `models` query) to get valid `stage` options for validation. Both fall back to the current hard-coded defaults (`DEFAULT_STAGES`, default field list) when no `lead` model exists — preserves behavior during rollout and in tests.
+
+### D4 — Dynamic base_data reconstruction on update (preserve custom fields)
+The stage/convert read-modify-write currently rebuilds `base_data` from a hard-coded `_LEAD_FIELDS` allowlist, which would **drop** customer-added fields. Change `_lead_base_data` to preserve every non-system column from the fetched row (exclude `entity_id`, `_*` metadata, and flattened custom columns handled separately) — i.e. reconstruct from the model's fields, or simply carry all non-underscore keys. This keeps custom fields intact across stage changes and conversion.
+
+### D5 — Convert-to-Family: admin picks the target stage (default = last stage)
+`convert` gains an optional `target_stage`. It creates Family → Student → links `converted_family_id`, then moves the lead to `target_stage` (validated against the model's stage options); if omitted, defaults to the **last** stage in the pipeline. Still guards double-conversion (409). Removes the hard-coded `Enrolled`. The convert dialog shows a stage `<select>` (from the model) defaulting to the last stage.
+- **Alternatives considered:** never change stage (loses the "won" signal); always jump to last stage (wrong when the last stage is "Lost"). Admin-pick with a sensible default is the most robust for arbitrary pipelines.
+
+### D6 — Model-driven capture forms; required-ness from the model
+`AddLeadModal` and the edit form render via `DynamicForm(leadModel)`, emitting `base_data`/`custom_fields`. The previous bespoke "guardian name + (email or phone)" rule is replaced by the model's `required` flags (`guardian_name` required by default). The public inquiry form renders the model's **prospect** fields — base fields excluding the reserved internal ones (`stage`, `source`, `converted_family_id`, `lead_id`) — fetched via an unauthenticated `models` query (DataCore models have no auth, like entities). Email-import maps parsed values onto model field names by name; unknown parsed keys are ignored.
+
+### D7 — Board card + graceful degradation
+The board groups leads by their `stage` value in model order. Each card shows whatever of the conventional fields exist (`guardian_name`, student name, email/phone); if a customer removes/renames them, the card shows the available fields without erroring. Leads whose stored `stage` is not in the current options (e.g. after a rename) render in an "Other"/uncategorized column so they are never hidden.
+
+## Risks / Trade-offs
+
+- **Renamed/removed stages orphan existing leads' values** → Mitigation: render unknown stage values in an "Other" column (never hidden); document that renaming stages doesn't migrate existing rows. No automatic data migration in this change.
+- **Reserved field name `stage`** → if a customer deletes the `stage` field, the pipeline can't function → Mitigation: fall back to `DEFAULT_STAGES` and surface a single, non-fatal notice; keep `stage` in the seeded default and treat it as required-by-convention in docs.
+- **Public form fetches model unauthenticated** → only the field *shape* (names/types/options) is exposed, no tenant data; consistent with DataCore's existing no-auth models/entities. Still guard the reserved internal fields server-side on public intake (already enforced) regardless of model.
+- **Backend model fetch per request** adds a DataCore round-trip to stage/convert/validation → Mitigation: fetch once per request; acceptable at current scale (a short-TTL cache is a follow-up).
+- **BREAKING vs unreleased behavior:** convert no longer auto-sets `Enrolled`; the email-or-phone rule is dropped. Both are on the unmerged branch, so no production impact; update the existing leads tests accordingly.

--- a/openspec/changes/admindash-leads-model-driven/proposal.md
+++ b/openspec/changes/admindash-leads-model-driven/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+The leads module currently hard-codes its pipeline stages (`New → … → Lost`) and its capture fields in AdminDash. Every other core entity — tenant, student, program, application/enrollment — is **customer-definable** through the LaunchPad onboarding flow (seed the default model, or edit fields and selection options in Papermite's review UI). Leads should work the same way: a school should be able to define its own pipeline stages and its own lead-capture fields during onboarding, and AdminDash should adapt to whatever they choose. The two things schools most need to shape about leads are exactly **the stages** and **the fields that capture lead info**.
+
+## What Changes
+
+- **Seed `lead` into the default model** (`base_model.json`) so it is defined and versioned like every other entity. The current fields and the current six stages become the **default** — a school that changes nothing keeps today's behavior.
+- **Represent pipeline stages as the `options` of a `selection` field named `stage`** (mirroring `student.status` / `program.status`). Defining/reordering stages is then just editing that field's options — no new schema. `source` likewise becomes a `selection` field. This makes stages first-class and customer-definable through the existing field/options editor.
+- **Make `lead` editable through the same onboarding path** as other entities: add a `Lead` domain model to Papermite so it appears in the extraction **review/edit UI** (add/remove fields, edit `stage` options, mark required), and is seeded by LaunchPad's "use default model".
+- **Make AdminDash leads model-driven:** the backend validates stages against the tenant's lead model (not a constant) and preserves all model fields (including custom ones) on update; the frontend derives the pipeline board, the stage dropdown, and the add/edit forms from the tenant's lead model. If the model defines new stages or new fields, the UI reflects them.
+- **Convert-to-Family no longer forces a hard-coded "Enrolled" stage** (that stage may not exist in a custom pipeline): convert still creates + links Family/Student and guards double-conversion, and the convert dialog lets the admin **pick the target stage** (defaulting to the pipeline's last stage), validated against the tenant's stage options. **BREAKING** relative to the just-built (unreleased) behavior that auto-set `Enrolled`.
+- **Graceful fallback:** if a tenant has no `lead` model yet, AdminDash falls back to today's default fields/stages, so nothing breaks during rollout.
+
+## Capabilities
+
+### New Capabilities
+- `lead-model-definition`: `lead` as a seeded, versioned, customer-definable model — default fields + `stage`/`source` as selection fields; editable via LaunchPad use-default and Papermite review; `lead_activity` remains a non-configurable transactional log.
+- `lead-model-driven-ui`: AdminDash derives the pipeline stages, capture fields, board, forms, and stage control from the tenant's lead model, with a safe fallback to defaults.
+
+### Modified Capabilities
+<!-- The base leads specs (lead-pipeline/lead-intake/lead-conversion) live in the unarchived
+     admindash-leads-module change, so their model-driven revisions are folded into the two
+     new capabilities above rather than expressed as delta specs against main. The behavioral
+     changes covered there: pipeline stages come from the model's `stage` options; capture
+     forms and required-ness come from the model; conversion no longer forces `Enrolled` and
+     instead moves to an admin-selected target stage (default = last). -->
+
+
+## Impact
+
+- **LaunchPad** (`launchpad/backend/app/data/base_model.json`): add the `lead` entity (default fields + `stage`/`source` selection fields). No flow changes — `use-default` already PUTs the whole model.
+- **Papermite** (`papermite/backend/app/models/domain.py` + `ENTITY_CLASSES`): add a `Lead` domain model so leads surface in the extraction/review editor for field + stage-option customization.
+- **AdminDash backend** (`admindash/backend/app/api/leads.py`): read the tenant's lead `stage` options from the model for validation; make the read-modify-write base_data reconstruction dynamic (preserve all/custom fields); drop the forced `Enrolled` on convert.
+- **AdminDash frontend**: `LeadPage` board, `LeadDetailDrawer` stage control, and `AddLeadModal`/edit become model-driven (via `getModel('lead')` + `DynamicForm`); `Lead`/`LEAD_STAGES` fixed types relax to model-driven; public inquiry form renders the model's prospect fields (excluding internal `stage`/`source`/`lead_id`/`converted_family_id`).
+- **DataCore**: no change — models + `lead` abbreviation already supported.

--- a/openspec/changes/admindash-leads-model-driven/specs/lead-model-definition/spec.md
+++ b/openspec/changes/admindash-leads-model-driven/specs/lead-model-definition/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: Lead is a seeded, customer-definable model
+
+The system SHALL define `lead` as a per-tenant model entity in the default model (`base_model.json`), seeded by the same "use default model" onboarding path as tenant/student/program. The default lead model SHALL contain the current lead capture fields as `base_fields` and an empty `custom_fields` list. A tenant that makes no changes SHALL retain today's fields and stages.
+
+#### Scenario: Use-default seeds the lead model
+
+- **WHEN** a tenant runs the onboarding "use default model" action
+- **THEN** the persisted model definition SHALL include a `lead` entity with the default base fields
+- **AND** the lead `stage` field SHALL be a `selection` field whose options are `New, Contacted, Tour Scheduled, Toured, Enrolled, Lost` in that order
+
+#### Scenario: Unchanged model preserves current behavior
+
+- **WHEN** a tenant does not customize the lead model
+- **THEN** the effective lead fields and stages SHALL equal the current defaults
+
+### Requirement: Stages are the options of the `stage` selection field
+
+The system SHALL represent the lead pipeline stages as the ordered `options` of a `selection` field named `stage` in the lead model. The order of the options SHALL define the pipeline order. The system SHALL NOT introduce a separate pipeline/stages schema.
+
+#### Scenario: Editing stage options redefines the pipeline
+
+- **WHEN** a customer edits the `stage` field's options (add, remove, reorder) through the model-definition editor
+- **THEN** the tenant's lead pipeline SHALL consist of exactly those options in that order
+
+#### Scenario: Source is a selection field
+
+- **WHEN** the lead model is seeded
+- **THEN** `source` SHALL be a `selection` field with options `web_form, manual, email_import`
+
+### Requirement: Lead is editable through the existing model-definition flow
+
+The system SHALL make the `lead` entity available in the Papermite extraction review/edit UI (add/remove fields, change types, edit selection options, mark required), the same way student/program are, by registering a `Lead` domain model. The system SHALL NOT require a new bespoke editor for lead fields or stages.
+
+#### Scenario: Lead appears in the review editor
+
+- **WHEN** a customer defines their model through Papermite's review flow and the extraction includes a lead entity
+- **THEN** the lead entity SHALL be editable there (fields and `stage`/`source` options) like other entities
+
+### Requirement: Lead activity log is not modelled
+
+The system SHALL keep `lead_activity` as a non-configurable transactional log — it SHALL NOT appear in the model definition or the model-definition editor.
+
+#### Scenario: Activity log excluded from model
+
+- **WHEN** the default model is seeded
+- **THEN** no `lead_activity` entity SHALL be present in the model definition

--- a/openspec/changes/admindash-leads-model-driven/specs/lead-model-driven-ui/spec.md
+++ b/openspec/changes/admindash-leads-model-driven/specs/lead-model-driven-ui/spec.md
@@ -1,0 +1,92 @@
+## ADDED Requirements
+
+### Requirement: Pipeline board and stage control derive from the model
+
+The system SHALL build the AdminDash leads pipeline board and the lead detail stage control from the tenant lead model's `stage` field options, in option order. It SHALL NOT use a hard-coded stage list when a lead model exists.
+
+#### Scenario: Board reflects custom stages
+
+- **WHEN** a tenant's lead model defines stages `Inquiry, Visit, Applied, Won, Withdrawn`
+- **THEN** the pipeline board SHALL show exactly those five columns in that order
+- **AND** the lead detail stage dropdown SHALL offer exactly those options
+
+#### Scenario: Leads with an unknown stage are still shown
+
+- **WHEN** a lead's stored `stage` value is not among the current model options (e.g. after a rename)
+- **THEN** the board SHALL display that lead in an "Other"/uncategorized column rather than hiding it
+
+### Requirement: Capture and edit forms derive from the model
+
+The system SHALL render the manual add-lead form and the lead edit form from the tenant lead model (all base and custom fields), using the shared dynamic form. Field requiredness SHALL come from the model's `required` flags. The system SHALL persist values as `base_data`/`custom_fields` accordingly.
+
+#### Scenario: Custom field appears in the form
+
+- **WHEN** a tenant adds a custom lead field `referral_source`
+- **THEN** the add-lead and edit forms SHALL include an input for `referral_source`
+- **AND** submitting it SHALL persist it on the lead
+
+#### Scenario: Requiredness comes from the model
+
+- **WHEN** the model marks `guardian_name` required and `email` optional
+- **THEN** the form SHALL block submit without `guardian_name` and SHALL allow submit without `email`
+
+### Requirement: Custom fields survive stage and conversion updates
+
+The system SHALL preserve all model fields (including customer-added fields) when it performs a read-modify-write update to a lead (stage change, conversion). It SHALL NOT drop fields that are outside a fixed built-in field list.
+
+#### Scenario: Stage change keeps custom fields
+
+- **WHEN** a lead with a custom field `referral_source = "Friend"` has its stage changed
+- **THEN** after the update the lead SHALL still have `referral_source = "Friend"`
+
+### Requirement: Stage validation uses the model
+
+The system SHALL validate a requested lead stage against the tenant lead model's `stage` options (not a hard-coded constant). A stage not among the model options SHALL be rejected.
+
+#### Scenario: Reject unknown stage
+
+- **WHEN** an admin attempts to move a lead to a stage that is not in the tenant's `stage` options
+- **THEN** the system SHALL reject the request with a validation error
+
+#### Scenario: Accept a customer-defined stage
+
+- **WHEN** the tenant's stages include `Won` and an admin moves a lead to `Won`
+- **THEN** the system SHALL accept it and record a `stage_change` activity from the previous stage to `Won`
+
+### Requirement: Convert-to-Family moves to an admin-selected stage
+
+The system SHALL let the admin choose the target stage during Convert-to-Family, defaulting to the last stage in the pipeline, validated against the model. Conversion SHALL create and link Family/Student and guard against double-conversion, and SHALL NOT assume a hard-coded `Enrolled` stage.
+
+#### Scenario: Convert to a chosen stage
+
+- **WHEN** an admin converts a lead and selects target stage `Won`
+- **THEN** the lead SHALL be linked to the created family and moved to `Won` with a `stage_change` activity
+
+#### Scenario: Convert defaults to the last stage
+
+- **WHEN** an admin converts a lead without choosing a stage
+- **THEN** the lead SHALL be moved to the last stage in the tenant's pipeline
+
+#### Scenario: Double-conversion still guarded
+
+- **WHEN** an admin converts a lead that already has a `converted_family_id`
+- **THEN** the system SHALL reject it and SHALL NOT create a duplicate family
+
+### Requirement: Public inquiry form derives from the model
+
+The system SHALL render the public inquiry web form from the tenant lead model's prospect fields — the base fields excluding the reserved internal fields `stage`, `source`, `converted_family_id`, and `lead_id`. It SHALL fetch the model without authentication and SHALL continue to force `source = web_form` and a default stage server-side regardless of the model.
+
+#### Scenario: Public form shows a custom prospect field
+
+- **WHEN** a tenant adds a custom lead field `hear_about_us` and a prospect opens the public form
+- **THEN** the form SHALL include `hear_about_us`
+- **AND** SHALL NOT include `stage`, `source`, `converted_family_id`, or `lead_id`
+
+### Requirement: Graceful fallback without a lead model
+
+The system SHALL fall back to the current default fields and stages when a tenant has no `lead` model, so the leads UI and backend continue to function during rollout.
+
+#### Scenario: No lead model present
+
+- **WHEN** a tenant has no `lead` entry in its model definition
+- **THEN** the leads board, forms, and stage validation SHALL use the built-in default fields and stages

--- a/openspec/changes/admindash-leads-model-driven/tasks.md
+++ b/openspec/changes/admindash-leads-model-driven/tasks.md
@@ -1,0 +1,50 @@
+## 1. LaunchPad — seed lead into the default model
+
+- [ ] 1.1 Add a `lead` entity to `launchpad/backend/app/data/base_model.json` with default `base_fields` (lead_id str; guardian_name str required; email email; phone phone; student_first_name str; student_last_name str; grade_of_interest str; message str; source selection [web_form,manual,email_import]; stage selection [New,Contacted,Tour Scheduled,Toured,Enrolled,Lost]; converted_family_id str) and `custom_fields: []`
+- [ ] 1.2 If a test asserts base_model contents / use-default payload, extend it to cover the `lead` entity and the `stage` options order; otherwise add a small test loading base_model.json and asserting the lead `stage` selection options
+
+## 2. Papermite — register the Lead domain model
+
+- [ ] 2.1 Add a `Lead` Pydantic model to `papermite/backend/app/models/domain.py` mirroring the default lead base fields, and register it in `ENTITY_CLASSES`
+- [ ] 2.2 Add/extend a test asserting `lead` is a known entity class and that its model definition build includes the `stage`/`source` selection fields
+
+## 3. AdminDash backend — model-driven stage validation + dynamic field preservation
+
+- [ ] 3.1 Add a helper `_lead_model(tenant, token)` in `leads.py` that queries the DataCore `models` table for `entity_type='lead'` and returns the model dict, or `None` (generalize the query helper to accept a table, or add `_dc_query_models`)
+- [ ] 3.2 Add `_stage_options(tenant, token) -> list[str]` returning the lead model's `stage` selection options, falling back to `DEFAULT_STAGES` (rename the current `STAGES` constant to `DEFAULT_STAGES`) when no model/stage field exists
+- [ ] 3.3 Replace hard-coded stage checks in `update_stage`, `list_leads` filter, and `convert` with validation against `_stage_options(...)`
+- [ ] 3.4 Make `_lead_base_data` reconstruct base_data from ALL non-system columns of the fetched row (drop the fixed `_LEAD_FIELDS` allowlist) so customer/custom fields survive read-modify-write; keep excluding `entity_id` and `_`-prefixed metadata
+- [ ] 3.5 `convert`: add optional `target_stage` to `ConvertRequest`; validate it against `_stage_options` (default to the LAST option when omitted); move the lead to it and log the `stage_change`; remove the forced `Enrolled`; keep the double-conversion 409 guard
+- [ ] 3.6 Update `create_lead`/manual create to no longer enforce the bespoke email-or-phone rule (accept the model's fields); keep forcing `stage` to the first stage option on create (default New) and `source=manual`
+- [ ] 3.7 Update `test_leads.py`: stage tests stub a lead model (and a no-model fallback case); convert tests assert `target_stage`/default-last behavior and that custom fields survive; remove/replace the email-or-phone 422 assertion
+- [ ] 3.8 Run `cd admindash && uv run pytest backend/tests/ -v` — all pass
+
+## 4. AdminDash backend — public lead model endpoint
+
+- [ ] 4.1 Add `GET /api/public/leads/{tenant_id}/model` (NO auth) returning the lead model's prospect fields (base fields minus `stage`,`source`,`converted_family_id`,`lead_id`), reusing the `tenant_id` charset guard; return the default prospect fields when no model exists
+- [ ] 4.2 Test: public model endpoint returns prospect fields, excludes internal fields, needs no JWT, 404s a malformed tenant
+
+## 5. AdminDash frontend — model plumbing + types
+
+- [ ] 5.1 Relax `src/types/models.ts`: keep `LEAD_STAGES` as `DEFAULT_LEAD_STAGES` fallback; make `Lead` a loose record (known meta fields + `[key: string]: unknown`); keep `LeadActivity` as-is
+- [ ] 5.2 Client: add `fetchPublicLeadModel(tenant)` (no auth) hitting the new public model endpoint; ensure `ModelContext.getModel(tenant,'lead')` is usable for the authenticated UI (it already is)
+- [ ] 5.3 Add a small `leadStages(model): string[]` util deriving the `stage` field options from a model (fallback `DEFAULT_LEAD_STAGES`) and a `prospectFields(model)` util
+
+## 6. AdminDash frontend — model-driven management UI
+
+- [ ] 6.1 `LeadPage.tsx`: load `getModel(tenant,'lead')`; build board columns from `leadStages(model)`; render leads whose stage is unknown in a trailing "Other" column; keep card graceful (show guardian_name/student/contact if present)
+- [ ] 6.2 `AddLeadModal.tsx`: render via `DynamicForm(leadModel)` (base+custom), emitting base_data/custom_fields to `createLead`; drop hard-coded field list and the email-or-phone rule
+- [ ] 6.3 `LeadDetailDrawer.tsx`: build the stage `<select>` from `leadStages(model)` (keep the confirm-before-change dialog); render the lead's fields dynamically from the model (read-only view + edit via DynamicForm)
+- [ ] 6.4 `ConvertToFamilyModal.tsx`: add a target-stage `<select>` from `leadStages(model)` defaulting to the last stage; pass `target_stage` to `convertLead`
+- [ ] 6.5 `ImportEmailModal.tsx`: map parsed values onto model field names (by name); render the reviewed fields from the model's prospect fields; unknown parsed keys ignored
+
+## 7. AdminDash frontend — model-driven public form
+
+- [ ] 7.1 `PublicInquiryPage.tsx`: fetch the model via `fetchPublicLeadModel(tenant)` and render its prospect fields dynamically (fallback to current fixed fields on error); keep success/error states and `submitPublicLead`
+- [ ] 7.2 Confirm the public route still renders unauthenticated and the reserved internal fields never appear
+
+## 8. Verify
+
+- [ ] 8.1 `cd datacore && uv run python -m pytest tests/ -q` (unchanged, sanity) and `cd admindash && uv run pytest backend/tests/ -q` — pass; run launchpad + papermite backend tests for tasks 1–2
+- [ ] 8.2 `cd admindash/frontend && npm run build && npm run lint` — build passes; no new lint errors over baseline
+- [ ] 8.3 Manual smoke: (a) seed default model → leads UI shows the six default stages/fields; (b) edit the lead model's `stage` options + add a custom field (via Papermite review or a direct model PUT) → board columns, forms, stage dropdown, and public form reflect the change; (c) change a stage (confirm dialog) and confirm custom fields survive; (d) convert a lead choosing a target stage; (e) submit the public form with the custom field

--- a/openspec/changes/admindash-leads-module/.openspec.yaml
+++ b/openspec/changes/admindash-leads-module/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-21

--- a/openspec/changes/admindash-leads-module/design.md
+++ b/openspec/changes/admindash-leads-module/design.md
@@ -1,0 +1,69 @@
+## Context
+
+AdminDash is a thin FastAPI backend + React SPA. The backend owns no storage — it JWT-validates requests and proxies to DataCore's entity API (`/api/entities/{tenant_id}/{entity_type}`) and query API (`/api/query`). DataCore stores every entity type in one shared per-tenant `{tenant}_entities` table keyed by an `entity_type` column, and (verified) accepts arbitrary new entity types with arbitrary `base_data` — no model registration required to persist. DataCore entity endpoints are themselves unauthenticated; all access control lives in the AdminDash backend proxy layer.
+
+Existing entity pages (StudentsPage, ProgramPage) are **model-driven**: they load a per-tenant `ModelDefinition` and render dynamic forms/tables. Leads, by contrast, have a **fixed, product-defined schema** (the same for every school), so they do not need the model-driven machinery.
+
+This change adds Lead + LeadActivity as new entity types, a dedicated AdminDash backend `leads` router to enforce lead-specific business rules, and new frontend pages. The `/leads` route and a placeholder `LeadPage` already exist and will be replaced.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Capture leads via public web form, authenticated manual entry, and email-paste import.
+- Move leads through a fixed pipeline with auto-logged stage changes.
+- Keep a single denormalized activity log per lead.
+- One-click convert a lead into Family + Student records, pre-filled and linked, marking the lead Enrolled.
+- Enforce lead-specific rules (public-intake field allowlist, tenant validation, double-conversion guard, auto-logging) server-side where they can be tested.
+
+**Non-Goals:**
+- No new DataCore storage tables or query-engine changes (leads reuse the entities table).
+- No lead-scoring, assignment/ownership, SLA reminders, email *sending*, or analytics.
+- No captcha/rate-limiting on the public form in this change (noted as a follow-up risk).
+- No transactional/atomic multi-entity write across DataCore (conversion is best-effort sequential).
+- No per-tenant customizable lead fields (fixed schema).
+
+## Decisions
+
+### D1 — Dedicated AdminDash `leads` backend router (not frontend orchestration over generic endpoints)
+Add `admindash/backend/app/api/leads.py` with lead-specific endpoints, persisting by calling DataCore's entity/query API via the existing httpx proxy pattern.
+- **Why:** Three requirements can't live safely in the client: (a) the **public web-form** endpoint is unauthenticated and must allowlist fields + validate the tenant server-side; (b) **stage transition + auto-logged activity** is a two-write pair; (c) **convert** is a multi-write with a double-conversion guard. AdminDash already has a pytest+respx suite, so server-side logic is directly testable.
+- **Alternative considered:** Model leads as generic entities and orchestrate stage/activity/convert from the frontend using existing `createEntity`/`updateEntity`/`postQuery`. Rejected: cannot do public unauthenticated intake, scatters security-sensitive logic into the browser, no server enforcement of guards.
+
+### D2 — Store leads and activities as DataCore entities (reuse, no new storage)
+`lead` and `lead_activity` become new `entity_type` values in the existing per-tenant entities table. Activities are one denormalized type distinguished by a `type` field (`call|email|note|stage_change`) — matching the goal's "single lead_activities table, don't over-normalize."
+- **Why:** DataCore already accepts new entity types with no schema change; this is the lowest-footprint persistence.
+- **Alternative:** New dedicated tables in DataCore. Rejected as unnecessary and cross-cutting.
+
+### D3 — Fixed-schema leads UI (not model-driven DynamicForm)
+Leads pages use explicit, hard-coded fields/columns/stages rather than loading a `ModelDefinition`.
+- **Why:** Leads have one product-wide schema; the model-driven path exists to support per-school-customizable entities (students) and would force per-tenant model seeding for no benefit.
+- **Alternative:** Register a `lead` `ModelDefinition` per tenant and reuse DynamicForm/StudentsPage. Rejected: adds a seeding dependency and indirection for a fixed schema. (We still may register a lead model later purely for dashboard discoverability — deferred.)
+
+### D4 — Human-friendly `lead_id` via DataCore `DEFAULT_ABBREVS`
+Add `"lead": "LD"` to `DEFAULT_ABBREVS` in `datacore/src/datacore/api/routes.py` so leads get sequential ids (`ABR-LD26...`) like students (`ST`) and programs (`PR`). Activities keep only the internal `entity_id` (no human id).
+- **Why:** Admins reference leads by a readable id; one-line change consistent with existing types, covered by a test.
+- **Alternative:** entity_id (hex) only. Rejected: inconsistent with sibling entity types and poor UX; but low-cost enough to include.
+
+### D5 — Email import parsed client-side (regex), reviewed, then saved via the normal create path
+The email-import modal extracts candidate fields (name/email/phone/student name) with a small client-side util, lets the admin correct them, then POSTs a normal lead with `source=email_import`. No backend parse endpoint, no AI call.
+- **Why:** Minimal; parsing an pasted inquiry email is a simple regex problem and keeps the backend surface small.
+- **Alternative:** Backend/Papermite AI extraction. Rejected as over-engineered for T0.
+
+### D6 — Public intake as an unauthenticated route in the admin SPA + a public backend endpoint
+Frontend: a standalone route (e.g. `/inquire/:tenantId`) rendered outside the auth guard in `App.tsx`. Backend: `POST /api/public/leads/{tenant_id}` with **no** JWT dependency, which validates the tenant exists (via DataCore) and accepts only prospect fields, forcing `source=web_form`, `stage=New`.
+- **Why:** Lowest-footprint way to satisfy "web form" intake for T0. AdminDash's Cloudflare-IP middleware only restricts origin traffic to Cloudflare, not end users, so a prospect's browser reaches it fine.
+- **Alternative:** Separate standalone public app. Rejected as out of scope for T0.
+
+### D7 — Conversion mapping (lead → family + student)
+Server-side `convert` endpoint, executed sequentially: create `family` → create `student` (with `family_id`) → update lead (`converted_family_id`, `stage=Enrolled`, log stage_change). Mapping:
+- Lead guardian name → `family.family_name`; lead email/phone → `family.primary_email`/`primary_phone`; lead address (if any) → `family.primary_address`.
+- Lead student first/last name → `student.first_name`/`last_name`; grade-of-interest → `student.grade_level` (only if it matches a valid option, else left blank); `student.family_id` = new family id; `student.status = "Enrolled"`.
+- Required student fields the lead lacks (`primary_address`) are surfaced in the review step for the admin to fill before commit.
+
+## Risks / Trade-offs
+
+- **Non-atomic conversion** (family created, then student fails) → orphan family. Mitigation: order writes family→student→lead, return a clear error identifying what succeeded; accept minor orphan risk for T0; note compensation/transaction as a follow-up.
+- **Public intake abuse** (spam/enumeration on the unauthenticated endpoint) → Mitigation for this change: strict field allowlist, tenant-existence check, no data returned beyond an ack. Captcha + rate-limit deferred to a follow-up.
+- **DataCore has no auth** → all lead access control depends on the AdminDash proxy correctly requiring JWT on every non-public route. Mitigation: reuse the existing `require_authenticated_user` dependency on all authed lead routes; cover the public route's field-allowlist with tests.
+- **Required student fields at conversion** (`primary_address`, `student_id`) not present on a lead → Mitigation: conversion review step collects/generates them (student_id via DataCore next-id) before commit; block commit if a required field is empty.
+- **Cross-service change** (one line in DataCore for the `LD` abbrev) → small blast radius, covered by a datacore test; deploy DataCore before AdminDash relies on the human id (AdminDash tolerates its absence).

--- a/openspec/changes/admindash-leads-module/proposal.md
+++ b/openspec/changes/admindash-leads-module/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+School administrators need a way to capture prospective-family interest and shepherd it toward enrollment. Today AdminDash can manage families, students, and programs, but there is no place to track a prospect *before* they become a family — inquiries arrive by web form, phone, and email and are managed ad hoc. A lead module gives admins a single pipeline from first inquiry to enrolled (or lost), with a lightweight activity trail and a one-click hand-off into the existing Family/Student records.
+
+## What Changes
+
+- Add a **Lead** entity (tenant-scoped, persisted in DataCore like other AdminDash entities) with contact and interest fields plus a pipeline `stage`.
+- **Lead intake** through three paths: a public web form (unauthenticated submission scoped to a tenant), authenticated manual entry inside AdminDash, and import from email (paste/forward an inquiry email → parse into lead fields for review before save).
+- **Pipeline** with fixed ordered stages: `New → Contacted → Tour Scheduled → Toured → Enrolled/Lost`. Admins move a lead between stages; stage changes are recorded.
+- **Activity log** per lead — a single `lead_activities` collection with a `type` enum (`call`, `email`, `note`, plus system-generated `stage_change`). Deliberately denormalized: one record shape for all activity types.
+- **Convert to Family** action — from a lead, pre-fill and create a Family record and an initial Student record from the lead's data, then mark the lead `Enrolled` and link it to the created family.
+
+## Capabilities
+
+### New Capabilities
+- `lead-intake`: Creating leads via public web form, authenticated manual entry, and email-paste import (parse-then-review).
+- `lead-pipeline`: The lead entity, its ordered pipeline stages, listing/filtering by stage, and stage-transition rules.
+- `lead-activity-log`: Recording and viewing per-lead activities (call/email/note) plus auto-logged stage changes, via a single denormalized activity collection.
+- `lead-conversion`: Converting a lead into Family + Student records, pre-filling from lead data and linking back to the lead.
+
+### Modified Capabilities
+<!-- No existing AdminDash spec requirements change; Family/Student creation is reused, not redefined. -->
+
+## Impact
+
+- **AdminDash backend** (`admindash/backend`): new `leads` router (CRUD, stage transitions, activities, convert), Pydantic schemas, and DataCore proxy calls for the new `leads` / `lead_activities` collections. One route is **public** (web-form intake) — outside the normal JWT-required set — and needs a scoped, unauthenticated path.
+- **AdminDash frontend** (`admindash/frontend`): new Leads pages (pipeline/list, lead detail with activity log, manual-entry & email-import forms, convert-to-family action), API client methods, routing + nav entry. A standalone public web-form page/route.
+- **DataCore**: two new tenant-scoped collections (`leads`, `lead_activities`). Reuses existing Family/Student write paths for conversion — no change to their schemas.
+- **Auth**: public intake endpoint is a new trust-boundary surface (unauthenticated write, tenant-scoped, needs abuse consideration — e.g. captcha/rate-limit noted as a follow-up).

--- a/openspec/changes/admindash-leads-module/specs/lead-activity-log/spec.md
+++ b/openspec/changes/admindash-leads-module/specs/lead-activity-log/spec.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+### Requirement: Single denormalized activity collection
+
+The system SHALL record lead activities in a single tenant-scoped `lead_activities` collection. Each activity SHALL have: id, tenant_id, lead_id, a `type` enum (`call`, `email`, `note`, `stage_change`), a free-text `body`, an optional structured `metadata` object (used by `stage_change` to hold `from`/`to`), `created_by` (the acting user, or `system` for auto-logged entries), and `created_at`. Activities are deliberately NOT split into per-type tables.
+
+#### Scenario: Activity shape is uniform
+
+- **WHEN** an activity of any type is stored
+- **THEN** it SHALL use the same record shape distinguished only by its `type` field
+
+### Requirement: Manual activity logging
+
+The system SHALL let an authenticated admin add a `call`, `email`, or `note` activity to a lead, with body text.
+
+#### Scenario: Admin logs a call
+
+- **WHEN** an admin adds a `call` activity with body "Left voicemail" to a lead
+- **THEN** the system SHALL store a `lead_activities` record of type `call` linked to that lead, with `created_by` set to the admin and `created_at` set
+
+#### Scenario: Activity requires a known type
+
+- **WHEN** an admin submits an activity with a type outside the enum
+- **THEN** the system SHALL reject it with a validation error
+
+### Requirement: Auto-logged stage changes
+
+The system SHALL automatically record a `stage_change` activity whenever a lead's stage changes, capturing the previous and new stage in `metadata` and `created_by` = `system`.
+
+#### Scenario: Stage change appears in the log
+
+- **WHEN** a lead moves from `Contacted` to `Tour Scheduled`
+- **THEN** a `stage_change` activity SHALL be recorded with metadata `{from: "Contacted", to: "Tour Scheduled"}`
+
+### Requirement: View activity timeline
+
+The system SHALL let an authenticated admin retrieve all activities for a lead, ordered most-recent-first, scoped to the tenant.
+
+#### Scenario: Timeline is chronological
+
+- **WHEN** an admin opens a lead's detail view
+- **THEN** the system SHALL return that lead's activities ordered by `created_at` descending
+- **AND** SHALL include both manual activities and auto-logged stage changes

--- a/openspec/changes/admindash-leads-module/specs/lead-conversion/spec.md
+++ b/openspec/changes/admindash-leads-module/specs/lead-conversion/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Convert a lead to a Family and Student
+
+The system SHALL provide a "Convert to Family" action that, from an existing lead, creates a Family record and an initial Student record pre-filled from the lead's data, using the same Family/Student creation paths AdminDash already uses. The mapping SHALL be: lead guardian name/email/phone → Family primary contact fields; lead student first/last name and grade/program of interest → the initial Student record. Fields the lead does not have are left blank for the admin to complete.
+
+#### Scenario: Convert pre-fills from lead data
+
+- **WHEN** an admin invokes Convert to Family on a lead that has a guardian name, email, and a student first name
+- **THEN** the system SHALL create a Family whose primary contact is populated from the lead
+- **AND** SHALL create a Student under that family populated from the lead's student fields
+- **AND** the created records SHALL be scoped to the lead's tenant
+
+#### Scenario: Admin reviews before commit
+
+- **WHEN** an admin opens the Convert to Family action
+- **THEN** the system SHALL present the pre-filled Family/Student fields for review and editing before the records are created
+
+### Requirement: Link and mark converted
+
+The system SHALL, upon successful conversion, set the lead's `converted_family_id` to the created family's id and move the lead to the `Enrolled` stage (recording a `stage_change` activity per lead-pipeline).
+
+#### Scenario: Lead is linked and marked enrolled
+
+- **WHEN** conversion completes successfully
+- **THEN** the lead's `converted_family_id` SHALL reference the new family
+- **AND** the lead's stage SHALL be `Enrolled`
+- **AND** a `stage_change` activity to `Enrolled` SHALL be recorded
+
+### Requirement: Guard against double conversion
+
+The system SHALL prevent converting a lead that has already been converted.
+
+#### Scenario: Already converted
+
+- **WHEN** an admin invokes Convert to Family on a lead that already has a `converted_family_id`
+- **THEN** the system SHALL reject the action and SHALL NOT create a duplicate family
+- **AND** SHALL surface that the lead is already converted, linking to the existing family

--- a/openspec/changes/admindash-leads-module/specs/lead-intake/spec.md
+++ b/openspec/changes/admindash-leads-module/specs/lead-intake/spec.md
@@ -1,0 +1,56 @@
+## ADDED Requirements
+
+### Requirement: Manual lead entry
+
+The system SHALL let an authenticated admin create a lead by entering its fields directly in AdminDash. Parent/guardian name is REQUIRED; at least one of email or phone is REQUIRED; all other fields are optional.
+
+#### Scenario: Admin creates a lead manually
+
+- **WHEN** an admin submits the manual-entry form with a guardian name and an email
+- **THEN** the system SHALL create a lead with `source` = `manual`, `stage` = `New`, scoped to the admin's tenant
+- **AND** SHALL return the created lead
+
+#### Scenario: Missing required contact
+
+- **WHEN** an admin submits the form with a guardian name but no email and no phone
+- **THEN** the system SHALL reject the request with a validation error naming the missing contact requirement
+
+### Requirement: Public web-form intake
+
+The system SHALL expose a public, unauthenticated intake endpoint that accepts a lead submission scoped to a specific tenant identified in the request path or payload. Submissions SHALL be stored with `source` = `web_form` and `stage` = `New`. The endpoint SHALL accept only the prospect-facing fields (guardian name, email, phone, student name, grade/program of interest, message) and SHALL ignore/reject any attempt to set internal fields (stage, source, converted_family_id).
+
+#### Scenario: Prospect submits the web form
+
+- **WHEN** an unauthenticated prospect submits the web form for a valid tenant with a guardian name and email
+- **THEN** the system SHALL create a lead for that tenant with `source` = `web_form` and `stage` = `New`
+- **AND** SHALL return a success acknowledgement without exposing other tenants' data
+
+#### Scenario: Unknown tenant
+
+- **WHEN** a web-form submission references a tenant that does not exist
+- **THEN** the system SHALL reject the submission and SHALL NOT create a lead
+
+#### Scenario: Internal fields are not settable from public form
+
+- **WHEN** a web-form payload includes `stage` = `Enrolled` or a `converted_family_id`
+- **THEN** the system SHALL ignore those fields and store the lead as `New` with no conversion link
+
+### Requirement: Email-import intake
+
+The system SHALL let an authenticated admin import a lead from an inquiry email by pasting the email text. The system SHALL parse the text into candidate lead fields (guardian name, email, phone, student name, message) and present them for admin review and correction before the lead is saved. The lead is only persisted when the admin confirms.
+
+#### Scenario: Parse then review
+
+- **WHEN** an admin pastes an inquiry email and requests parsing
+- **THEN** the system SHALL return candidate field values extracted from the text
+- **AND** SHALL NOT persist a lead until the admin confirms
+
+#### Scenario: Confirm import
+
+- **WHEN** an admin confirms the reviewed fields from an email import
+- **THEN** the system SHALL create a lead with `source` = `email_import` and `stage` = `New`
+
+#### Scenario: Best-effort parsing
+
+- **WHEN** the pasted email lacks a detectable phone or student name
+- **THEN** the system SHALL return the fields it could extract and leave the rest blank for the admin to fill

--- a/openspec/changes/admindash-leads-module/specs/lead-pipeline/spec.md
+++ b/openspec/changes/admindash-leads-module/specs/lead-pipeline/spec.md
@@ -1,0 +1,56 @@
+## ADDED Requirements
+
+### Requirement: Lead entity
+
+The system SHALL provide a tenant-scoped Lead entity representing a prospective family's inquiry. A Lead SHALL have: a unique id, tenant_id, prospect contact fields (parent/guardian name, email, phone), student interest fields (student first name, student last name, grade/program of interest — all optional), a free-text `notes` field, a `source` field indicating how the lead arrived (`web_form`, `manual`, `email_import`), a `stage` field, timestamps (`created_at`, `updated_at`), and an optional `converted_family_id` link. All Lead data is scoped to the tenant embedded in the request.
+
+#### Scenario: Lead is created with defaults
+
+- **WHEN** a lead is created without an explicit stage
+- **THEN** its `stage` SHALL default to `New`
+- **AND** `created_at` and `updated_at` SHALL be set to the creation time
+- **AND** it SHALL be scoped to the requesting tenant
+
+#### Scenario: Leads are tenant-isolated
+
+- **WHEN** a user requests leads
+- **THEN** the system SHALL return only leads whose `tenant_id` matches the tenant in the caller's token
+- **AND** SHALL never return leads belonging to another tenant
+
+### Requirement: Pipeline stages
+
+The system SHALL define a fixed, ordered set of pipeline stages: `New`, `Contacted`, `Tour Scheduled`, `Toured`, `Enrolled`, `Lost`. Every lead SHALL be in exactly one stage. `Enrolled` and `Lost` are terminal stages.
+
+#### Scenario: Stage must be a known value
+
+- **WHEN** a lead is created or updated with a `stage` not in the defined set
+- **THEN** the system SHALL reject the request with a validation error
+
+### Requirement: Stage transitions
+
+The system SHALL allow an authenticated admin to move a lead to any other stage. Each stage change SHALL update the lead's `stage` and `updated_at`, and SHALL record a `stage_change` activity capturing the previous and new stage (see lead-activity-log).
+
+#### Scenario: Admin advances a lead
+
+- **WHEN** an admin changes a lead's stage from `New` to `Contacted`
+- **THEN** the lead's `stage` SHALL become `Contacted`
+- **AND** a `stage_change` activity SHALL be recorded with from=`New`, to=`Contacted`
+
+#### Scenario: Stage change is idempotent-safe
+
+- **WHEN** an admin sets a lead to the stage it is already in
+- **THEN** the system SHALL accept the request without creating a redundant `stage_change` activity
+
+### Requirement: List and filter leads
+
+The system SHALL let an authenticated admin list leads for their tenant and filter the list by stage.
+
+#### Scenario: Filter by stage
+
+- **WHEN** an admin lists leads filtered by stage `Toured`
+- **THEN** the system SHALL return only that tenant's leads currently in stage `Toured`
+
+#### Scenario: Board view grouping
+
+- **WHEN** an admin views the pipeline board
+- **THEN** leads SHALL be grouped by stage in the defined stage order

--- a/openspec/changes/admindash-leads-module/tasks.md
+++ b/openspec/changes/admindash-leads-module/tasks.md
@@ -1,0 +1,60 @@
+## 1. DataCore — human-friendly lead id
+
+- [ ] 1.1 Add `"lead": "LD"` to `DEFAULT_ABBREVS` in `datacore/src/datacore/api/routes.py`
+- [ ] 1.2 Add a datacore test asserting `POST /api/entities/{tenant}/lead` auto-assigns a sequential `base_data.lead_id` (e.g. `ABR-LD26...`), mirroring the existing student next-id test
+
+## 2. AdminDash backend — leads router (authenticated)
+
+- [ ] 2.1 Create `admindash/backend/app/api/leads.py` with a `_lead_proxy` helper reusing the httpx→DataCore pattern from `entities.py` (base URL `settings.datacore_url`, forward `user["_token"]`)
+- [ ] 2.2 Define Pydantic schemas: `LeadCreate` (guardian_name required, email/phone at least one), `LeadStageUpdate` (stage in the fixed enum), `ActivityCreate` (type in `call|email|note`, body), and the stage constant list `New, Contacted, Tour Scheduled, Toured, Enrolled, Lost`
+- [ ] 2.3 `POST /api/leads/{tenant_id}` — create a lead with `source=manual`, `stage=New`; validate contact requirement; proxy to DataCore entities create; return created lead
+- [ ] 2.4 `GET /api/leads/{tenant_id}` — list leads for tenant with optional `?stage=` filter, via DataCore `/api/query` SQL on `entity_type='lead'`
+- [ ] 2.5 `GET /api/leads/{tenant_id}/{lead_id}` — fetch a single lead
+- [ ] 2.6 `PATCH /api/leads/{tenant_id}/{lead_id}/stage` — validate new stage; if unchanged, no-op (no activity); else update lead stage + `updated_at` and create a `lead_activity` of type `stage_change` with metadata `{from,to}`, `created_by=system`
+- [ ] 2.7 `POST /api/leads/{tenant_id}/{lead_id}/activities` — create a `lead_activity` (type in enum, body), `created_by`=current user
+- [ ] 2.8 `GET /api/leads/{tenant_id}/{lead_id}/activities` — return the lead's activities ordered `created_at` desc via `/api/query`
+- [ ] 2.9 `POST /api/leads/{tenant_id}/{lead_id}/convert` — guard against existing `converted_family_id` (409 with existing family id); create `family` then `student` (family_id link, status=Enrolled) from a supplied/reviewed payload; update lead `converted_family_id` + stage=Enrolled + stage_change activity; return created ids
+- [ ] 2.10 All routes in 2.3–2.9 depend on `require_authenticated_user`
+- [ ] 2.11 Register the leads router in `admindash/backend/app/main.py`
+
+## 3. AdminDash backend — public intake (unauthenticated)
+
+- [ ] 3.1 `POST /api/public/leads/{tenant_id}` with NO auth dependency: accept only prospect fields (guardian_name, email, phone, student_first_name, student_last_name, grade_of_interest, message); reject/ignore internal fields
+- [ ] 3.2 Validate the tenant exists (probe DataCore) before writing; on unknown tenant return 404 without creating a lead
+- [ ] 3.3 Force `source=web_form`, `stage=New`; proxy create to DataCore; return a minimal ack (no other tenant data)
+- [ ] 3.4 Register the public route in `main.py` (ensure it is reachable without a JWT and, in tests, past the Cloudflare-IP middleware)
+
+## 4. AdminDash backend — tests
+
+- [ ] 4.1 `test_leads.py`: create/list(+stage filter)/get happy paths with respx stubbing DataCore
+- [ ] 4.2 Stage transition test: asserts lead updated AND a `stage_change` activity created; same-stage no-op creates no activity
+- [ ] 4.3 Activity create/list tests (type validation rejects unknown type; list ordered desc)
+- [ ] 4.4 Convert tests: pre-fills family+student, links lead, marks Enrolled; double-convert returns 409
+- [ ] 4.5 Public intake tests: creates web_form lead; unknown tenant 404; internal fields (stage/converted_family_id) ignored; no JWT required
+- [ ] 4.6 Run `uv run pytest backend/tests/ -v` — all pass
+
+## 5. AdminDash frontend — API client + types
+
+- [ ] 5.1 Add `Lead`, `LeadActivity`, and stage type/const to `frontend/src/types/models.ts` (fixed schema)
+- [ ] 5.2 Add client functions in `frontend/src/api/client.ts`: `listLeads(tenant, stage?)`, `getLead`, `createLead`, `updateLeadStage`, `listActivities`, `addActivity`, `convertLead`, and `submitPublicLead(tenant, fields)` (no auth header)
+- [ ] 5.3 Add a client-side `parseInquiryEmail(text)` util in `frontend/src/utils/` (regex for name/email/phone/student name) with a couple of inline example cases
+
+## 6. AdminDash frontend — leads pages
+
+- [ ] 6.1 Replace placeholder `frontend/src/pages/LeadPage.tsx` with a pipeline view: leads grouped by stage in defined order, plus a stage filter; reuse `StatusBadge`/`DataTable` styling and `ui-tokens`
+- [ ] 6.2 Lead detail (drawer or route): show fields, stage control (dropdown that calls `updateLeadStage`), activity timeline (desc), and an "Add activity" form (call/email/note)
+- [ ] 6.3 Manual-entry modal: guardian name + contact required; on submit `createLead` (source=manual)
+- [ ] 6.4 Email-import modal: paste text → `parseInquiryEmail` → editable review fields → confirm → `createLead` (source=email_import)
+- [ ] 6.5 Convert-to-Family modal: pre-fill family+student fields from lead (mapping per design D7); collect required `primary_address`; on confirm `convertLead`; show "already converted" state linking the family when guarded
+- [ ] 6.6 Add leads i18n keys to `frontend/src/i18n/translations.ts` (en-US, zh-CN) for the new UI strings
+
+## 7. AdminDash frontend — public web form
+
+- [ ] 7.1 Create `frontend/src/pages/PublicInquiryPage.tsx` — standalone form (guardian name, email, phone, student name, grade of interest, message) calling `submitPublicLead`; success + error states
+- [ ] 7.2 Wire a public route `/inquire/:tenantId` in `App.tsx` OUTSIDE the auth guard (no redirect-to-login)
+
+## 8. Verify
+
+- [ ] 8.1 `cd admindash/frontend && npm run build && npm run lint` — pass
+- [ ] 8.2 `cd datacore && uv run python -m pytest tests/ -v` and `cd admindash && uv run pytest backend/tests/ -v` — pass
+- [ ] 8.3 Manual smoke: create lead (manual + email import), advance through stages (timeline logs), add activities, submit public form, convert to family (verify Family+Student created and lead Enrolled)

--- a/papermite/backend/app/models/domain.py
+++ b/papermite/backend/app/models/domain.py
@@ -128,6 +128,21 @@ class Enrollment(BaseEntity):
     end_date: Optional[_dt.date] = None
 
 
+class Lead(BaseEntity):
+    entity_type: str = "LEAD"
+    lead_id: str = ""
+    guardian_name: str = ""
+    email: Optional[EmailStr] = None
+    phone: Optional[str] = None
+    student_first_name: Optional[str] = None
+    student_last_name: Optional[str] = None
+    grade_of_interest: Optional[str] = None
+    message: Optional[str] = None
+    source: Optional[str] = None
+    stage: Optional[str] = None
+    converted_family_id: Optional[str] = None
+
+
 class Attendance(BaseEntity):
     entity_type: str = "ATTENDANCE"
     student_id: str = ""
@@ -172,6 +187,7 @@ ENTITY_CLASSES: Dict[str, type[BaseEntity]] = {
     "student": Student,
     "family": Family,
     "contact": Contact,
+    "lead": Lead,
     "enrollment": Enrollment,
     "attendance": Attendance,
     "registration_application": RegistrationApplication,

--- a/papermite/backend/tests/test_domain.py
+++ b/papermite/backend/tests/test_domain.py
@@ -116,3 +116,48 @@ def test_registration_application_no_program_fields():
     ra = RegistrationApplication(application_id="A1", school_year="2025-2026")
     assert "program_id" not in ra.model_fields
     assert "program_name" not in ra.model_fields
+
+
+from app.models.domain import Lead
+
+
+def test_lead_defaults():
+    lead = Lead(lead_id="L1", guardian_name="Jane Doe")
+    assert lead.entity_type == "LEAD"
+    assert lead.lead_id == "L1"
+    assert lead.guardian_name == "Jane Doe"
+    assert lead.email is None
+    assert lead.phone is None
+    assert lead.student_first_name is None
+    assert lead.student_last_name is None
+    assert lead.grade_of_interest is None
+    assert lead.message is None
+    assert lead.source is None
+    assert lead.stage is None
+    assert lead.converted_family_id is None
+    assert lead.custom_fields == {}
+
+
+def test_lead_with_optional_fields():
+    lead = Lead(
+        lead_id="L2",
+        guardian_name="Bob Smith",
+        email="bob@example.com",
+        phone="555-1234",
+        student_first_name="Alice",
+        student_last_name="Smith",
+        grade_of_interest="3rd",
+        message="Interested in after-school program",
+        source="website",
+        stage="contacted",
+        converted_family_id="F99",
+    )
+    assert lead.email == "bob@example.com"
+    assert lead.phone == "555-1234"
+    assert lead.student_first_name == "Alice"
+    assert lead.converted_family_id == "F99"
+
+
+def test_entity_classes_has_lead():
+    assert "lead" in ENTITY_CLASSES
+    assert ENTITY_CLASSES["lead"] is Lead


### PR DESCRIPTION
## Summary

Adds a **lead-management module** to AdminDash and makes its **fields and pipeline stages customer-definable** through the same model-definition flow as tenant/student/program. Built via OpenSpec across two changes (`admindash-leads-module`, `admindash-leads-model-driven`) with subagent-driven, per-task-reviewed TDD.

## Part 1 — Lead module

- **Intake** — three paths: public web form (`/inquire/:tenantId`, unauthenticated), authenticated manual entry, and email-paste import (parse → review → save).
- **Pipeline** — ordered stages with a board view + stage filter; changing a lead's stage requires a confirmation dialog.
- **Activity log** — a single denormalized `lead_activity` type (`call`/`email`/`note`) plus auto-logged `stage_change` entries; newest-first timeline.
- **Convert to Family** — creates + links a Family and initial Student from lead data, guards against double-conversion (409).
- Leads/activities are new **DataCore entity types** in the existing shared table — no new storage. A dedicated AdminDash `leads` backend router enforces the security-sensitive rules (public-intake field allowlist + tenant/charset validation, stage auto-logging, convert guard) server-side. `"lead": "LD"` added to DataCore `DEFAULT_ABBREVS` for human-friendly IDs.

## Part 2 — Model-driven fields + stages

Leads now follow the same customer-definable model mechanism as every other core entity.

- **Stages = the `options` of a `selection` field named `stage`** (mirroring `student.status`) — defining/reordering stages is just editing that field's options; no new schema. `source` is likewise a selection field.
- **LaunchPad** `base_model.json` seeds a `lead` entity (current fields + `stage`/`source`); `use-default` seeds it with everything else. **Papermite** registers a `Lead` domain model so leads appear in the field/options review editor. A school that changes nothing keeps the six default stages and default fields.
- **AdminDash backend** reads the tenant's lead model: stage validation, the create-time default stage, and convert all derive from the model (not constants); read-modify-write updates preserve customer/custom fields; new unauthenticated `GET /api/public/leads/{tenant}/model` feeds the public form (base + custom prospect fields, reserved fields stripped). **Convert lets the admin pick the target stage** (default = last stage).
- **AdminDash frontend** derives the pipeline board, stage dropdown, and add/edit/import/public forms from the lead model via `DynamicForm`; leads whose stored stage is no longer in the pipeline render in an "Other" column; everything falls back to today's defaults when a tenant has no lead model.

## Tests / verification

- DataCore **219**, AdminDash backend **72**, LaunchPad **22**, Papermite **104** (incl. Lead domain) — all pass. Frontend `npm run build` succeeds; lint at the pre-existing baseline (0 new).
- Each task spec/quality-reviewed before commit; a final cross-service integration review confirmed the seams (stage derivation, custom-field survival, public trust boundary, default-list coherence) with fixes applied.

## Notes

- The model-driven behavior is backward-compatible: until a tenant has a `lead` model, the UI/backend use the seeded defaults. Re-run onboarding **"use default model"** (now includes `lead`), or edit the `stage` options / add a custom field in Papermite's review editor, and the board, forms, stage dropdown, and public form all adapt.

## Deferred follow-ups (not regressions from this branch)

- Enforce `user.tenant_id == path tenant_id` centrally in the AdminDash proxy layer (pre-existing gap shared by `query.py`/`entities.py`).
- Parameterize SQL at the DataCore `/api/query` boundary (public intake mitigates via a `tenant_id` charset guard).
- Public-form abuse protection (captcha / rate-limit).
- Short-TTL cache for the per-request lead-model fetch.
- Papermite `test_auth.py` has a pre-existing import breakage (`get_registry_store`) unrelated to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
