### PR TITLE
fix(datacore): readonly endpoint returns 400 for all query errors (self-correction)

### DIFF
--- a/datacore/src/datacore/api/readonly_query.py
+++ b/datacore/src/datacore/api/readonly_query.py
@@ -7,6 +7,7 @@ existing engine with filesystem access disabled. Does NOT reimplement execution.
 import re
 from enum import Enum
 
+import duckdb
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
@@ -83,11 +84,14 @@ def readonly_query(req: ReadOnlyQueryRequest):
         )
     except TableNotFoundError:
         return {"data": [], "total": 0}
+    except duckdb.Error as e:
+        # The (untrusted, LLM-authored) SQL failed to execute — bad column, type
+        # conversion, invalid input, etc. Any such failure is a query problem, so
+        # return 400 with the message and let the caller self-correct. 500 is
+        # reserved for genuine non-query failures below.
+        raise HTTPException(status_code=400, detail=f"SQL error: {e}")
     except Exception as e:
-        msg = str(e)
-        if "Catalog Error" in msg or "Parser Error" in msg or "Binder Error" in msg:
-            raise HTTPException(status_code=400, detail=f"SQL error: {msg}")
-        raise HTTPException(status_code=500, detail=f"Query failed: {msg}")
+        raise HTTPException(status_code=500, detail=f"Query failed: {e}")
 
     for row in result["rows"]:
         row.pop("vector", None)

--- a/datacore/tests/test_readonly_query.py
+++ b/datacore/tests/test_readonly_query.py
@@ -49,3 +49,15 @@ def test_endpoint_rejects_write(seeded_store):
         rq.readonly_query(rq.ReadOnlyQueryRequest(
             tenant_id="t1", table="entities", sql="DELETE FROM data"))
     assert ei.value.status_code == 400
+
+
+def test_endpoint_maps_execution_error_to_400(seeded_store):
+    """A DuckDB execution error (e.g. type conversion) must be 400, not 500, so the
+    caller (LLM) can self-correct instead of seeing a system failure."""
+    rq._store = seeded_store
+    with pytest.raises(HTTPException) as ei:
+        rq.readonly_query(rq.ReadOnlyQueryRequest(
+            tenant_id="t1", table="entities",
+            sql="SELECT CAST('x' AS INTEGER) AS n"))
+    assert ei.value.status_code == 400
+    assert "SQL error" in str(ei.value.detail)


### PR DESCRIPTION
Found while testing locally: a chat query hit a DuckDB Conversion Error, which the readonly endpoint returned as 500 (only Catalog/Parser/Binder were mapped to 400). run_query treats 500 as a system failure ('technical difficulties') so the LLM couldn't self-correct. Now catches `duckdb.Error` broadly → 400 with the message; 500 reserved for genuine non-query failures. Test added; verified live (the 'transportation need' query now self-corrects and answers). /api/query (internal) unchanged.