### PR TITLE
fix(admindash): raise admindash-api memory to 1gb (chat OOM)

### DIFF
--- a/admindash/fly.toml
+++ b/admindash/fly.toml
@@ -41,6 +41,10 @@ primary_region = "sjc"
     timeout = "5s"
     path = "/api/health"
 
+# The in-process Pydantic-AI chat agent (POST /api/chat) needs more headroom
+# than the base proxy: at 256mb a chat request OOM-killed the machine. 1gb is
+# ample for the Haiku tool-calling agent (far lighter than papermite's 4gb
+# document/vision extraction).
 [[vm]]
   size = "shared-cpu-1x"
-  memory = "256mb"
+  memory = "1gb"


### PR DESCRIPTION
Prod chat returned no results: at 256mb the in-process Pydantic-AI agent OOM-killed admindash-api on the first `POST /api/chat` (logs: `Out of memory: Killed process` → reboot; proxy `could not finish reading HTTP body`). Papermite (also pydantic-ai) already runs at 4gb for the same reason.

Fixed live via `fly scale memory 1024 -a admindash-api`; this persists it in fly.toml so deploys don't revert to 256mb. No redeploy needed (live machine already at 1gb).

🤖 Generated with [Claude Code](https://claude.com/claude-code)