### PR TITLE
Revert: chat student-field search (per-pattern approach)

### DIFF
--- a/admindash/backend/app/chat/tools.py
+++ b/admindash/backend/app/chat/tools.py
@@ -1,5 +1,3 @@
-import json
-
 from pydantic_ai import Agent, RunContext
 
 from app.chat.datacore import (
@@ -11,43 +9,6 @@ from app.chat.datacore import (
 )
 
 _ACTIVE = "_status = 'active'"
-
-# System / non-domain columns excluded when listing or matching searchable fields.
-_SYS_COLS = frozenset({
-    "vector", "base_data", "custom_fields", "entity_id", "entity_type",
-    "tenant_id", "name",
-})
-
-
-def _norm_value(v: object) -> str:
-    """Normalize a stored field value to comparable text. Selection fields are
-    stored JSON-encoded (e.g. '["Aunt"]'); decode them to 'Aunt'."""
-    if v is None:
-        return ""
-    s = str(v)
-    if s.startswith("["):
-        try:
-            arr = json.loads(s)
-            if isinstance(arr, list):
-                return ", ".join(str(x) for x in arr)
-        except (ValueError, TypeError):
-            pass
-    return s
-
-
-def _searchable_fields(row: dict) -> set[str]:
-    """Domain field names on a flattened student row (base + custom)."""
-    return {k for k in row if k not in _SYS_COLS and not k.startswith("_")}
-
-
-def _resolve_field(requested: str, available: set[str]) -> str | None:
-    """Map a user phrase ('Preferred Pickup') to an actual field name
-    ('preferred_pickup'), tolerating spaces/case and partial matches."""
-    key = requested.strip().lower().replace(" ", "_")
-    if key in available:
-        return key
-    partial = sorted(f for f in available if key in f or f in key)
-    return partial[0] if partial else None
 
 
 def _fmt_students(rows: list[dict]) -> str:
@@ -158,74 +119,6 @@ def register_read_tools(agent: Agent) -> None:
             f"id={r.get('entity_id','?')})"
             for r in rows[:25]
         )
-
-    @agent.tool
-    async def list_student_fields(ctx: RunContext[ChatDeps]) -> str:
-        """List the student fields that can be searched (base and custom, e.g.
-        preferred_pickup, medical_conditions, school). Use this when unsure of a
-        field's exact name before calling search_students."""
-        rows = await dc_query(
-            ctx.deps,
-            f"SELECT * EXCLUDE (vector) FROM data WHERE entity_type = 'student' "
-            f"AND {_ACTIVE} LIMIT 1",
-        )
-        if not rows:
-            return "No students exist yet, so there are no fields to search."
-        fields = sorted(_searchable_fields(rows[0]))
-        return "Searchable student fields: " + ", ".join(fields)
-
-    @agent.tool
-    async def search_students(
-        ctx: RunContext[ChatDeps],
-        field: str,
-        value: str | None = None,
-        match: str = "contains",
-    ) -> str:
-        """Find students by ANY field, including custom fields (e.g.
-        preferred_pickup, medical_conditions, school, transportation).
-        match='set'      -> students where the field has any non-empty value (ignores value)
-        match='equals'   -> field equals value (case-insensitive)
-        match='contains' -> field contains value (case-insensitive; the default)
-        Example: field='preferred pickup', value='Aunt', match='contains'."""
-        rows = await dc_query(
-            ctx.deps,
-            f"SELECT * EXCLUDE (vector) FROM data WHERE entity_type = 'student' "
-            f"AND {_ACTIVE}",
-        )
-        if not rows:
-            return "No active students."
-        available = _searchable_fields(rows[0])
-        fname = _resolve_field(field, available)
-        if not fname:
-            return (
-                f"No student field matching {field!r}. Searchable fields: "
-                + ", ".join(sorted(available))
-            )
-        m = (match or "contains").lower()
-        want = (value or "").strip().lower()
-        hits: list[tuple[dict, str]] = []
-        for r in rows:
-            text = _norm_value(r.get(fname))
-            low = text.lower()
-            if m in ("set", "has", "present"):
-                ok = bool(text.strip())
-            elif m in ("equals", "is", "eq"):
-                ok = bool(want) and low == want
-            else:
-                ok = bool(want) and want in low
-            if ok:
-                hits.append((r, text))
-        if not hits:
-            cond = f"{m} {value!r}" if value else "is set"
-            return f"No students found where {fname} {cond}."
-        cond = f"{m} {value!r}" if value else "is set"
-        lines = [
-            f"- {r.get('first_name','')} {r.get('last_name','')} "
-            f"(id={r.get('entity_id','?')}) — {fname}: {text}"
-            for r, text in hits[:40]
-        ]
-        more = "" if len(hits) <= 40 else f"\n…and {len(hits) - 40} more."
-        return f"{len(hits)} student(s) where {fname} {cond}:\n" + "\n".join(lines) + more
 
 
 def register_write_tools(agent: Agent) -> None:

