### PR TITLE
feat(admindash): render markdown tables in chat

### DIFF
--- a/admindash/frontend/src/components/ChatPanel.css
+++ b/admindash/frontend/src/components/ChatPanel.css
@@ -36,3 +36,12 @@
 .chat-msg__text .markdown code { background: var(--bg-tertiary); padding: 0.05rem 0.3rem;
   border-radius: 4px; font-family: var(--font-mono); font-size: 0.85em; }
 .chat-msg__text .markdown strong { font-weight: 600; }
+
+/* Markdown tables in assistant messages */
+.chat-msg__text .markdown table.md-table { border-collapse: collapse; width: 100%;
+  margin: 0.4rem 0; font-size: 0.85em; }
+.chat-msg__text .markdown table.md-table th,
+.chat-msg__text .markdown table.md-table td { border: 1px solid var(--border-subtle);
+  padding: 0.3rem 0.5rem; text-align: left; vertical-align: top; }
+.chat-msg__text .markdown table.md-table th { background: var(--bg-tertiary); font-weight: 600; }
+.chat-msg__text .markdown table.md-table tr:nth-child(even) td { background: var(--bg-primary); }

--- a/admindash/frontend/src/components/Markdown.tsx
+++ b/admindash/frontend/src/components/Markdown.tsx
@@ -1,11 +1,11 @@
-import type { ReactNode } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
 
 /**
  * Minimal, safe Markdown renderer for chat messages. Produces React nodes
  * directly (never dangerouslySetInnerHTML), so untrusted model output cannot
  * inject HTML. Supports the subset LLMs commonly emit: paragraphs, single-line
- * breaks, unordered/ordered lists, ATX headings, and inline **bold**, *italic*,
- * `code`. Not a full CommonMark implementation — intentionally small.
+ * breaks, unordered/ordered lists, ATX headings, GFM tables, and inline
+ * **bold**, *italic*, `code`. Not a full CommonMark implementation — small.
  */
 
 const INLINE = /(`[^`]+`|\*\*[^*]+\*\*|__[^_]+__|\*[^*\s][^*]*\*|_[^_\s][^_]*_)/g;
@@ -32,8 +32,84 @@ function renderInline(text: string): ReactNode[] {
   return nodes;
 }
 
+type Align = 'left' | 'center' | 'right' | undefined;
+
+/** Split a table row into trimmed cells, tolerating optional leading/trailing `|`. */
+function splitRow(line: string): string[] {
+  let s = line.trim();
+  if (s.startsWith('|')) s = s.slice(1);
+  if (s.endsWith('|')) s = s.slice(0, -1);
+  return s.split('|').map((c) => c.trim());
+}
+
+/** True if the line is a GFM separator row like `| --- | :--: | ---: |`. */
+function isTableSeparator(line: string): boolean {
+  const cells = splitRow(line);
+  return cells.length > 0 && cells.every((c) => /^:?-+:?$/.test(c));
+}
+
+function parseAligns(sep: string): Align[] {
+  return splitRow(sep).map((c) => {
+    const l = c.startsWith(':');
+    const r = c.endsWith(':');
+    if (l && r) return 'center';
+    if (r) return 'right';
+    if (l) return 'left';
+    return undefined;
+  });
+}
+
+function alignStyle(a: Align): CSSProperties | undefined {
+  return a ? { textAlign: a } : undefined;
+}
+
 function renderBlock(block: string, key: number): ReactNode {
   const lines = block.split('\n');
+
+  // GFM table: header row, a |---|---| separator, then data rows.
+  if (lines.length >= 2 && lines[0].includes('|') && isTableSeparator(lines[1])) {
+    const aligns = parseAligns(lines[1]);
+    const cols = aligns.length;
+    let header = splitRow(lines[0]);
+    // Models sometimes run prose straight into the header with no line break
+    // ("…grade level.| A | B |"). The separator fixes the column count, so any
+    // extra leading header cells are prose — peel them off and show above.
+    let lead: string | null = null;
+    if (header.length > cols) {
+      lead = header.slice(0, header.length - cols).join(' | ').trim();
+      header = header.slice(header.length - cols);
+    }
+    const rows = lines.slice(2).filter((l) => l.trim() !== '').map(splitRow);
+    const table = (
+      <table className="md-table">
+        <thead>
+          <tr>
+            {header.map((c, i) => (
+              <th key={i} style={alignStyle(aligns[i])}>{renderInline(c)}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((cells, r) => (
+            <tr key={r}>
+              {cells.map((c, i) => (
+                <td key={i} style={alignStyle(aligns[i])}>{renderInline(c)}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    );
+    if (lead) {
+      return (
+        <div key={key}>
+          <p>{renderInline(lead)}</p>
+          {table}
+        </div>
+      );
+    }
+    return <div key={key}>{table}</div>;
+  }
 
   if (lines.every((l) => /^\s*[-*]\s+/.test(l))) {
     return (


### PR DESCRIPTION
Chat tables came through as raw `| ... |` text. The Markdown renderer now parses GFM tables into real HTML tables (with alignment + styling), and handles the common case where the model runs prose straight into the header with no line break. Build+lint clean; verified with a headless browser (table renders, zero raw pipe rows).