--- a/admindash/backend/tests/test_chat_tools.py
+++ b/admindash/backend/tests/test_chat_tools.py
@@ -8,7 +8,7 @@ from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai import ModelMessage, ModelResponse, TextPart, ToolCallPart
 from pydantic_ai.messages import ToolReturnPart
 
-from app.chat.tools import ChatDeps, register_read_tools, _resolve_field, _norm_value
+from app.chat.tools import ChatDeps, register_read_tools
 from app.chat.datacore import sql_literal
 
 models.ALLOW_MODEL_REQUESTS = False
@@ -61,59 +61,3 @@ async def test_find_student_queries_datacore():
     assert b"entity_type = 'student'" in sent.content
     assert b"'%Lovelace%'" in sent.content
     assert "Ada" in result.output
-
-
-def test_resolve_field_maps_phrase_to_field():
-    fields = {"preferred_pickup", "medical_conditions", "school"}
-    assert _resolve_field("Preferred Pickup", fields) == "preferred_pickup"
-    assert _resolve_field("school", fields) == "school"
-    assert _resolve_field("pickup", fields) == "preferred_pickup"  # partial
-    assert _resolve_field("nonexistent", fields) is None
-
-
-def test_norm_value_decodes_selection_array():
-    assert _norm_value('["Aunt"]') == "Aunt"
-    assert _norm_value('["Aunt", "Mom"]') == "Aunt, Mom"
-    assert _norm_value("Cherrywood") == "Cherrywood"
-    assert _norm_value(None) == ""
-
-
-_STUDENTS = {
-    "data": [
-        {"entity_id": "s1", "first_name": "Ann", "last_name": "Lee",
-         "preferred_pickup": '["Aunt"]', "school": "Cherrywood"},
-        {"entity_id": "s2", "first_name": "Bob", "last_name": "Ng",
-         "preferred_pickup": "", "school": "Oakdale"},
-        {"entity_id": "s3", "first_name": "Cy", "last_name": "Fox",
-         "preferred_pickup": '["Mom"]', "school": "Cherrywood"},
-    ],
-    "total": 3,
-}
-
-
-async def test_search_students_contains_custom_field():
-    agent = _agent_that_calls(
-        "search_students", {"field": "preferred pickup", "value": "Aunt", "match": "contains"})
-    deps = ChatDeps(tenant_id="t1", token="Bearer x", datacore_url=DATACORE)
-    with respx.mock:
-        route = respx.post(f"{DATACORE}/api/query").mock(
-            return_value=httpx.Response(200, json=_STUDENTS))
-        result = await agent.run("who has Aunt pickup", deps=deps)
-    # SELECT excludes the embedding vector
-    assert b"EXCLUDE (vector)" in route.calls.last.request.content
-    assert "Ann" in result.output          # preferred_pickup ["Aunt"] matches
-    assert "Bob" not in result.output      # empty pickup
-    assert "Cy" not in result.output       # ["Mom"] doesn't contain Aunt
-
-
-async def test_search_students_set_matches_non_empty():
-    agent = _agent_that_calls(
-        "search_students", {"field": "preferred_pickup", "match": "set"})
-    deps = ChatDeps(tenant_id="t1", token="Bearer x", datacore_url=DATACORE)
-    with respx.mock:
-        respx.post(f"{DATACORE}/api/query").mock(
-            return_value=httpx.Response(200, json=_STUDENTS))
-        result = await agent.run("who has pickup set", deps=deps)
-    assert "Ann" in result.output          # has pickup
-    assert "Cy" in result.output           # has pickup
-    assert "Bob" not in result.output      # empty pickup


### PR DESCRIPTION
Rolls back #92 (search_students / list_student_fields). The per-pattern tool approach doesn't generalize to unforeseen queries; a general query capability will replace it. Reverts code only — leaves the admindash-api 1gb memory bump in place.